### PR TITLE
#1 make NPCs sleep properly

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix001_FixNpcSleep.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix001_FixNpcSleep.d
@@ -1,0 +1,62 @@
+/*
+ * #1 NPCs wake up immediately
+ */
+func void Ninja_G1CP_001_FixNpcSleep() {
+    HookDaedalusFuncS("ZS_SleepBed_Loop", "Ninja_G1CP_001_FixNpcSleep_Hook");
+};
+
+/*
+ * This function intercepts the NPC state to introduce more conditions
+ */
+func int Ninja_G1CP_001_FixNpcSleep_Hook() {
+    // Changing the condition to start the ZS_SitAround is not easily possible with completely overwriting the function
+    // Overwriting the function should be avoided, because that would remove any additional changes from someone else
+    // Instead we will intercept AI_StartState and return if ZS_SitAround is to be started but our conditions fail
+
+    // Temporarily hook AI_StartState
+    const int AI_StartState_popped = 6627839; //0x6521FF
+    HookEngineF(AI_StartState_popped, 5, Ninja_G1CP_001_FixNpcSleep_StateHook);
+
+    // Call original function
+    ContinueCall();
+    var int ret; ret = MEM_PopIntResult();
+
+    // Remove hook again (only remove function but leave changes in engine for performance)
+    RemoveHookF(AI_StartState_popped, 0, Ninja_G1CP_001_FixNpcSleep_StateHook);
+
+    // Return original return value
+    return ret;
+};
+
+/*
+ * This function hooks AI_StartState (temporarily, see above) and aborts if certain conditions are met
+ * EAX is the address of the NPC. If not valid, AI_StartState is aborted
+ */
+func void Ninja_G1CP_001_FixNpcSleep_StateHook() {
+    // Create potentially missing symbols locally
+    const int BS_FLAG_INTERRUPTABLE    = 32768;
+    const int BS_MOBINTERACT_INTERRUPT = 16 | BS_FLAG_INTERRUPTABLE;
+
+    // Check for valid ZS-function
+    var int funcId; funcId = MEM_ReadInt(ESP+40);
+    if (funcId < 0) || (funcId > currSymbolTableLength) {
+        return;
+    };
+
+    // Check if it is ZS_SitAround that is about to be started
+    var zCPar_symbol symb; symb = _^(MEM_GetSymbolByIndex(funcId));
+    if (!Hlp_StrCmp(symb.name, "ZS_SitAround")) {
+        return;
+    };
+
+    // Make sure the NPC is valid
+    if (!Hlp_Is_oCNpc(EAX)) {
+        return;
+    };
+
+    // If our conditions are not met, abort AI_StartState
+    var C_Npc slf; slf = _^(EAX);
+    if (Ninja_G1CP_BodyStateContains(slf, BS_MOBINTERACT_INTERRUPT)) {
+        EAX = 0; // Terminate AI_StartState
+    };
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -13,6 +13,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
     const int once = 0;
     if (!once) {
         Ninja_G1CP_TestSuite();
+        Ninja_G1CP_001_FixNpcSleep();                                   // #1
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
 
         once = 1;

--- a/src/Ninja/G1CP/Content/Tests/test001.d
+++ b/src/Ninja/G1CP/Content/Tests/test001.d
@@ -1,0 +1,13 @@
+/*
+ * #1 NPCs wake up immediately
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: NPCs should be able to sleep.
+ */
+func void Ninja_G1CP_Test_001() {
+    if (Ninja_G1CP_TestsuiteAllowManual) {
+        Wld_SetTime(0, 0);
+        AI_Teleport(hero, "PSI_PATH_11_5");
+    };
+};

--- a/src/Ninja/G1CP/Content/misc.d
+++ b/src/Ninja/G1CP/Content/misc.d
@@ -11,3 +11,13 @@ func string Ninja_G1CP_LFill(var string str, var string fill, var int total) {
     end;
     return str;
 };
+
+
+/*
+ * Copy of C_BodyStateContains to ensure it exists as expected
+ */
+func int Ninja_G1CP_BodyStateContains(var int npcInstance, var int bodystate) {
+    const int mod = 31 | 32768 | 65536; // BS_MAX | BS_FLAG_INTERRUPTABLE | BS_FLAG_FREEHANDS
+    var C_Npc slf; slf = Hlp_GetNpc(npcInstance);
+    return ((Npc_GetBodyState(slf) & mod) == (bodystate & mod));
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -8,11 +8,13 @@ Content\localization.d
 Content\testsuite.d
 
 // Session fixes
+Content\Fixes\Session\fix001_FixNpcSleep.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
 
 // Tests
+Content\Tests\test001.d
 Content\Tests\test059.d
 
 // Initialization


### PR DESCRIPTION
This PR is not ready for merging yet. The issue below should be addressed first.

Are you sure this works as expected? A check against `Npc_GetBodyState` rarely renders true, because the body state is a bitfield, a combination of multiple active body states. That's why there is the function `C_BodyStateContains`. Is there a particular reason why you used `Npc_GetBodyState`?

_Originally posted by @szapp in https://github.com/AmProsius/gothic-1-community-patch/issues/1#issuecomment-761538175_


To test this fix, manual confirmation is required: When running `test 1` from the console, the hero is teleported to a hut at night. The user can confirm if the NPC inside remains asleep.