### PR TITLE
#10: Adjust walk mode in follow state

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix010_FollowWalkMode.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix010_FollowWalkMode.d
@@ -1,0 +1,81 @@
+/*
+ * #10 Companions don't adjust their walking speed
+ */
+func void Ninja_G1CP_010_FollowWalkMode() {
+    // Only register hooks, if both functions are found
+    if (MEM_FindParserSymbol("ZS_FollowPC_Loop")    != -1)
+    && (MEM_FindParserSymbol("B_FollowPC_AssessSC") != -1) {
+        HookDaedalusFuncS("ZS_FollowPC_Loop", "Ninja_G1CP_010_FollowWalkMode_Hook");
+        HookDaedalusFuncS("B_FollowPC_AssessSC", "Ninja_G1CP_010_FollowWalkMode_AssessSCHook");
+    };
+};
+
+/*
+ * This function intercepts the NPC state to introduce more conditions
+ */
+func int Ninja_G1CP_010_FollowWalkMode_Hook() {
+    // Define possibly missing symbols locally
+    const int BS_FLAG_INTERRUPTABLE = 32768;
+    const int BS_WALK               = 1 | BS_FLAG_INTERRUPTABLE;
+    const int BS_RUN                = 3;
+    const int NPC_WALK              = 1;
+
+    if (Ninja_G1CP_BodyStateContains(hero, BS_WALK)) && (Ninja_G1CP_BodyStateContains(self, BS_RUN)) {
+        AI_SetWalkmode(self, NPC_WALK);
+    };
+
+    // Place hook to intercept setting the walk mode
+    const int AI_SetWalkMode_popped = 6648584; //0x657308
+    HookEngineF(AI_SetWalkMode_popped, 5, Ninja_G1CP_010_FollowWalkMode_SetModeHook);
+
+    // Call the original function (There might be other important changes that we do not want to overwrite!)
+    ContinueCall();
+    var int ret; ret = MEM_PopIntResult();
+
+    // Remove hook again (only remove function but leave changes in engine for performance)
+    RemoveHookF(AI_SetWalkMode_popped, 0, Ninja_G1CP_010_FollowWalkMode_SetModeHook);
+
+    // Return original return value
+    return ret;
+};
+
+func void Ninja_G1CP_010_FollowWalkMode_SetModeHook() {
+    // Define possibly missing symbols locally
+    const int BS_FLAG_INTERRUPTABLE = 32768;
+    const int BS_WALK               = 1 | BS_FLAG_INTERRUPTABLE;
+    const int NPC_RUN               = 0;
+    const int NPC_WALK              = 1;
+
+    // Check if NPC is valid
+    if (!Hlp_Is_oCNpc(EAX)) {
+        return;
+    };
+    var C_Npc slf; slf = _^(EAX);
+
+    // Get walk mode
+    var int modePtr; modePtr = ESP+28;
+    var int mode; mode = MEM_ReadInt(modePtr);
+
+    // Adjust walking mode before calling the original function (gives opportunity for other changes there)
+    if (mode == NPC_RUN) && (Ninja_G1CP_BodyStateContains(hero, BS_WALK)) {
+        MEM_WriteInt(modePtr, NPC_WALK);
+    };
+};
+
+
+func void Ninja_G1CP_010_FollowWalkMode_AssessSCHook() {
+    // Define possibly missing symbols locally
+    const int BS_FLAG_INTERRUPTABLE = 32768;
+    const int BS_WALK               = 1 | BS_FLAG_INTERRUPTABLE;
+    const int BS_RUN                = 3;
+    const int NPC_RUN               = 0;
+
+    if (Ninja_G1CP_BodyStateContains(hero, BS_RUN)) && (Ninja_G1CP_BodyStateContains(self, BS_WALK)) {
+        Npc_ClearAIQueue(self);
+        AI_StandUpQuick(self);
+        AI_SetWalkmode(self, NPC_RUN);
+    };
+
+    // Call original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -19,6 +19,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_003_RegainDroppedWeapon();                           // #3
         Ninja_G1CP_007_PracticeSwordWithWeapon();                       // #7
         Ninja_G1CP_009_FixFlee();                                       // #9
+        Ninja_G1CP_010_FollowWalkMode();                                // #10
         Ninja_G1CP_015_HoratioStrength();                               // #15
         Ninja_G1CP_016_ThorusBribeDialog();                             // #16
         Ninja_G1CP_017_JackalProtectionMoney();                         // #17

--- a/src/Ninja/G1CP/Content/Tests/test010.d
+++ b/src/Ninja/G1CP/Content/Tests/test010.d
@@ -1,0 +1,77 @@
+/*
+ * #10 Companions don't adjust their walking speed
+ *
+ * A test NPC is inserted in the ZS_FollowPC state
+ *
+ * Expected behavior: The NPC will pick up on the hero's walking mode
+ */
+func void Ninja_G1CP_Test_010() {
+    if (!Ninja_G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Insert test NPC
+    var string wp; wp = Npc_GetNearestWP(hero);
+    Wld_InsertNpc(Ninja_G1CP_Test_010_Npc, wp);
+    var C_Npc test; test = Hlp_GetNpc(Ninja_G1CP_Test_010_Npc);
+    if (!Hlp_IsValidNpc(test)) {
+        Ninja_G1CP_TestsuiteErrorDetail(10, "Failed to insert NPC");
+        return;
+    };
+
+    // Check for ZS_FollowPC
+    var int symbId; symbId = MEM_FindParserSymbol("ZS_FollowPC");
+    if (!symbId) {
+        Ninja_G1CP_TestsuiteErrorDetail(10, "'ZS_FollowPC' not found");
+        return;
+    };
+
+    // Update state dynamically (to make sure it exists)
+    MEM_WriteInt(_@(test.bodymass)+8, symbId);
+};
+
+
+/*
+ * The actual test will run through the NPC's AI state (see below)
+ */
+instance Ninja_G1CP_Test_010_Npc(C_Npc) {
+    name          = "Test 10";
+    attribute[0]  = 2;
+    attribute[1]  = 2;
+    senses        = 7;
+    senses_range  = 2000;
+    Mdl_SetVisual(self, "HUMANS.MDS");
+    Mdl_SetVisualBody(self, "HUM_BODY_NAKED0", 1, 1, "Hum_Head_Fighter", 1, 1, -1);
+};
+
+/*
+ * Add dialog to remove the NPC
+ */
+instance Ninja_G1CP_Test_010_Dialog(C_Info) {
+    npc         = Ninja_G1CP_Test_010_Npc;
+    condition   = Ninja_G1CP_Test_010_Dialog_Condition;
+    information = Ninja_G1CP_Test_010_Dialog_Info;
+    important   = 1;
+    permanent   = 1;
+};
+func int Ninja_G1CP_Test_010_Dialog_Condition() {
+    var int symbId; symbId = MEM_FindParserSymbol("ZS_Talk");
+    if (!symbId) {
+        return FALSE;
+    };
+    // Npc_IsInState(self, symbId)
+    MEM_PushInstParam(self);
+    MEM_PushIntParam(symbId);
+    MEM_Call(Npc_IsInState);
+    if (MEM_PopIntResult()) {
+        return TRUE;
+    };
+};
+func void Ninja_G1CP_Test_010_Dialog_Info() {
+    AI_StopProcessInfos(self);
+    AI_StopProcessInfos(other);
+
+    // Delete the NPC once finished
+    MEM_WriteInt(_@(self.bodymass)+8, 0); // Clear start_aistate
+    AI_Function_I(hero, Wld_RemoveNpc, Ninja_G1CP_Test_010_Npc);
+};

--- a/src/Ninja/G1CP/Content/misc.d
+++ b/src/Ninja/G1CP/Content/misc.d
@@ -16,9 +16,8 @@ func string Ninja_G1CP_LFill(var string str, var string fill, var int total) {
 /*
  * Copy of C_BodyStateContains to ensure it exists as expected
  */
-func int Ninja_G1CP_BodyStateContains(var int npcInstance, var int bodystate) {
+func int Ninja_G1CP_BodyStateContains(var C_Npc slf, var int bodystate) {
     const int mod = 31 | 32768 | 65536; // BS_MAX | BS_FLAG_INTERRUPTABLE | BS_FLAG_FREEHANDS
-    var C_Npc slf; slf = Hlp_GetNpc(npcInstance);
     return ((Npc_GetBodyState(slf) & mod) == (bodystate & mod));
 };
 

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -18,6 +18,7 @@ Content\Fixes\Session\fix002_FixDoor.d
 Content\Fixes\Session\fix003_RegainDroppedWeapon.d
 Content\Fixes\Session\fix007_PracticeSwordWithWeapon.d
 Content\Fixes\Session\fix009_FixFlee.d
+Content\Fixes\Session\fix010_FollowWalkMode.d
 Content\Fixes\Session\fix015_HoratioStrength.d
 Content\Fixes\Session\fix016_ThorusBribeDialog.d
 Content\Fixes\Session\fix017_JackalProtectionMoney.d
@@ -33,6 +34,7 @@ Content\Tests\test002.d
 Content\Tests\test003.d
 Content\Tests\test007.d
 Content\Tests\test009.d
+Content\Tests\test010.d
 Content\Tests\test015.d
 Content\Tests\test016.d
 Content\Tests\test017.d


### PR DESCRIPTION
The NPC will now adjust their walking speed (walking vs. running) according to the player.

1. Player runs: NPC runs.
2. Player walks: NPC walks - as soon as close enough to the player
3. Player runs again: NPC starts running immediately - only works if there is line of sight!

Test: Manual confirmation required. Run `test 10`.

Closes #10.