### PR TITLE
#15 fix strengh decrease in Horatio's dialog

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix015_HoratioStrength.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix015_HoratioStrength.d
@@ -1,0 +1,54 @@
+/*
+ * #15 Horatio may lower STRENGTH
+ */
+func void Ninja_G1CP_015_HoratioStrength() {
+    HookDaedalusFuncS("DIA_Horatio_HelpSTR_LEARN_NOW", "Ninja_G1CP_015_HoratioStrength_Hook");
+};
+
+/*
+ * Backup of strength before dialog (global to be accessible from the print hook)
+ */
+const int Ninja_G1CP_015_HoratioStrength_StrBak = 0;
+
+/*
+ * This function wraps around DIA_Horatio_HelpSTR_LEARN_NOW to reinstate the strength if it decreased
+ */
+func void Ninja_G1CP_015_HoratioStrength_Hook() {
+    // Backup the strength before the dialog
+    Ninja_G1CP_015_HoratioStrength_StrBak = hero.attribute[/*ATR_STRENGTH*/4];
+
+    // Place hook to fix on-screen information
+    const int PrintScreen_popped = 6630384; //0x652BF0
+    HookEngineF(PrintScreen_popped, 6, Ninja_G1CP_015_HoratioStrength_PrintFix);
+
+    // Call the original DIA_Horatio_HelpSTR_LEARN_NOW
+    ContinueCall();
+
+    // Remove print fix hook again
+    RemoveHookF(PrintScreen_popped, 6, Ninja_G1CP_015_HoratioStrength_PrintFix);
+
+    // If lower, reset strength to before
+    if (hero.attribute[/*ATR_STRENGTH*/4] < Ninja_G1CP_015_HoratioStrength_StrBak) {
+        hero.attribute[/*ATR_STRENGTH*/4] = Ninja_G1CP_015_HoratioStrength_StrBak;
+    };
+};
+
+/*
+ * This function hooks PrintScreen (temporarily, see above) and replaces the on-screen text if necessary
+ */
+func void Ninja_G1CP_015_HoratioStrength_PrintFix() {
+    // Get text parameter
+    var zString zstr; zstr = _^(ESP+60);
+    var int pos; pos = zstr.len-3;
+    var string textEnd; textEnd = STR_FromChar(zstr.ptr+pos);
+
+    // Compare if it ends on "100"
+    if (Hlp_StrCmp(textEnd, "100")) {
+        var string text; text = MEM_ReadString(ESP+60);
+        text = STR_SubStr(text, 0, pos);
+        text = ConcatStrings(text, IntToString(Ninja_G1CP_015_HoratioStrength_StrBak));
+
+        // Assign with new string
+        MEM_WriteString(ESP+60, text);
+    };
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -13,6 +13,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
     const int once = 0;
     if (!once) {
         Ninja_G1CP_TestSuite();
+        Ninja_G1CP_015_HoratioStrength();                               // #15
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
 
         once = 1;

--- a/src/Ninja/G1CP/Content/Tests/test015.d
+++ b/src/Ninja/G1CP/Content/Tests/test015.d
@@ -1,5 +1,5 @@
 /*
- * #15 Vendors equip strongest weapon
+ * #15 Horatio may lower STRENGTH
  *
  * The hero is first given strength < 100 and then strength > 100 before each calling the original dialog.
  *
@@ -16,9 +16,9 @@ func int Ninja_G1CP_Test_015() {
     var int strengthBak; strengthBak = hero.attribute[/*ATR_STRENGTH*/4];
 
     // First pass: strength < 100
-    hero.attribute[/*ATR_STRENGTH*/4] = 80;
+    hero.attribute[/*ATR_STRENGTH*/4] = 10;
     MEM_CallByID(symbId);
-    if (hero.attribute[/*ATR_STRENGTH*/4] <= 80) {
+    if (hero.attribute[/*ATR_STRENGTH*/4] <= 10) {
         Ninja_G1CP_TestsuiteErrorDetail(15, "Strength was not increased when below 100");
         hero.attribute[/*ATR_STRENGTH*/4] = strengthBak;
         return FALSE;

--- a/src/Ninja/G1CP/Content/Tests/test015.d
+++ b/src/Ninja/G1CP/Content/Tests/test015.d
@@ -1,0 +1,38 @@
+/*
+ * #15 Vendors equip strongest weapon
+ *
+ * The hero is first given strength < 100 and then strength > 100 before each calling the original dialog.
+ *
+ * Expected behavior: The hero never loses strength
+ */
+func int Ninja_G1CP_Test_015() {
+    var int symbId; symbId = MEM_FindParserSymbol("DIA_Horatio_HelpSTR_LEARN_NOW");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail(15, "Original dialog not found");
+        return FALSE;
+    };
+
+    // Backup the original strength
+    var int strengthBak; strengthBak = hero.attribute[/*ATR_STRENGTH*/4];
+
+    // First pass: strength < 100
+    hero.attribute[/*ATR_STRENGTH*/4] = 80;
+    MEM_CallByID(symbId);
+    if (hero.attribute[/*ATR_STRENGTH*/4] <= 80) {
+        Ninja_G1CP_TestsuiteErrorDetail(15, "Strength was not increased when below 100");
+        hero.attribute[/*ATR_STRENGTH*/4] = strengthBak;
+        return FALSE;
+    };
+
+    // Second pass: strength > 100
+    hero.attribute[/*ATR_STRENGTH*/4] = 1000;
+    MEM_CallByID(symbId);
+    if (hero.attribute[/*ATR_STRENGTH*/4] != 1000) {
+        Ninja_G1CP_TestsuiteErrorDetail(15, "Strength was reset to 100");
+        hero.attribute[/*ATR_STRENGTH*/4] = strengthBak;
+        return FALSE;
+    };
+
+    hero.attribute[/*ATR_STRENGTH*/4] = strengthBak;
+    return TRUE;
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -8,11 +8,13 @@ Content\localization.d
 Content\testsuite.d
 
 // Session fixes
+Content\Fixes\Session\fix015_HoratioStrength.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
 
 // Tests
+Content\Tests\test015.d
 Content\Tests\test059.d
 
 // Initialization


### PR DESCRIPTION
This fix wraps around the dialog of Horatio to revert the strength should it have decreased. As a bonus, the `PrintScreen` call is intercepted to replace the on-screen information accordingly.

You may run a test with `test 15` from the in-game console.