### PR TITLE
#36: Enable Fisk's fence quest

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,5 +44,6 @@
 * Fix #28: Mordrag bringt den Spieler nicht mehr zum Neuen Lager, wenn dieser ihn vorher verprügelt und aus dem Alten Lager vertireben hat.
 * Fix #29: Buster bringt dem Spieler nicht mehr Akrobatik bei, wenn dieser das Talent bereits gelernt hat.
 * Fix #31: Wolf können keine Minecrawlerpanzerplatten mehr angeboten werden, wenn der Spieler ihm schon die erforderliche Anzahl gebracht hat.
+* Fix #36: Fisks Quest "Neuer Hehler für Fisk" is nun immer erhältlich, egal, wie Thorus' Quest "Auftrag von Thorus" (erfolgreich) beendet wurde.  
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.
 * Fix #59: Händler rüsten nicht mehr ihre Waffe um, wenn der Spieler ihnen eine stärkere verkauft. Aufgrund einer wichtigen Spielmechanik wird allerdings eine Waffe ausgerüstet, sofern der Händler vorher noch keine Waffe diese Art (Nahkampf, Fernkampf) ausgerüstet hatte.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 * Fix #28: Mordrag no longer escorts the player to the New Camp if the player forcibly threw him out of the Old Camp.
 * Fix #29: Buster no longer teaches Acrobatics if the player already gained the skill.
 * Fix #31: Wolf can't be offered Minecrawler's Armor Plates any longer if the player already gave him the requested amount.
+* Fix #36: Fisk's quest "New Fence for Fisk" is now available regardless of how the quest "Thorus' Quest" is (successfully) completed.
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #59: Vendors don't re-equip their weapon when the player sells them a more powerful one. However, due to important game mechanics, they will still equip a weapon if they didn't have a weapon of that type (meelee, ranged) equipped before.
 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix036_FiskFenceQuest.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix036_FiskFenceQuest.d
@@ -1,0 +1,68 @@
+/*
+ * #36 Fisk's quest isn't triggered
+ */
+func int Ninja_G1CP_036_FiskFenceQuest() {
+    if (MEM_FindParserSymbol("Stt_311_Fisk_MordragKO_Condition") != -1)
+    && (MEM_FindParserSymbol("Org_826_Mordrag") != -1)
+    && (MEM_FindParserSymbol("MordragKO_HauAb") != -1)
+    && (MEM_FindParserSymbol("MordragKO_StayAtNC") != -1) {
+        HookDaedalusFuncS("Stt_311_Fisk_MordragKO_Condition", "Ninja_G1CP_036_FiskFenceQuest_Hook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int Ninja_G1CP_036_FiskFenceQuest_Hook() {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Fixing this dialog is a bit more challenging than the other ones, because the new condition should yield the
+    // truth value of the condition to be true (not false like the other fixes usually) depending on other - possibly
+    // unknown - conditions within the function.
+    // So, one of the variables that is going to be checked will be temporarily set to true to make this happen.
+
+    // Check if the variable exists
+    var int hauAbBak;
+    var int hauAbPtr; hauAbPtr = MEM_GetSymbol("MordragKO_HauAb");
+    if (hauAbPtr) {
+        hauAbPtr += zCParSymbol_content_offset;
+        hauAbBak = MEM_ReadInt(hauAbPtr);
+    };
+
+    // If the variable exists but is false, overwrite it with our new truth value to implement an OR condition
+    if (hauAbPtr) && (!hauAbBak) {
+
+        // Check for variable
+        var int stayAtNC; stayAtNC = MEM_GetSymbol("MordragKO_StayAtNC");
+        if (stayAtNC) {
+            stayAtNC = MEM_ReadInt(stayAtNC + zCParSymbol_content_offset);
+        };
+
+        // Check for Mordrag
+        var C_Npc mordrag; mordrag = Hlp_GetNpc(MEM_FindParserSymbol("Org_826_Mordrag"));
+        var int mordragDead; mordragDead = Npc_IsDead(mordrag);
+
+        // The condition should now look like this:
+        // if (otherConditions) && ((hauAb) || (mordragDead) || (stayAtNC)) {
+        //     return TRUE;
+        // };
+
+        // Add as OR (since hauAbBak is False we could just omit it)
+        MEM_WriteInt(hauAbPtr, (hauAbBak) || (mordragDead) || (stayAtNC));
+    };
+
+    // Call the function as usual, with the possibly modified variable
+    ContinueCall();
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore the variable we abused
+    if (hauAbPtr) {
+        MEM_WriteInt(hauAbPtr, hauAbBak);
+    };
+
+    // Pass on the return value
+    return ret;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -27,6 +27,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_028_MordragNoEscort();                               // #28
         Ninja_G1CP_029_BusterAcrobatics();                              // #29
         Ninja_G1CP_031_WolfPlateDialog();                               // #31
+        Ninja_G1CP_036_FiskFenceQuest();                                // #36
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
         Ninja_G1CP_InitEnd();
     };

--- a/src/Ninja/G1CP/Content/Tests/test036.d
+++ b/src/Ninja/G1CP/Content/Tests/test036.d
@@ -1,0 +1,122 @@
+/*
+ * #36 Fisk's quest isn't triggered
+ *
+ * The hero is given the correct guild and the condition function of the dialog is called.
+ *
+ * Expected behavior: The condition function will return TRUE.
+ */
+func int Ninja_G1CP_Test_036() {
+    // Define possibly missing symbols locally
+    const int GIL_NONE          = 0;
+    const int ATR_HITPOINTS     = 0;
+    const int ATR_HITPOINTS_MAX = 1;
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if the dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("Stt_311_Fisk_MordragKO_Condition");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog 'Stt_311_Fisk_MordragKO_Condition' not found");
+        passed = FALSE;
+    };
+
+    // Find Fisk
+    var int symbId; symbId = MEM_FindParserSymbol("Stt_311_Fisk");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Npc 'Stt_311_Fisk' not found");
+        passed = FALSE;
+    };
+
+    // Check if Fisk exists in the world
+    var C_Npc fisk; fisk = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(fisk)) {
+        Ninja_G1CP_TestsuiteErrorDetail("Npc 'Stt_311_Fisk' is not a valid NPC");
+        passed = FALSE;
+    };
+
+    // Find Mordrag
+    symbId = MEM_FindParserSymbol("Org_826_Mordrag");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Npc 'Org_826_Mordrag' not found");
+        passed = FALSE;
+    };
+
+    // Check if Mordrag exists in the world
+    var C_Npc mordrag; mordrag = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(mordrag)) {
+        Ninja_G1CP_TestsuiteErrorDetail("Npc 'Org_826_Mordrag' is not a valid NPC");
+        passed = FALSE;
+    };
+
+    // Check if variable exists
+    var int hauAbPtr; hauAbPtr = MEM_GetSymbol("MordragKO_HauAb");
+    if (!hauAbPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'MordragKO_HauAb' not found");
+        passed = FALSE;
+    };
+    hauAbPtr += zCParSymbol_content_offset;
+
+    // Check if variable exists
+    var int stayAtNcPtr; stayAtNcPtr = MEM_GetSymbol("MordragKO_StayAtNC");
+    if (!stayAtNcPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Symbol 'MordragKO_StayAtNC' not found");
+        passed = FALSE;
+    };
+    stayAtNcPtr += zCParSymbol_content_offset;
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Backup values
+    var int hauAbBak; hauAbBak = MEM_ReadInt(hauAbPtr);          // Variable
+    var int stayAtNCBak; stayAtNCBak = MEM_ReadInt(stayAtNcPtr); // Variable
+    var int guildBak; guildBak = Npc_GetTrueGuild(hero);         // Guild
+    var int hpBak; hpBak = mordrag.attribute[ATR_HITPOINTS];     // Mordrag's HP
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);                // Self
+    var C_Npc othBak; othBak = MEM_CpyInst(other);               // Other
+
+    // Set new values
+    MEM_WriteInt(hauAbPtr, FALSE);                               // Variable
+    Npc_SetTrueGuild(hero, GIL_NONE);                            // Guild
+    self  = MEM_CpyInst(fisk);                                   // Self
+    other = MEM_CpyInst(hero);                                   // Other
+
+    // Now do two passes for each OR-condition
+    var int ret; ret = 0;
+
+    // First pass: Mordrag is dead but MordragKO_StayAtNC if false
+    mordrag.attribute[ATR_HITPOINTS] = 0;
+    MEM_WriteInt(stayAtNcPtr, FALSE);
+
+    // Call dialog condition function
+    MEM_CallByID(funcId);
+    ret += MEM_PopIntResult();
+    if (!ret) {
+        Ninja_G1CP_TestsuiteErrorDetail("Condition 'Mordrag is dead' failed");
+    };
+
+    // Second pass: MordragKO_StayAtNC is true but Mordrag is alive
+    mordrag.attribute[ATR_HITPOINTS] = mordrag.attribute[ATR_HITPOINTS_MAX];
+    MEM_WriteInt(stayAtNcPtr, TRUE);
+
+    // Call dialog condition function
+    MEM_CallByID(funcId);
+    ret += MEM_PopIntResult();
+    if (!ret) {
+        Ninja_G1CP_TestsuiteErrorDetail("Condition 'stay at NC' failed");
+    };
+
+    // Restore values
+    self  = MEM_CpyInst(slfBak);                                 // Self
+    other = MEM_CpyInst(othBak);                                 // Other
+    mordrag.attribute[ATR_HITPOINTS] = hpBak;                    // Mordrag's HP
+    Npc_SetTrueGuild(hero, guildBak);                            // Guild
+    MEM_WriteInt(stayAtNcPtr, stayAtNCBak);                      // Variable
+    MEM_WriteInt(hauAbPtr, hauAbBak);                            // Variable
+
+    // Check return value
+    return (ret == 2);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -41,6 +41,7 @@ Content\Fixes\Session\fix026_LaresGuardAttacks.d
 Content\Fixes\Session\fix028_MordragNoEscort.d
 Content\Fixes\Session\fix029_BusterAcrobatics.d
 Content\Fixes\Session\fix031_WolfPlateDialog.d
+Content\Fixes\Session\fix036_FiskFenceQuest.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
@@ -66,6 +67,7 @@ Content\Tests\test026.d
 Content\Tests\test028.d
 Content\Tests\test029.d
 Content\Tests\test031.d
+Content\Tests\test036.d
 Content\Tests\test050.d
 Content\Tests\test059.d
 


### PR DESCRIPTION
### Description
Fixes #36. The dialog is now available for two extra conditions
1. Mordrag is dead.
2. Mordrag stays at the new camp.

### Test
Run automatic test with `test 36`. The test executes the dialog condition function twice for both conditions mentioned above.
