### PR TITLE
#53: Make ladders in old mine usable

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix053_OldMineLadders.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix053_OldMineLadders.d
@@ -1,0 +1,186 @@
+/*
+ * #53 Ladder in Old Mine too short
+ */
+
+/* Old positions of the ladders (Integerfloats for precision) */
+const int Ninja_G1CP_053_OldMineLadders_PosL1old[16] = {1056645348, 1039739221,  1063053323, -996629510,
+                                                        1036063365, 1064967154, -1102844970, -975445247,
+                                                       -1084372949, 1043555876,  1055881796, -981167673,
+                                                                 0,          0,           0, 1065353216};
+const int Ninja_G1CP_053_OldMineLadders_PosL2old[16] = {1054446790, 1042272444,  1063535493, -996953302,
+                                                        1023915813, 1065045910, -1103093957, -975519819,
+                                                       -1083730910, 1038076817,  1054012091, -981016188,
+                                                                 0,          0,           0, 1065353216};
+/* New positions of the ladders */
+const int Ninja_G1CP_053_OldMineLadders_PosL1new[16] = {1056177182, -2147483648, 1063325801,  -996629510,
+                                                                 0,  1065353216,          0,  -975445247,
+                                                       -1084157847, -2147483648, 1056177182,  -981167673,
+                                                                 0,           0,          0,  1065353216};
+const int Ninja_G1CP_053_OldMineLadders_PosL2new[16] = {1054262023, -2147483648, 1063805944,  -996953302,
+                                                                 0,  1065353216,          0,  -975519819,
+                                                       -1083677704, -2147483648, 1054262023,  -981016188,
+                                                                 0,           0,          0,  1065353216};
+/* Position of the new plank connecting the ladders to the cliff */
+const float Ninja_G1CP_053_OldMineLadders_PlkPos[16] = {0.419457, 0.000000, 0.907775, -1000.000000,
+                                                        0.000000, 1.000000, 0.000000, -6625.000000,
+                                                       -0.907775, 0.000000, 0.419457, -4300.000000,
+                                                        0.000000, 0.000000, 0.000000,     1.000000};
+
+/*
+ * This function applies the changes of #53
+ */
+func void Ninja_G1CP_053_OldMineLadders() {
+    // Expected properties
+    const string waypoint = "OM_185";
+    const string mobName = "LADDER_4";
+    const string visName = "LADDER_3.ASC";
+    const float distToWp = 300.0;
+    // New properties
+    const string visNew = "LADDER_4.ASC";
+    const string name1 = "NINJA_G1CP_053_LADDER1";
+    const string name2 = "NINJA_G1CP_053_LADDER2";
+    // New plank vob
+    const string plkVis = "Min_Lob_Planks_2x3m.3DS";
+    const string plkName = "NINJA_G1CP_053_PLANK";
+
+    // First, check if the closest waypoint exists (correct world)
+    var int wpPtr; wpPtr = Ninja_G1CP_GetWaypointByName(waypoint);
+    if (!wpPtr) {
+        return;
+    };
+
+    // Check if already applied
+    if (MEM_SearchVobByName(plkName)) {
+        return;
+    };
+
+    // Find all vobs of matching name
+    var int arrPtr; arrPtr = MEM_SearchAllVobsByName(mobName);
+
+    // Narrow down the search
+    var int found; found = 0;
+    repeat(i, MEM_ArraySize(arrPtr)); var int i;
+        var int vobPtr; vobPtr = MEM_ArrayRead(arrPtr, i);
+
+        // Check if vob is a ladder
+        if (!Hlp_Is_oCMobLadder(vobPtr)) {
+            continue;
+        };
+
+        // Check if it is in certain range of the way point
+        var int dist; dist = Ninja_G1CP_GetDistToWp(vobPtr, wpPtr);
+        if (dist > castToIntf(300.0)) {
+            continue;
+        };
+
+        // Make sure it has a visual
+        var zCVob ladder; ladder = _^(vobPtr);
+        if (!ladder.visual) {
+            continue;
+        };
+
+        // Confirm visual name (non-recyclable call)
+        var int vtbl; vtbl = MEM_ReadInt(ladder.visual);
+        var int GetVisualName; GetVisualName = MEM_ReadInt(vtbl+32);
+        CALL_RetValIszString();
+        CALL__thiscall(ladder.visual, GetVisualName);
+        if (!Hlp_StrCmp(CALL_RetValAszString(), visName)) {
+            continue;
+        };
+
+        // Confirm exact position and update it
+        if (MEM_CompareWords(vobPtr+60, _@(Ninja_G1CP_053_OldMineLadders_PosL1old), 16)) {
+            MEM_RenameVob(vobPtr, name1);
+            MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_PosL1new), vobPtr+60, 16);
+        } else if (MEM_CompareWords(vobPtr+60, _@(Ninja_G1CP_053_OldMineLadders_PosL2old), 16)) {
+            MEM_RenameVob(vobPtr, name2);
+            MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_PosL2new), vobPtr+60, 16);
+        } else {
+            continue;
+        };
+
+        // Set the new visual
+        const int zCVob__SetVisual = 6123424; //0x5D6FA0
+        const int call = 0;
+        const int visNamePtr = 0;
+        if (CALL_Begin(call)) {
+            visNamePtr = _@s(visNew);
+            CALL_PtrParam(_@(visNamePtr));
+            CALL__thiscall(_@(vobPtr), zCVob__SetVisual);
+            call = CALL_End();
+        };
+
+        found += 1;
+    end;
+    MEM_ArrayFree(arrPtr);
+
+    // Check if at least one ladder was found
+    if (!found) {
+        return;
+    };
+
+    // Add the plank on the upper end
+    var int plankPtr; plankPtr = MEM_InsertVob(plkVis, waypoint);
+    MEM_RenameVob(plankPtr, plkName);
+    var zCVob plank; plank = _^(plankPtr);
+
+    // Remove collision
+    var int bits; bits = plank.bitfield[0];
+    plank.bitfield[0] = (plank.bitfield[0] & ~zCVob_bitfield0_collDetectionStatic
+                                           & ~zCVob_bitfield0_collDetectionDynamic);
+
+    const int zCVob__SetTrafoObjToWorld = 6219616; //0x5EE760
+    const int trfPtr = 0;
+    const int call2 = 0;
+    if (CALL_Begin(call2)) {
+        trfPtr = _@f(Ninja_G1CP_053_OldMineLadders_PlkPos);
+        CALL_PtrParam(_@(trfPtr));
+        CALL__thiscall(_@(plankPtr), zCVob__SetTrafoObjToWorld);
+        call2 = CALL_End();
+    };
+
+    // Reset collision
+    plank.bitfield[0] = bits;
+};
+
+
+/*
+ * This function reverts the changes of #53
+ */
+func void Ninja_G1CP_053_OldMineLadders_Revert() {
+    const string name1 = "NINJA_G1CP_053_LADDER1";
+    const string name2 = "NINJA_G1CP_053_LADDER2";
+    const string plkName = "NINJA_G1CP_053_PLANK";
+    const string mobName = "LADDER_4";
+    const string visName = "LADDER_3.ASC";
+
+    // Remove plank (may be zero)
+    MEM_DeleteVob(MEM_SearchVobByName(plkName));
+
+    // Create call first time
+    const int zCVob__SetVisual = 6123424; //0x5D6FA0
+    const int call = 0;
+    const int visNamePtr = 0;
+    if (!call) {
+        CALL_Open();
+        visNamePtr = _@s(visName);
+        CALL_PtrParam(_@(visNamePtr));
+        CALL__thiscall(_@(vobPtr), zCVob__SetVisual);
+        call = CALL_Close();
+    };
+
+    // Revert the changes to the ladders if applicable
+    var int vobPtr;
+    vobPtr = MEM_SearchVobByName(name1);
+    if (vobPtr) {
+        MEM_RenameVob(vobPtr, mobName);
+        MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_PosL1old), vobPtr+60, 16);
+        ASM_Run(call);
+    };
+    vobPtr = MEM_SearchVobByName(name2);
+    if (vobPtr) {
+        MEM_RenameVob(vobPtr, mobName);
+        MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_PosL2old), vobPtr+60, 16);
+        ASM_Run(call);
+    };
+};

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix053_OldMineLadders.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix053_OldMineLadders.d
@@ -3,28 +3,38 @@
  */
 
 /* Old positions of the ladders (Integerfloats for precision) */
-const int Ninja_G1CP_053_OldMineLadders_PosL1old[16] = {1056645348, 1039739221,  1063053323, -996629510,
-                                                        1036063365, 1064967154, -1102844970, -975445247,
-                                                       -1084372949, 1043555876,  1055881796, -981167673,
-                                                                 0,          0,           0, 1065353216};
-const int Ninja_G1CP_053_OldMineLadders_PosL2old[16] = {1054446790, 1042272444,  1063535493, -996953302,
-                                                        1023915813, 1065045910, -1103093957, -975519819,
-                                                       -1083730910, 1038076817,  1054012091, -981016188,
-                                                                 0,          0,           0, 1065353216};
+const int Ninja_G1CP_053_OldMineLadders_L1PosOld[16] = {
+    1056645348, 1039739221,  1063053323, -996629510,
+    1036063365, 1064967154, -1102844970, -975445247,
+   -1084372949, 1043555876,  1055881796, -981167673,
+             0,          0,           0, 1065353216
+};
+const int Ninja_G1CP_053_OldMineLadders_L2PosOld[16] = {
+    1054446790, 1042272444,  1063535493, -996953302,
+    1023915813, 1065045910, -1103093957, -975519819,
+   -1083730910, 1038076817,  1054012091, -981016188,
+             0,          0,           0, 1065353216
+};
 /* New positions of the ladders */
-const int Ninja_G1CP_053_OldMineLadders_PosL1new[16] = {1056177182, -2147483648, 1063325801,  -996629510,
-                                                                 0,  1065353216,          0,  -975445247,
-                                                       -1084157847, -2147483648, 1056177182,  -981167673,
-                                                                 0,           0,          0,  1065353216};
-const int Ninja_G1CP_053_OldMineLadders_PosL2new[16] = {1054262023, -2147483648, 1063805944,  -996953302,
-                                                                 0,  1065353216,          0,  -975519819,
-                                                       -1083677704, -2147483648, 1054262023,  -981016188,
-                                                                 0,           0,          0,  1065353216};
+const int Ninja_G1CP_053_OldMineLadders_L1PosNew[16] = {
+    1056177182, -2147483648, 1063325801,  -996629510,
+             0,  1065353216,          0,  -975445247,
+   -1084157847, -2147483648, 1056177182,  -981167673,
+             0,           0,          0,  1065353216
+};
+const int Ninja_G1CP_053_OldMineLadders_L2PosNew[16] = {
+    1054262023, -2147483648, 1063805944,  -996953302,
+             0,  1065353216,          0,  -975519819,
+   -1083677704, -2147483648, 1054262023,  -981016188,
+             0,           0,          0,  1065353216
+};
 /* Position of the new plank connecting the ladders to the cliff */
-const float Ninja_G1CP_053_OldMineLadders_PlkPos[16] = {0.419457, 0.000000, 0.907775, -1000.000000,
-                                                        0.000000, 1.000000, 0.000000, -6625.000000,
-                                                       -0.907775, 0.000000, 0.419457, -4300.000000,
-                                                        0.000000, 0.000000, 0.000000,     1.000000};
+const float Ninja_G1CP_053_OldMineLadders_PlkPos[16] = {
+    0.419457, 0.000000, 0.907775, -1000.000000,
+    0.000000, 1.000000, 0.000000, -6625.000000,
+   -0.907775, 0.000000, 0.419457, -4300.000000,
+    0.000000, 0.000000, 0.000000,     1.000000
+};
 
 /*
  * This function applies the changes of #53
@@ -69,7 +79,7 @@ func void Ninja_G1CP_053_OldMineLadders() {
 
         // Check if it is in certain range of the way point
         var int dist; dist = Ninja_G1CP_GetDistToWp(vobPtr, wpPtr);
-        if (dist > castToIntf(300.0)) {
+        if (dist > castToIntf(distToWp)) {
             continue;
         };
 
@@ -89,12 +99,12 @@ func void Ninja_G1CP_053_OldMineLadders() {
         };
 
         // Confirm exact position and update it
-        if (MEM_CompareWords(vobPtr+60, _@(Ninja_G1CP_053_OldMineLadders_PosL1old), 16)) {
+        if (MEM_CompareWords(vobPtr+60, _@(Ninja_G1CP_053_OldMineLadders_L1PosOld), 16)) {
             MEM_RenameVob(vobPtr, name1);
-            MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_PosL1new), vobPtr+60, 16);
-        } else if (MEM_CompareWords(vobPtr+60, _@(Ninja_G1CP_053_OldMineLadders_PosL2old), 16)) {
+            MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_L1PosNew), vobPtr+60, 16);
+        } else if (MEM_CompareWords(vobPtr+60, _@(Ninja_G1CP_053_OldMineLadders_L2PosOld), 16)) {
             MEM_RenameVob(vobPtr, name2);
-            MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_PosL2new), vobPtr+60, 16);
+            MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_L2PosNew), vobPtr+60, 16);
         } else {
             continue;
         };
@@ -174,13 +184,13 @@ func void Ninja_G1CP_053_OldMineLadders_Revert() {
     vobPtr = MEM_SearchVobByName(name1);
     if (vobPtr) {
         MEM_RenameVob(vobPtr, mobName);
-        MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_PosL1old), vobPtr+60, 16);
+        MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_L1PosOld), vobPtr+60, 16);
         ASM_Run(call);
     };
     vobPtr = MEM_SearchVobByName(name2);
     if (vobPtr) {
         MEM_RenameVob(vobPtr, mobName);
-        MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_PosL2old), vobPtr+60, 16);
+        MEM_CopyWords(_@(Ninja_G1CP_053_OldMineLadders_L2PosOld), vobPtr+60, 16);
         ASM_Run(call);
     };
 };

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -12,10 +12,12 @@ func void Ninja_G1CP_HookGameSaveFixes() {
  * Apply all game save sensitive fixes
  */
 func void Ninja_G1CP_GamesaveFixes_Add() {
+    Ninja_G1CP_053_OldMineLadders();
 };
 
 /*
  * Revert all game save sensitive fixes
  */
 func void Ninja_G1CP_GamesaveFixes_Revert() {
+    Ninja_G1CP_053_OldMineLadders_Revert();
 };

--- a/src/Ninja/G1CP/Content/Misc/waypoint.d
+++ b/src/Ninja/G1CP/Content/Misc/waypoint.d
@@ -1,0 +1,47 @@
+/*
+ * Waypoint functions
+ */
+
+func int Ninja_G1CP_GetWaypointByName(var string name) {
+    const int zCWayNet__GetWaypoint = 7366448; //0x706730
+
+    var int waynetPtr; waynetPtr = MEM_World.wayNet;
+    var int wpNamePtr; wpNamePtr = _@s(name);
+
+    const int call = 0;
+    if (Call_Begin(call)) {
+        CALL_PutRetValTo(_@(ret));
+        CALL__fastcall(_@(waynetPtr), _@(wpNamePtr), zCWayNet__GetWaypoint);
+        call = CALL_End();
+    };
+
+    var int ret;
+    return +ret;
+};
+
+
+func int Ninja_G1CP_GetDistToWp(var int vobPtr, var int wpPtr) {
+    if (!vobPtr) || (!wpPtr) {
+        return 0;
+    };
+
+    // Check if vob exists in world
+    var zCVob vob; vob = _^(vobPtr);
+    if (!vob.homeWorld) {
+        return 0;
+    };
+
+    // Obtain position
+    var zCWaypoint wp; wp = _^(wpPtr);
+
+    // Get distances
+    var int dist[3];
+    dist[0] = sqrf(subf(wp.pos[0], vob.trafoObjToWorld[ 3]));
+    dist[1] = sqrf(subf(wp.pos[1], vob.trafoObjToWorld[ 7]));
+    dist[2] = sqrf(subf(wp.pos[2], vob.trafoObjToWorld[11]));
+
+    return sqrtf(addf(addf(dist[0], dist[1]), dist[2]));
+};
+func int Ninja_G1CP_GetDistToWpName(var int vobPtr, var string name) {
+    return Ninja_G1CP_GetDistToWp(vobPtr, Ninja_G1CP_GetWaypointByName(name));
+};

--- a/src/Ninja/G1CP/Content/Tests/test053.d
+++ b/src/Ninja/G1CP/Content/Tests/test053.d
@@ -7,9 +7,13 @@
  */
 func void Ninja_G1CP_Test_053() {
     if (Ninja_G1CP_TestsuiteAllowManual) {
-        const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
-        CALL_zStringPtrParam("OM_185");
-        CALL_zStringPtrParam("OLDMINE.ZEN");
-        CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
+        if (!Hlp_StrCmp(MEM_World.worldFilename, "OLDMINE.ZEN")) {
+            const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
+            CALL_zStringPtrParam("OM_185");
+            CALL_zStringPtrParam("OLDMINE.ZEN");
+            CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
+        } else {
+            AI_Teleport(hero, "OM_185");
+        };
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test053.d
+++ b/src/Ninja/G1CP/Content/Tests/test053.d
@@ -1,0 +1,15 @@
+/*
+ * #53 Ladder in Old Mine too short
+ *
+ * The hero is moved to the old mine and teleported to the bottom of the ladders
+ *
+ * Expected behavior: The ladders are repositioned vertically and a small platform connects them to the cliff
+ */
+func void Ninja_G1CP_Test_053() {
+    if (Ninja_G1CP_TestsuiteAllowManual) {
+        const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
+        CALL_zStringPtrParam("OM_185");
+        CALL_zStringPtrParam("OLDMINE.ZEN");
+        CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -11,6 +11,7 @@ Content\testsuite.d
 Content\Misc\aivar.d
 Content\Misc\info.d
 Content\Misc\Npc_CanSeeVob.d
+Content\Misc\waypoint.d
 
 // Session fixes
 Content\Fixes\Session\fix001_FixNpcSleep.d
@@ -34,6 +35,7 @@ Content\Fixes\Session\fix029_BusterAcrobatics.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
+Content\Fixes\Gamesave\fix053_OldMineLadders.d
 
 // Tests
 Content\Tests\test001.d
@@ -54,6 +56,7 @@ Content\Tests\test025.d
 Content\Tests\test026.d
 Content\Tests\test028.d
 Content\Tests\test029.d
+Content\Tests\test053.d
 Content\Tests\test059.d
 
 // Initialization


### PR DESCRIPTION
### Description
Fixes #53. This change elongates and re-positions the two ladders in the old mine to stop the player from falling down. Since the ladders are changed to be vertical, the gap to the cliff is bridged with a wooden plank in the style of the old mine (same visual).

### Test
Run manual test with `test 53`.

#### Details 
As for any game save sensitive fix, testing will have to be a bit more elaborate:
1. Run the test on a new game
2. Run the test on a loaded game (prior to the fix, or preferably from vanilla Gothic or a mod)
3. Start the game with the fix active
    - Run the test
    - Save the game
    - Unload the fix (or preferably the entire patch, leaving vanilla Gothic or mod)
    - Load the game save
    - Confirm the fix was reverted

It should be briefly visible that the fix is reverted when saving. 