### PR TITLE
#18: Add new condition to Bloodwyn's dialog

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix018_BloodwynProtectionMoney.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix018_BloodwynProtectionMoney.d
@@ -1,0 +1,19 @@
+/*
+ * #18 Bloodwyn doesn't recognize the player's camp membership
+ */
+func void Ninja_G1CP_018_BloodwynProtectionMoney() {
+    HookDaedalusFuncS("Info_Bloodwyn_Hello_Condition", "Ninja_G1CP_018_BloodwynProtectionMoney_Hook");
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int Ninja_G1CP_018_BloodwynProtectionMoney_Hook() {
+    // Add the new condition (other conditions remain untouched)
+    if (Npc_GetTrueGuild(hero)) {
+        return FALSE;
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -17,6 +17,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_003_RegainDroppedWeapon();                           // #3
         Ninja_G1CP_015_HoratioStrength();                               // #15
         Ninja_G1CP_017_JackalProtectionMoney();                         // #17
+        Ninja_G1CP_018_BloodwynProtectionMoney();                       // #18
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
 
         once = 1;

--- a/src/Ninja/G1CP/Content/Tests/test018.d
+++ b/src/Ninja/G1CP/Content/Tests/test018.d
@@ -1,0 +1,35 @@
+/*
+ * #18 Bloodwyn doesn't recognize the player's camp membership
+ *
+ * The hero is given a new guild and the condition function of the dialog is called.
+ *
+ * Expected behavior: The condition function will return FALSE.
+ */
+func int Ninja_G1CP_Test_018() {
+    var int symbId; symbId = MEM_FindParserSymbol("Info_Bloodwyn_Hello_Condition");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail(18, "Original dialog not found");
+        return FALSE;
+    };
+
+    // Backup the original guild
+    var int guildBak; guildBak = Npc_GetTrueGuild(hero);
+
+    // Assign a random guild
+    Npc_SetTrueGuild(hero, 4);
+
+    // Call dialog condition function
+    MEM_CallByID(symbId);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore guild
+    Npc_SetTrueGuild(hero, guildBak);
+
+    // Check return value
+    if (ret) {
+        Ninja_G1CP_TestsuiteErrorDetail(18, "Dialog condition failed");
+        return FALSE;
+    } else {
+        return TRUE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -14,6 +14,7 @@ Content\Misc\Npc_CanSeeVob.d
 Content\Fixes\Session\fix003_RegainDroppedWeapon.d
 Content\Fixes\Session\fix015_HoratioStrength.d
 Content\Fixes\Session\fix017_JackalProtectionMoney.d
+Content\Fixes\Session\fix018_BloodwynProtectionMoney.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
@@ -22,6 +23,7 @@ Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 Content\Tests\test003.d
 Content\Tests\test015.d
 Content\Tests\test017.d
+Content\Tests\test018.d
 Content\Tests\test059.d
 
 // Initialization


### PR DESCRIPTION
Like #65 this PR checks whether the player has a guild or not.
The fix can be tested with `test 18`.

Closes #18.