### PR TITLE
#9: Remove freeze from fleeing

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix009_FixFlee.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix009_FixFlee.d
@@ -1,0 +1,36 @@
+/*
+ * #9 NPCs freeze when fleeing
+ */
+func void Ninja_G1CP_009_FixFlee() {
+    HookDaedalusFuncS("ZS_Flee_Loop", "Ninja_G1CP_009_FixFlee_Hook");
+};
+
+/*
+ * This function intercepts the NPC state to introduce more conditions
+ */
+func int Ninja_G1CP_009_FixFlee_Hook() {
+    // Temporarily disable AI_Wait
+    const int AI_Wait_popped = 6644536; //0x656338
+    const int once = 0;
+    if (!once) {
+        MemoryProtectionOverride(AI_Wait_popped, 4);
+        once = 1;
+    };
+    const int orig = 3296983179; /*8B F8 83 C4*/
+    const int newb = 3296984881; /*31 FF 83 C4*/
+    if (MEM_ReadInt(AI_Wait_popped) == orig) {
+        MEM_WriteInt(AI_Wait_popped, newb);
+    };
+
+    // Call the original function (There might be other important changes that we do not want to overwrite!)
+    ContinueCall();
+    var int ret; ret = MEM_PopIntResult();
+
+    // Re-enable the AI_Wait
+    if (MEM_ReadInt(AI_Wait_popped) == newb) {
+        MEM_WriteInt(AI_Wait_popped, orig);
+    };
+
+    // Return original return value
+    return ret;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -17,6 +17,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_001_FixNpcSleep();                                   // #1
         Ninja_G1CP_003_RegainDroppedWeapon();                           // #3
         Ninja_G1CP_007_PracticeSwordWithWeapon();                       // #7
+        Ninja_G1CP_009_FixFlee();                                       // #9
         Ninja_G1CP_015_HoratioStrength();                               // #15
         Ninja_G1CP_016_ThorusBribeDialog();                             // #16
         Ninja_G1CP_017_JackalProtectionMoney();                         // #17

--- a/src/Ninja/G1CP/Content/Tests/test009.d
+++ b/src/Ninja/G1CP/Content/Tests/test009.d
@@ -1,0 +1,14 @@
+/*
+ * #9 NPCs freeze when fleeing
+ *
+ * Any NPC in the area is set to the ZS_Flee state (may not work for all of them if 'other' is invalid)
+ *
+ * Expected behavior: The NPCs will flee from the player without freezing (might be hard to determine when the run away)
+ */
+func void Ninja_G1CP_Test_009() {
+    if (Ninja_G1CP_TestsuiteAllowManual) {
+        // AI_Teleport(hero, "PSI_TEMPLE_COURT_2"); // Clears AI queue!
+        other = MEM_CpyInst(hero); // Might be dangerous!
+        AI_SetNpcsToState(hero, ZS_Flee, 4000);
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -16,6 +16,7 @@ Content\Misc\Npc_CanSeeVob.d
 Content\Fixes\Session\fix001_FixNpcSleep.d
 Content\Fixes\Session\fix003_RegainDroppedWeapon.d
 Content\Fixes\Session\fix007_PracticeSwordWithWeapon.d
+Content\Fixes\Session\fix009_FixFlee.d
 Content\Fixes\Session\fix015_HoratioStrength.d
 Content\Fixes\Session\fix016_ThorusBribeDialog.d
 Content\Fixes\Session\fix017_JackalProtectionMoney.d
@@ -28,6 +29,7 @@ Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 Content\Tests\test001.d
 Content\Tests\test003.d
 Content\Tests\test007.d
+Content\Tests\test009.d
 Content\Tests\test015.d
 Content\Tests\test016.d
 Content\Tests\test017.d


### PR DESCRIPTION
This PR should be ready.

Testing this fix is a bit tricky, because the NPC has to be visible all times while fleeing from the player. The rest requires to position the hero in a location surrounded by as many NPCs as possible to increase the chances of observing (not observing) the freeze. It's best to run the test first without and then with the fix, to remember where freezes do happen without the fix. To do so remove the fix here: 

https://github.com/AmProsius/gothic-1-community-patch/blob/ca8adc9d50a1c8e48340cbfd70702ccdddde4f72/src/Ninja/G1CP/Content/NinjaInit.d#L20

Run the test with `test 9`.