### PR TITLE
#7 fix sword practice

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix007_PracticeSwordWithWeapon.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix007_PracticeSwordWithWeapon.d
@@ -1,0 +1,72 @@
+/*
+ * #7 NPCs practice sword training without a weapon
+ */
+func void Ninja_G1CP_007_PracticeSwordWithWeapon() {
+    HookDaedalusFuncS("ZS_PracticeSword_Loop", "Ninja_G1CP_007_PracticeSwordWithWeapon_Hook");
+};
+
+/*
+ * This function intercepts the state loop to draw a weapon if non is readied
+ */
+func void Ninja_G1CP_007_PracticeSwordWithWeapon_Hook() {
+    // Define possibly missing symbols locally
+    const int INV_WEAPON  = 1;
+    const int ITEM_KAT_NF = 2;
+
+    // Make sure the NPC has a weapon
+    if (!Npc_HasReadiedMeleeWeapon(self)) {
+
+        // Check for equipped weapon
+        if (Npc_HasEquippedMeleeWeapon(self)) {
+            AI_RemoveWeapon(self); // In case of fist mode
+            AI_DrawWeapon(self);
+        } else {
+            // Check if the NPC has a melee weapon in the inventory
+            // Explicitly check for a weapon instead of using AI_EquipBestMeleeWeapon to take action if no weapon is
+            // available, see below (success == FALSE).
+
+            // Back up the global symbol
+            var int itemBak; itemBak = _@(item);
+
+            // Iterate over all six weapon slots (see C_NpcHasWeapon)
+            MEM_InitLabels();
+            var int success; success = 0;
+            repeat(slot, 6); var int slot;
+                Npc_GetInvItemBySlot(self, INV_WEAPON, slot);
+                if (Hlp_IsValidItem(item)) {
+                    if (item.mainflag == ITEM_KAT_NF) {
+                        EquipWeapon(self, Hlp_GetInstanceID(item));  // Equip this exact weapon in particular
+                        AI_RemoveWeapon(self); // In case of fist mode
+                        AI_DrawWeapon(self);
+                        success = 1;
+                        break;
+                    };
+                };
+            end;
+
+            // Finally re-instate the global symbol
+            MEM_AssignInstSuppressNullWarning = TRUE;
+            item = _^(itemBak);
+            MEM_AssignInstSuppressNullWarning = FALSE;
+
+            // No melee weapon, what now?
+            if (!success) {
+                var int symbId; symbId = MEM_FindParserSymbol("ZS_StandAround");
+                if (symbId != -1) {
+                    // AI_StartState(self, symbId, 1, ""); // Does not work, expects func parameter
+                    MEM_PushInstParam(self);
+                    MEM_PushIntParam(symbId); // Func parameter as integer
+                    MEM_PushIntParam(1);
+                    MEM_PushStringParam("");
+                    MEM_Call(AI_StartState);
+                } else {
+                    // We tried everything. Go ahead and train with your imaginary weapon!
+                };
+            };
+        };
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};
+

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -15,6 +15,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_MenuVersionNumber();
         Ninja_G1CP_TestSuite();
         Ninja_G1CP_003_RegainDroppedWeapon();                           // #3
+        Ninja_G1CP_007_PracticeSwordWithWeapon();                       // #7
         Ninja_G1CP_015_HoratioStrength();                               // #15
         Ninja_G1CP_017_JackalProtectionMoney();                         // #17
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59

--- a/src/Ninja/G1CP/Content/Tests/test007.d
+++ b/src/Ninja/G1CP/Content/Tests/test007.d
@@ -1,0 +1,107 @@
+/*
+ * #7 NPCs practice sword training without a weapon
+ *
+ * Two test NPCs are spawned to perform the sword practice. One of them has a sword in their inventory, the other one
+ * doesn't. For technical reasons the hero will be locked and turning to one of the NPCs. It might be difficult to watch
+ * both of them.
+ *
+ * Expected behavior: One NPC will equip and draw their weapon to perform the practice. The other will stand still.
+ */
+const int Ninja_G1CP_Test_007_Pass = 0;
+
+func void Ninja_G1CP_Test_007() {
+    if (!Ninja_G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Check if AI state exists
+    var int symbId; symbId = MEM_FindParserSymbol("ZS_PracticeSword");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail(7, "AI state 'ZS_PracticeSword' does not exist");
+        return;
+    };
+
+    // Two passes
+    Ninja_G1CP_Test_007_Pass = 0;
+
+    // Insert test NPC
+    var string wp; wp = Npc_GetNearestWP(hero);
+    Wld_InsertNpc(Ninja_G1CP_Test_007_Npc, wp);
+    var C_Npc test; test = Hlp_GetNpc(Ninja_G1CP_Test_007_Npc);
+    if (!Hlp_IsValidNpc(test)) {
+        Ninja_G1CP_TestsuiteErrorDetail(7, "Failed to insert NPC");
+        return;
+    };
+
+    // Second pass
+    Wld_InsertNpc(Ninja_G1CP_Test_007_Npc, wp);
+};
+
+/*
+ * The actual test will run through the NPC's AI state (see below)
+ */
+instance Ninja_G1CP_Test_007_Npc(C_Npc) {
+    name          = "Test 7";
+    attribute[0]  = 2;
+    attribute[1]  = 2;
+    attribute[4]  = 1000; // Enough strength to carry any weapon
+    attribute[5]  = 1000; // Enough dexterity to carry any weapon
+    senses        = 7;
+    senses_range  = 2000;
+    start_aistate = ZS_Ninja_G1CP_Test_007_NpcRountine;
+    Mdl_SetVisual(self, "HUMANS.MDS");
+    Mdl_SetVisualBody(self, "HUM_BODY_NAKED0", 1, 1, "Hum_Head_Fighter", 1, 1, -1);
+    EquipItem(self, MEM_FindParserSymbol("ItRw_Bow_Small_01"));  // Should not be used to practice
+};
+
+/*
+ * AI state is stared once the NPC is properly inserted
+ */
+func void ZS_Ninja_G1CP_Test_007_NpcRountine() {};
+func int  ZS_Ninja_G1CP_Test_007_NpcRountine_Loop() {
+    // First pass: Trigger the script
+    if (Npc_GetStateTime(self) <= 1) {
+        // Only add the item now (spawn would have auto-equipped the sword)
+
+        // One of the two NPCs has a weapon
+        if (Ninja_G1CP_Test_007_Pass == 1) {
+            CreateInvItem(self, MEM_FindParserSymbol("Scars_Schwert"));
+        };
+        Ninja_G1CP_Test_007_Pass += 1;
+
+        // Trigger the AI state
+        var int symbId; symbId = MEM_FindParserSymbol("ZS_PracticeSword");
+        if (symbId != -1) {
+            // AI_StartState(self, symbId, 0, ""); // Does not work, expects func parameter
+            MEM_PushInstParam(self);
+            MEM_PushIntParam(symbId); // Func parameter as integer
+            MEM_PushIntParam(0);
+            MEM_PushStringParam("");
+            MEM_Call(AI_StartState);
+
+            // Somehow needs to end
+            AI_TurnToNpc(hero, self);
+            AI_Wait(hero, 5);
+            AI_Function(hero, Ninja_G1CP_Test_007_Success);
+        } else {
+            // Send to zSpy directly here because it is after the test has finished
+            MEM_SendToSpy(zERR_TYPE_FAULT, "  Test   7: AI state 'ZS_PracticeSword' does not exist");
+        };
+        return 1;
+    };
+};
+func void Ninja_G1CP_Test_007_NpcRemove() {
+    // Delete the NPC once finished
+    MEM_WriteInt(_@(self.bodymass)+8, 0); // Clear start_aistate
+    AI_Function_I(hero, Wld_RemoveNpc, Ninja_G1CP_Test_007_Npc);
+};
+func void Ninja_G1CP_Test_007_Success() {
+    Print(ConcatStrings(ConcatStrings("Test 3 passed (PART ", IntToString(Ninja_G1CP_Test_007_Pass-1)), " of 2)"));
+    Ninja_G1CP_Test_007_NpcRemove();
+    Ninja_G1CP_Test_007_Pass += 1;
+};
+func void ZS_Ninja_G1CP_Test_007_NpcRountine_End() {
+    Print(ConcatStrings(ConcatStrings("Test 3 failed (PART ", IntToString(Ninja_G1CP_Test_007_Pass-1)), " of 2)"));
+    Ninja_G1CP_Test_007_NpcRemove();
+    Ninja_G1CP_Test_007_Pass += 1;
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -12,6 +12,7 @@ Content\Misc\Npc_CanSeeVob.d
 
 // Session fixes
 Content\Fixes\Session\fix003_RegainDroppedWeapon.d
+Content\Fixes\Session\fix007_PracticeSwordWithWeapon.d
 Content\Fixes\Session\fix015_HoratioStrength.d
 Content\Fixes\Session\fix017_JackalProtectionMoney.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
@@ -20,6 +21,7 @@ Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Tests
 Content\Tests\test003.d
+Content\Tests\test007.d
 Content\Tests\test015.d
 Content\Tests\test017.d
 Content\Tests\test059.d


### PR DESCRIPTION
This fix is a bit more elaborate than proposed [here](https://github.com/AmProsius/gothic-1-community-patch/issues/7#issuecomment-757119039).

There are different scenarios:

1. The NPC has a melee weapon equipped but not drawn. -> Draw weapon
2. The NPC doesn't have a weapon equipped. -> Search if a weapon is available, eqiup and draw it
3. The NPC doesn't have a weapon in their inventory. -> Switch to `ZS_StandAround`
4. The NPC doesn't have a weapon and `ZS_StandAround` does not exist (for some reason). -> Do sword practice without a weapon and make a fool out of yourself.