### PR TITLE
#24: Cor Kalom closes correct quest

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix024_CorKalomWrongQuest.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix024_CorKalomWrongQuest.d
@@ -1,0 +1,42 @@
+/*
+ * #24 Cor Kalom closes wrong quest
+ */
+func void Ninja_G1CP_024_CorKalomWrongQuest() {
+    HookDaedalusFuncS("Info_Kalom_KrautboteBACK_Info", "Ninja_G1CP_024_CorKalomWrongQuest_Hook");
+};
+
+/*
+* Intercept the dialog 'Info_Kalom_KrautboteBACK_Info'
+*/
+func void Ninja_G1CP_024_CorKalomWrongQuest_Hook() {
+    // Define possibly missing symbols locally
+    const int LOG_SUCCESS = 2;
+
+    // Local backups
+    var int drugMonopolBak;
+    var int drugMonopolPtr; drugMonopolPtr = 0;
+    var int krautbotePtr;   krautbotePtr   = 0;
+
+    // Check if symbols exist and backup current values
+    var int symbPtr;
+    symbPtr = MEM_GetSymbol("Kalom_DrugMonopol");
+    if (symbPtr) {
+        drugMonopolPtr = symbPtr + zCParSymbol_content_offset;
+        drugMonopolBak = MEM_ReadInt(drugMonopolPtr);
+    };
+    symbPtr = MEM_GetSymbol("Kalom_Krautbote");
+    if (symbPtr) {
+        krautbotePtr = symbPtr + zCParSymbol_content_offset;
+    };
+
+    // Continue with the original function
+    ContinueCall();
+
+    // Reinstate and correct the variables
+    if (drugMonopolPtr) {
+        MEM_WriteInt(drugMonopolPtr, drugMonopolBak);
+    };
+    if (krautbotePtr) {
+        MEM_WriteInt(krautbotePtr, LOG_SUCCESS);
+    };
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -26,6 +26,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_018_BloodwynProtectionMoney();                       // #18
         Ninja_G1CP_019_ScorpioFightDialog();                            // #19
         Ninja_G1CP_020_KirgoGivesBeer();                                // #20
+        Ninja_G1CP_024_CorKalomWrongQuest();                            // #24
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
 
         once = 1;

--- a/src/Ninja/G1CP/Content/Tests/test024.d
+++ b/src/Ninja/G1CP/Content/Tests/test024.d
@@ -17,41 +17,41 @@ func int Ninja_G1CP_Test_024() {
     // Find Cor Kalom first
     var int symbId; symbId = MEM_FindParserSymbol("GUR_1201_CorKalom");
     if (symbId == -1) {
-        Ninja_G1CP_TestsuiteErrorDetail(20, "NPC 'GUR_1201_CorKalom' not found");
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'GUR_1201_CorKalom' not found");
         passed = FALSE;
     };
 
     // Check if Cor Kalom exists in the world
     var C_Npc kalom; kalom = Hlp_GetNpc(symbId);
     if (!Hlp_IsValidNpc(kalom)) {
-        Ninja_G1CP_TestsuiteErrorDetail(20, "'GUR_1201_CorKalom' is not a valid NPC");
+        Ninja_G1CP_TestsuiteErrorDetail("'GUR_1201_CorKalom' is not a valid NPC");
         passed = FALSE;
     };
 
     // Check if dialog exists
     var int funcId; funcId = MEM_FindParserSymbol("Info_Kalom_KrautboteBACK_Info");
     if (funcId == -1) {
-        Ninja_G1CP_TestsuiteErrorDetail(24, "Dialog function 'Info_Kalom_KrautboteBACK_Info' not found");
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'Info_Kalom_KrautboteBACK_Info' not found");
         passed = FALSE;
     };
 
     // Check if the ore nugget item exists
     var int nuggetId; nuggetId = MEM_FindParserSymbol("ItMiNugget");
     if (nuggetId == -1) {
-        Ninja_G1CP_TestsuiteErrorDetail(20, "Item 'ItMiNugget' not found");
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItMiNugget' not found");
         passed = FALSE;
     };
 
     // Obtain symbols
     var int drugMonopolPtr; drugMonopolPtr = MEM_GetSymbol("Kalom_DrugMonopol");
     if (!drugMonopolPtr) {
-        Ninja_G1CP_TestsuiteErrorDetail(24, "Variable 'Kalom_DrugMonopol' not found");
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'Kalom_DrugMonopol' not found");
         passed = FALSE;
     };
     drugMonopolPtr += zCParSymbol_content_offset;
     var int krautbotePtr; krautbotePtr = MEM_GetSymbol("Kalom_Krautbote");
     if (!krautbotePtr) {
-        Ninja_G1CP_TestsuiteErrorDetail(24, "Variable 'Kalom_Krautbote' not found");
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'Kalom_Krautbote' not found");
         passed = FALSE;
     };
     krautbotePtr += zCParSymbol_content_offset;
@@ -101,11 +101,11 @@ func int Ninja_G1CP_Test_024() {
 
     // Confirm the fix
     if (drugMonopolAfter != LOG_RUNNING) {
-        Ninja_G1CP_TestsuiteErrorDetail(24, "Mission 'Kalom_DrugMonopol' was wrongfully closed");
+        Ninja_G1CP_TestsuiteErrorDetail("Mission 'Kalom_DrugMonopol' was wrongfully closed");
         passed = FALSE;
     };
     if (krautboteAfter != LOG_SUCCESS) {
-        Ninja_G1CP_TestsuiteErrorDetail(24, "Mission 'Kalom_Krautbote' is still open");
+        Ninja_G1CP_TestsuiteErrorDetail("Mission 'Kalom_Krautbote' is still open");
         passed = FALSE;
     };
 

--- a/src/Ninja/G1CP/Content/Tests/test024.d
+++ b/src/Ninja/G1CP/Content/Tests/test024.d
@@ -1,0 +1,113 @@
+/*
+ * #24 Cor Kalom closes wrong quest
+ *
+ * The hero is given 500 ore nuggets and the dialog function is called.
+ * Caution: This test will trigger the dialog as told and closes the quest. Save the game before this test.
+ *
+ * Expected behavior: The variable 'Kalom_DrugMonopol' remains as before and 'Kalom_Krautbote' is set to 'LOG_SUCCESS'
+ */
+func int Ninja_G1CP_Test_024() {
+    // Define possibly missing symbols locally
+    const int LOG_RUNNING = 1;
+    const int LOG_SUCCESS = 2;
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Find Cor Kalom first
+    var int symbId; symbId = MEM_FindParserSymbol("GUR_1201_CorKalom");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail(20, "NPC 'GUR_1201_CorKalom' not found");
+        passed = FALSE;
+    };
+
+    // Check if Cor Kalom exists in the world
+    var C_Npc kalom; kalom = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(kalom)) {
+        Ninja_G1CP_TestsuiteErrorDetail(20, "'GUR_1201_CorKalom' is not a valid NPC");
+        passed = FALSE;
+    };
+
+    // Check if dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("Info_Kalom_KrautboteBACK_Info");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail(24, "Dialog function 'Info_Kalom_KrautboteBACK_Info' not found");
+        passed = FALSE;
+    };
+
+    // Check if the ore nugget item exists
+    var int nuggetId; nuggetId = MEM_FindParserSymbol("ItMiNugget");
+    if (nuggetId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail(20, "Item 'ItMiNugget' not found");
+        passed = FALSE;
+    };
+
+    // Obtain symbols
+    var int drugMonopolPtr; drugMonopolPtr = MEM_GetSymbol("Kalom_DrugMonopol");
+    if (!drugMonopolPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail(24, "Variable 'Kalom_DrugMonopol' not found");
+        passed = FALSE;
+    };
+    drugMonopolPtr += zCParSymbol_content_offset;
+    var int krautbotePtr; krautbotePtr = MEM_GetSymbol("Kalom_Krautbote");
+    if (!krautbotePtr) {
+        Ninja_G1CP_TestsuiteErrorDetail(24, "Variable 'Kalom_Krautbote' not found");
+        passed = FALSE;
+    };
+    krautbotePtr += zCParSymbol_content_offset;
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Back up the values
+    var int drugMonopolBak; drugMonopolBak = MEM_ReadInt(drugMonopolPtr);
+    var int krautboteBak;   krautboteBak   = MEM_ReadInt(krautbotePtr);
+
+    // Set the variables
+    MEM_WriteInt(drugMonopolPtr, LOG_RUNNING);
+    MEM_WriteInt(krautbotePtr,   LOG_RUNNING);
+
+    // Add 500 ore for the condition within the dialog
+    CreateInvItems(hero, nuggetId, 500);
+
+    // Backup self and other
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);
+    var C_Npc othBak; othBak = MEM_CpyInst(other);
+
+    // Set self and other
+    self  = MEM_CpyInst(kalom);
+    other = MEM_CpyInst(hero);
+
+    // Just run the dialog and see what happens
+    MEM_CallByID(funcId);
+
+    // Restore self and other
+    self  = MEM_CpyInst(slfBak);
+    other = MEM_CpyInst(othBak);
+
+    // Stop the output units
+    Npc_ClearAIQueue(hero);
+    AI_StandUpQuick(hero);
+
+    // Check the variables now
+    var int drugMonopolAfter; drugMonopolAfter = MEM_ReadInt(drugMonopolPtr);
+    var int krautboteAfter;   krautboteAfter   = MEM_ReadInt(krautbotePtr);
+
+    // Restore the variables
+    MEM_WriteInt(drugMonopolPtr, drugMonopolBak);
+    MEM_WriteInt(krautbotePtr, krautboteBak);
+
+    // Confirm the fix
+    if (drugMonopolAfter != LOG_RUNNING) {
+        Ninja_G1CP_TestsuiteErrorDetail(24, "Mission 'Kalom_DrugMonopol' was wrongfully closed");
+        passed = FALSE;
+    };
+    if (krautboteAfter != LOG_SUCCESS) {
+        Ninja_G1CP_TestsuiteErrorDetail(24, "Mission 'Kalom_Krautbote' is still open");
+        passed = FALSE;
+    };
+
+    return passed;
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -25,6 +25,7 @@ Content\Fixes\Session\fix017_JackalProtectionMoney.d
 Content\Fixes\Session\fix018_BloodwynProtectionMoney.d
 Content\Fixes\Session\fix019_ScorpioFightDialog.d
 Content\Fixes\Session\fix020_KirgoGivesBeer.d
+Content\Fixes\Session\fix024_CorKalomWrongQuest.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
@@ -42,6 +43,7 @@ Content\Tests\test017.d
 Content\Tests\test018.d
 Content\Tests\test019.d
 Content\Tests\test020.d
+Content\Tests\test024.d
 Content\Tests\test059.d
 
 // Initialization


### PR DESCRIPTION
Though this test is automatic, afterwards the mission's are closed. The game should be saved before and loaded after.

Run the test with `test 24`.

Closes #24.