### PR TITLE
#31: Remove Wolf's plate dialog

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix031_WolfPlateDialog.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix031_WolfPlateDialog.d
@@ -1,0 +1,44 @@
+/*
+ * #31 Wolf's minecrawler plate dialog doesn't disappear
+ */
+func int Ninja_G1CP_031_WolfPlateDialog() {
+    if (MEM_FindParserSymbol("Info_Wolf_MCPLATESFEW_Condition")    != -1)
+    && (MEM_FindParserSymbol("Info_Wolf_MCPLATESENOUGH_Condition") != -1)
+    && (MEM_FindParserSymbol("Info_Wolf_MCPLATESENOUGH")           != -1) {
+        HookDaedalusFuncS("Info_Wolf_MCPLATESFEW_Condition", "Ninja_G1CP_031_WolfPlateDialog_Hook1");
+        HookDaedalusFuncS("Info_Wolf_MCPLATESENOUGH_Condition", "Ninja_G1CP_031_WolfPlateDialog_Hook2");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int Ninja_G1CP_031_WolfPlateDialog_Hook1() {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Add the new condition (other conditions remain untouched)
+    if (Npc_KnowsInfo(hero, MEM_FindParserSymbol("Info_Wolf_MCPLATESENOUGH"))) {
+        return FALSE;
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};
+
+/*
+ * Exact copy of the function above. Need unique functions for both because of the way Daedalus hooks work
+ */
+func int Ninja_G1CP_031_WolfPlateDialog_Hook2() {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Add the new condition (other conditions remain untouched)
+    if (Npc_KnowsInfo(hero, MEM_FindParserSymbol("Info_Wolf_MCPLATESENOUGH"))) {
+        return FALSE;
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -33,6 +33,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_026_LaresGuardAttacks();                             // #26
         Ninja_G1CP_028_MordragNoEscort();                               // #28
         Ninja_G1CP_029_BusterAcrobatics();                              // #29
+        Ninja_G1CP_031_WolfPlateDialog();                               // #31
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
         Ninja_G1CP_InitEnd();
     };

--- a/src/Ninja/G1CP/Content/Tests/test031.d
+++ b/src/Ninja/G1CP/Content/Tests/test031.d
@@ -1,0 +1,105 @@
+/*
+ * #31 Wolf's minecrawler plate dialog doesn't disappear
+ *
+ * A required dialog is set to 'told' and the condition functions of both dialogs are called.
+ *
+ * Expected behavior: The condition functions will return FALSE.
+ */
+func int Ninja_G1CP_Test_031_RunDialog(var C_Npc wolf, var int itmInst, var int num, var string dialogName) {
+    // Check if dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol(dialogName);
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail(ConcatStrings("Original dialog not found: ", dialogName));
+        return FALSE;
+    };
+
+    // Backup values
+    var int toldBak; toldBak = Npc_KnowsInfo(hero, MEM_FindParserSymbol("Info_Wolf_MCPLATESENOUGH")); // Told status
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);                                                     // Self
+    var C_Npc othBak; othBak = MEM_CpyInst(other);                                                    // Other
+
+    // Set new values
+    Ninja_G1CP_SetInfoTold("Info_Wolf_MCPLATESENOUGH", TRUE);                                         // Told status
+    CreateInvItems(hero, itmInst, num);                                                               // Create items
+    self  = MEM_CpyInst(wolf);                                                                        // Self
+    other = MEM_CpyInst(hero);                                                                        // Other
+
+    // Call dialog condition function
+    MEM_CallByID(funcId);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore values
+    self  = MEM_CpyInst(slfBak);                                                                      // Self
+    other = MEM_CpyInst(othBak);                                                                      // Other
+    Npc_RemoveInvItems(hero, itmInst, Npc_HasItems(hero, itmInst));                                   // Remove items
+    Ninja_G1CP_SetInfoTold("Info_Wolf_MCPLATESENOUGH", toldBak);                                      // Told status
+
+    // Check return value
+    if (ret) {
+        Ninja_G1CP_TestsuiteErrorDetail(ConcatStrings("Dialog condition failed: ", dialogName));
+        return FALSE;
+    };
+
+    return TRUE;
+};
+func int Ninja_G1CP_Test_031() {
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Find Wolf
+    var int symbId; symbId = MEM_FindParserSymbol("ORG_855_Wolf");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Npc 'ORG_855_Wolf' not found");
+        passed = FALSE;
+    };
+
+    // Check if Wolf exists in the world
+    var C_Npc wolf; wolf = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(wolf)) {
+        Ninja_G1CP_TestsuiteErrorDetail("Npc 'ORG_855_Wolf' is not a valid NPC");
+        passed = FALSE;
+    };
+
+    // Find item
+    var int itmInst; itmInst = MEM_FindParserSymbol("ItAt_Crawler_02");
+    if (itmInst == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItAt_Crawler_02' not found");
+        passed = FALSE;
+    };
+
+    // Check if variable exists
+    var int knowsPlatesPtr; knowsPlatesPtr = MEM_GetSymbol("Knows_GetMCPlates");
+    if (!knowsPlatesPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'Knows_GetMCPlates' not found");
+        passed = FALSE;
+    };
+    knowsPlatesPtr += zCParSymbol_content_offset;
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Backup common values
+    var int knowsPlatesBak; knowsPlatesBak = MEM_ReadInt(knowsPlatesPtr);
+    var int itmNumBak; itmNumBak = Npc_HasItems(hero, itmInst);
+
+    // Set new values
+    MEM_WriteInt(knowsPlatesPtr, TRUE);
+    if (itmNumBak > 0) {
+        Npc_RemoveInvItems(hero, itmInst, itmNumBak);
+    };
+
+    // Run dialogs
+    var int ret; ret = 0;
+    ret += Ninja_G1CP_Test_031_RunDialog(wolf, itmInst, 1,  "Info_Wolf_MCPLATESFEW_Condition");
+    ret += Ninja_G1CP_Test_031_RunDialog(wolf, itmInst, 15, "Info_Wolf_MCPLATESENOUGH_Condition");
+
+    // Restore values
+    MEM_WriteInt(knowsPlatesPtr, knowsPlatesBak);
+    if (itmNumBak > 0) {
+        CreateInvItems(hero, itmInst, itmNumBak);
+    };
+
+    return (ret == 2);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -37,6 +37,7 @@ Content\Fixes\Session\fix025_SaturasSellsRobe.d
 Content\Fixes\Session\fix026_LaresGuardAttacks.d
 Content\Fixes\Session\fix028_MordragNoEscort.d
 Content\Fixes\Session\fix029_BusterAcrobatics.d
+Content\Fixes\Session\fix031_WolfPlateDialog.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
@@ -61,6 +62,7 @@ Content\Tests\test025.d
 Content\Tests\test026.d
 Content\Tests\test028.d
 Content\Tests\test029.d
+Content\Tests\test031.d
 Content\Tests\test050.d
 Content\Tests\test059.d
 


### PR DESCRIPTION
### Description
Fixes #31. Wolf's dialog options regarding the mine crawler plates should disappear once the respective dialog was told.

### Test
Run automatic test with `test 31`.
