### PR TITLE
#17 add new condition to jackal's dialog

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix017_JackalProtectionMoney.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix017_JackalProtectionMoney.d
@@ -1,0 +1,19 @@
+/*
+ * #17 Jackal doesn't recognize the player's camp membership
+ */
+func void Ninja_G1CP_017_JackalProtectionMoney() {
+    HookDaedalusFuncS("Info_Jackal_Hello_Condition", "Ninja_G1CP_017_JackalProtectionMoney_Hook");
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int Ninja_G1CP_017_JackalProtectionMoney_Hook() {
+    // Add the new condition (other conditions remain untouched)
+    if (Npc_GetTrueGuild(hero)) {
+        return FALSE;
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -13,6 +13,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
     const int once = 0;
     if (!once) {
         Ninja_G1CP_TestSuite();
+        Ninja_G1CP_017_JackalProtectionMoney();                         // #17
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
 
         once = 1;

--- a/src/Ninja/G1CP/Content/Tests/test017.d
+++ b/src/Ninja/G1CP/Content/Tests/test017.d
@@ -1,0 +1,35 @@
+/*
+ * #17 Jackal doesn't recognize the player's camp membership
+ *
+ * The hero is given a new guild and the condition function of the dialog is called.
+ *
+ * Expected behavior: The condition function will return FALSE.
+ */
+func int Ninja_G1CP_Test_017() {
+    var int symbId; symbId = MEM_FindParserSymbol("Info_Jackal_Hello_Condition");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail(17, "Original dialog not found");
+        return FALSE;
+    };
+
+    // Backup the original guild
+    var int guildBak; guildBak = Npc_GetTrueGuild(hero);
+
+    // Assign a random guild
+    Npc_SetTrueGuild(hero, 4);
+
+    // Call dialog condition function
+    MEM_CallByID(symbId);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore guild
+    Npc_SetTrueGuild(hero, guildBak);
+
+    // Check return value
+    if (ret) {
+        Ninja_G1CP_TestsuiteErrorDetail(17, "Dialog condition failed");
+        return FALSE;
+    } else {
+        return TRUE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -8,11 +8,13 @@ Content\localization.d
 Content\testsuite.d
 
 // Session fixes
+Content\Fixes\Session\fix017_JackalProtectionMoney.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
 
 // Tests
+Content\Tests\test017.d
 Content\Tests\test059.d
 
 // Initialization


### PR DESCRIPTION
There is simple a new condition added (before the remaining dialog conditions are checked) whether the hero is assigned to a guild.

You may run a test with `test 17`