### PR TITLE
#3 correctly pick up weapons after fight

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix003_RegainDroppedWeapon.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix003_RegainDroppedWeapon.d
@@ -1,0 +1,95 @@
+/*
+ * #3 NPCs don't collect weapons after fight
+ *
+ * The following issues are addressed:
+ *  - The NPC now correctly picks up the detected item, even if they have to turn around
+ *  - The NPC now only picks up a weapon if they don't already have one of the type equipped
+ *  - The NPC now no longer equips the best weapon, but the one that was picked up (complementing #59)
+ *
+ * This fix requires LeGo AI-Functions.
+ */
+func void Ninja_G1CP_003_RegainDroppedWeapon() {
+    HookDaedalusFuncS("B_RegainDroppedWeapon", "Ninja_G1CP_003_RegainDroppedWeapon_Hook");
+};
+
+/*
+ * This function essentially replaces (not technically!) the function 'B_RegainDroppedWeapon'
+ */
+func void Ninja_G1CP_003_RegainDroppedWeapon_Logic(var C_Npc slf) {
+    Npc_PerceiveAll(slf);
+
+    // Define possibly missing symbols locally
+    const int ITEM_KAT_NF  = 1<<1;
+    const int ITEM_KAT_FF  = 1<<2;
+    const int ITEM_KAT_MUN = 1<<3;
+
+    // Melee weapon
+    if (Wld_DetectItem(slf, ITEM_KAT_NF)) {
+        if (Npc_GetDistToItem(slf, item) < 5000)         // Prevent walking off too far
+        && (Ninja_G1CP_Npc_CanSeeItemFreeLOS(slf, item)) // Does not have to face it, only line of sight
+        && (!Npc_HasEquippedMeleeWeapon(slf)) {
+            AI_TakeItem(slf, item);
+            AI_Function_NI(slf, EquipWeapon, slf, Hlp_GetInstanceID(item)); // Equip this exact weapon in particular
+        };
+    };
+
+    // Ranged weapon
+    if (Wld_DetectItem(slf, ITEM_KAT_FF)) {
+        if (Npc_GetDistToItem(slf, item) < 5000)
+        && (Ninja_G1CP_Npc_CanSeeItemFreeLOS(slf, item))
+        && (!Npc_HasEquippedRangedWeapon(slf)) {
+            AI_TakeItem(slf, item);
+            AI_Function_NI(slf, EquipWeapon, slf, Hlp_GetInstanceID(item));
+        };
+    };
+
+    // Ammunition (just a bonus)
+    if (Wld_DetectItem(slf, ITEM_KAT_MUN)) {
+        if (Npc_GetDistToItem(slf, item) < 5000)
+        && (Ninja_G1CP_Npc_CanSeeItemFreeLOS(slf, item)) {
+            AI_TakeItem(slf, item);
+        };
+    };
+};
+
+/*
+ * This function disables part of the external function calls of the original function
+ */
+func void Ninja_G1CP_003_RegainDroppedWeapon_Hook(var C_Npc slf) {
+    // Extra sugar: Back up the global symbol
+    var int itemBak; itemBak = _@(item);
+
+    // Temporarily disable AI_TakeItem, AI_EquipBestRangedWeapon and AI_EquipBestMeleeWeapon
+    const int AI_TakeItem_p              = 6660155; //0x65A03B
+    const int AI_EquipBestMeleeWeapon_p  = 6654871; //0x658B97
+    const int AI_EquipBestRangedWeapon_p = 6655079; //0x658C67
+    const int once = 0;
+    if (!once) {
+        MemoryProtectionOverride(AI_TakeItem_p, 2);
+        MemoryProtectionOverride(AI_EquipBestMeleeWeapon_p, 2);
+        MemoryProtectionOverride(AI_EquipBestRangedWeapon_p, 2);
+        once = 1;
+    };
+    const int orig = 3296983179; /*8B F8 83 C4*/
+    const int newb = 3296984881; /*31 FF 83 C4*/
+    if (MEM_ReadInt(AI_TakeItem_p)              == orig) { MEM_WriteInt(AI_TakeItem_p,              newb); };
+    if (MEM_ReadInt(AI_EquipBestMeleeWeapon_p)  == orig) { MEM_WriteInt(AI_EquipBestMeleeWeapon_p,  newb); };
+    if (MEM_ReadInt(AI_EquipBestRangedWeapon_p) == orig) { MEM_WriteInt(AI_EquipBestRangedWeapon_p, newb); };
+
+    // Call the original function (There might be other important changes that we do not want to overwrite!)
+    PassArgumentN(slf);
+    ContinueCall();
+
+    // Re-enable the engine functions
+    if (MEM_ReadInt(AI_TakeItem_p)              == newb) { MEM_WriteInt(AI_TakeItem_p,              orig); };
+    if (MEM_ReadInt(AI_EquipBestMeleeWeapon_p)  == newb) { MEM_WriteInt(AI_EquipBestMeleeWeapon_p,  orig); };
+    if (MEM_ReadInt(AI_EquipBestRangedWeapon_p) == newb) { MEM_WriteInt(AI_EquipBestRangedWeapon_p, orig); };
+
+    // And now, we do it our way
+    Ninja_G1CP_003_RegainDroppedWeapon_Logic(slf);
+
+    // Finally re-instate the global symbol
+    MEM_AssignInstSuppressNullWarning = TRUE;
+    item = _^(itemBak);
+    MEM_AssignInstSuppressNullWarning = FALSE;
+};

--- a/src/Ninja/G1CP/Content/Misc/Npc_CanSeeVob.d
+++ b/src/Ninja/G1CP/Content/Misc/Npc_CanSeeVob.d
@@ -1,0 +1,33 @@
+/*
+ * More versatile version of Npc_CanSee
+ */
+func int Ninja_G1CP_Npc_CanSeeVob(var int npcPtr, var int vobPtr, var int withAngles) {
+    if (!vobPtr) || (!Hlp_Is_oCNpc(npcPtr)) {
+        return FALSE;
+    };
+
+    const int oCNpc__CanSee = 6938640; //0x69E010
+    const int call = 0;
+    if (CALL_Begin(call)) {
+        CALL_IntParam(_@(withAngles));
+        CALL_PtrParam(_@(vobPtr));
+        CALL_PutRetValTo(_@(ret));
+        CALL__thiscall(_@(npcPtr), oCNpc__CanSee);
+        call = CALL_End();
+    };
+
+    var int ret;
+    return +ret;
+};
+
+
+/*
+ * Equivalent function of Npc_CanSeeNpcFreeLOS for Items
+ */
+func int Ninja_G1CP_Npc_CanSeeItemFreeLOS(var C_Npc slf, var C_Item itm) {
+    if (Hlp_IsValidNpc(slf)) && (Hlp_IsValidItem(itm)) {
+        return Ninja_G1CP_Npc_CanSeeVob(_@(slf), _@(itm), TRUE);
+    } else {
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -13,6 +13,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
     const int once = 0;
     if (!once) {
         Ninja_G1CP_TestSuite();
+        Ninja_G1CP_003_RegainDroppedWeapon();                           // #3
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
 
         once = 1;
@@ -25,6 +26,6 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
  */
 func void Ninja_G1CP_Init() {
     // Wrapper for "LeGo_Init" to ensure correct LeGo initialization without breaking the mod
-    LeGo_MergeFlags(LeGo_ConsoleCommands);
+    LeGo_MergeFlags(LeGo_ConsoleCommands | LeGo_AI_Function);
 
 };

--- a/src/Ninja/G1CP/Content/Tests/test003.d
+++ b/src/Ninja/G1CP/Content/Tests/test003.d
@@ -1,0 +1,97 @@
+/*
+ * #3 NPCs don't collect weapons after fight
+ *
+ * A test NPC is inserted along with some weapons (bow equipped), before the script B_RegainDroppedWeapon is triggered
+ *
+ * Expected behavior: The NPC will pick up and equip the sword, leave the bow, draw the sword and show it
+ */
+func void Ninja_G1CP_Test_003() {
+    if (!Ninja_G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Insert test NPC
+    var string wp; wp = Npc_GetNearestWP(hero);
+    Wld_InsertNpc(Ninja_G1CP_Test_003_Npc, wp);
+    var C_Npc test; test = Hlp_GetNpc(Ninja_G1CP_Test_003_Npc);
+    if (!Hlp_IsValidNpc(test)) {
+        Ninja_G1CP_TestsuiteErrorDetail(3, "Failed to insert NPC");
+        return;
+    };
+
+    // Insert items
+    wp = Npc_GetNearestWP(hero);
+    Wld_InsertItem(MEM_FindParserSymbol("Whistlers_Schwert"), wp);
+    Wld_InsertItem(MEM_FindParserSymbol("Wolfs_Bogen"), wp);
+    Wld_InsertItem(MEM_FindParserSymbol("ItAmArrow"), wp);
+};
+
+
+
+/*
+ * The actual test will run through the NPC's AI state (see below)
+ */
+instance Ninja_G1CP_Test_003_Npc(C_Npc) {
+    name          = "Test 3";
+    attribute[0]  = 2;
+    attribute[1]  = 2;
+    attribute[4]  = 1000; // Enough strength to carry any weapon
+    attribute[5]  = 1000; // Enough dexterity to carry any weapon
+    start_aistate = ZS_Ninja_G1CP_Test_003_NpcRountine;
+    senses        = 7;
+    senses_range  = 2000;
+    Mdl_SetVisual(self, "HUMANS.MDS");
+    Mdl_SetVisualBody(self, "HUM_BODY_NAKED0", 1, 1, "Hum_Head_Fighter", 1, 1, -1);
+    EquipItem(self, MEM_FindParserSymbol("ItRw_Bow_Small_01"));  // Should not be replaced
+    CreateInvItem(self, MEM_FindParserSymbol("Diegos_Bogen"));   // by this one (stronger)
+    // EquipItem(self, MEM_FindParserSymbol("ItMw_1H_Club_01"));    // Same for melee weapon
+    // CreateInvItem(self, MEM_FindParserSymbol("Scars_Schwert"));  // ...
+    CreateInvItems(self, MEM_FindParserSymbol("ItAmArrow"), 20); // Need arrows for AI_EquipBestRangedWeapon
+};
+
+
+/*
+ * AI state is stared once the NPC is properly inserted
+ */
+func void ZS_Ninja_G1CP_Test_003_NpcRountine() {};
+func int  ZS_Ninja_G1CP_Test_003_NpcRountine_Loop() {
+    // First pass: Trigger the script
+    if (Npc_GetStateTime(self) <= 1) {
+        var int symbId; symbId = MEM_FindParserSymbol("B_RegainDroppedWeapon");
+        if (symbId != -1) {
+            MEM_PushInstParam(self);
+            MEM_CallById(symbId);
+        } else {
+            // Send to zSpy directly here because it is after the test has finished
+            MEM_SendToSpy(zERR_TYPE_FAULT, "  Test   3: 'B_RegainDroppedWeapon' not found");
+        };
+
+        Npc_SetStateTime(self, 2);
+        return 0;
+    };
+
+    // Second pass: Show off if it worked
+    var int failed; failed = FALSE;
+    if (!Npc_HasEquippedMeleeWeapon(self)) {
+        // Send to zSpy directly here because it is after the test has finished
+        MEM_SendToSpy(zERR_TYPE_FAULT, "  Test   3: NPC did not pickup/equip the melee weapon");
+        failed = TRUE;
+    };
+    if (Npc_GetRangedWeapon(self) != MEM_FindParserSymbol("ItRw_Bow_Small_01")) {
+        // Send to zSpy directly here because it is after the test has finished
+        MEM_SendToSpy(zERR_TYPE_FAULT, "  Test   3: NPC illegitimately equipped the best bow");
+        failed = TRUE;
+    };
+    if (!failed) {
+        // Test passed: Celebrate!
+        AI_ReadyMeleeWeapon(self);
+        AI_PlayAni(self, "T_IGETYOU");
+        Print("Test 3 passed");
+    };
+    return 1;
+};
+func void ZS_Ninja_G1CP_Test_003_NpcRountine_End() {
+    // Delete the NPC once done
+    MEM_WriteInt(_@(self.bodymass)+8, 0); // Clear start_aistate
+    AI_Function_I(hero, Wld_RemoveNpc, Ninja_G1CP_Test_003_Npc);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -7,12 +7,16 @@ Content\misc.d
 Content\localization.d
 Content\testsuite.d
 
+Content\Misc\Npc_CanSeeVob.d
+
 // Session fixes
+Content\Fixes\Session\fix003_RegainDroppedWeapon.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
 
 // Tests
+Content\Tests\test003.d
 Content\Tests\test059.d
 
 // Initialization


### PR DESCRIPTION
This fix is a little more elaborate to ensure that the underlying function `B_RegainDroppedWeapon` is still called instead of fully replaced. This is to ensure that any new code added to the function is still being called and the patch does not interfere.

The following issues are addressed:
 - The NPC now correctly picks up the detected item, even if they have to turn around
 - The NPC now only picks up a weapon if they don't already have one of the type equipped
 - The NPC now no longer equips the best weapon, but the one that was picked up (complementing #59)

The test of the fix requires manual confirmation: Run `test 3` from the console and watch an NPC getting inserted, equipped with a bow, and some loose weapons on the ground. Regardless of where the NPC is facing, it should turn to the items and pick up the melee weapon (and ammunition) only. Since the NPC already has a bow equipped, it will leave the bow item on the ground. If the NPC draws the sword afterwards and waves, the test passed.