### PR TITLE
#38: Snaf now correctly offers the Nek dialog 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,5 +44,6 @@
 * Fix #28: Mordrag bringt den Spieler nicht mehr zum Neuen Lager, wenn dieser ihn vorher verprügelt und aus dem Alten Lager vertireben hat.
 * Fix #29: Buster bringt dem Spieler nicht mehr Akrobatik bei, wenn dieser das Talent bereits gelernt hat.
 * Fix #31: Wolf können keine Minecrawlerpanzerplatten mehr angeboten werden, wenn der Spieler ihm schon die erforderliche Anzahl gebracht hat.
+* Fix #38: Snaf spricht nun auch über Nek, wenn die Quest "Snafs Rezept" abgeschlossen wurde. 
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.
 * Fix #59: Händler rüsten nicht mehr ihre Waffe um, wenn der Spieler ihnen eine stärkere verkauft. Aufgrund einer wichtigen Spielmechanik wird allerdings eine Waffe ausgerüstet, sofern der Händler vorher noch keine Waffe diese Art (Nahkampf, Fernkampf) ausgerüstet hatte.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 * Fix #28: Mordrag no longer escorts the player to the New Camp if the player forcibly threw him out of the Old Camp.
 * Fix #29: Buster no longer teaches Acrobatics if the player already gained the skill.
 * Fix #31: Wolf can't be offered Minecrawler's Armor Plates any longer if the player already gave him the requested amount.
+* Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #59: Vendors don't re-equip their weapon when the player sells them a more powerful one. However, due to important game mechanics, they will still equip a weapon if they didn't have a weapon of that type (meelee, ranged) equipped before.
 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix038_SnafDialogNek.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix038_SnafDialogNek.d
@@ -1,0 +1,48 @@
+/*
+ * #38 Snaf's Nek dialog disappears
+ */
+func int Ninja_G1CP_038_SnafDialogNek() {
+    if (MEM_FindParserSymbol("DIA_Snaf_WhereNek_Condition") != -1)
+    && (MEM_FindParserSymbol("Snaf_Zutaten") != -1) {
+        HookDaedalusFuncS("DIA_Snaf_WhereNek_Condition", "Ninja_G1CP_038_SnafDialogNek_Hook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int Ninja_G1CP_038_SnafDialogNek_Hook() {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Define possibly missing symbols locally
+    const int LOG_RUNNING = 1;
+    const int LOG_SUCCESS = 2;
+
+    // Check if the variable exists
+    var int questBak;
+    var int questPtr; questPtr = MEM_GetSymbol("Snaf_Zutaten");
+    if (questPtr) {
+        questPtr += zCParSymbol_content_offset;
+        questBak = MEM_ReadInt(questPtr);
+
+        // If the quest is successful, set it temporarily to 'running' to trigger the condition function
+        if (questBak == LOG_SUCCESS) {
+            MEM_WriteInt(questPtr, LOG_RUNNING);
+        };
+    };
+
+    // Call the function as usual, with the possibly modified variable
+    ContinueCall();
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore the variable we abused
+    if (questPtr) {
+        MEM_WriteInt(questPtr, questBak);
+    };
+
+    // Pass on the return value
+    return ret;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -27,6 +27,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_028_MordragNoEscort();                               // #28
         Ninja_G1CP_029_BusterAcrobatics();                              // #29
         Ninja_G1CP_031_WolfPlateDialog();                               // #31
+        Ninja_G1CP_038_SnafDialogNek();                                 // #38
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
         Ninja_G1CP_InitEnd();
     };

--- a/src/Ninja/G1CP/Content/Tests/test038.d
+++ b/src/Ninja/G1CP/Content/Tests/test038.d
@@ -1,0 +1,75 @@
+/*
+ * #38 Snaf's Nek dialog disappears
+ *
+ * The quest "Snaf's Recipe" is set to successful and the condition function of the dialog is called.
+ *
+ * Expected behavior: The condition function will return TRUE.
+ */
+func int Ninja_G1CP_Test_038() {
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Define possibly missing symbols locally
+    const int LOG_SUCCESS = 2;
+
+    // Check if the dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("DIA_Snaf_WhereNek_Condition");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'DIA_Snaf_WhereNek_Condition' not found");
+        passed = FALSE;
+    };
+
+    // Find Snaf
+    var int symbId; symbId = MEM_FindParserSymbol("VLK_581_Snaf");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Npc 'VLK_581_Snaf' not found");
+        passed = FALSE;
+    };
+
+    // Check if Snaf exists in the world
+    var C_Npc snaf; snaf = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(snaf)) {
+        Ninja_G1CP_TestsuiteErrorDetail("Npc 'VLK_581_Snaf' is not a valid NPC");
+        passed = FALSE;
+    };
+
+    // Check if variable exists
+    var int questPtr; questPtr = MEM_GetSymbol("Snaf_Zutaten");
+    if (!questPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'Snaf_Zutaten' not found");
+        passed = FALSE;
+    };
+    questPtr += zCParSymbol_content_offset;
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Backup values
+    var int questBak; questBak = MEM_ReadInt(questPtr); // Variable
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);       // Self
+    var C_Npc othBak; othBak = MEM_CpyInst(other);      // Other
+
+    // Set new values
+    MEM_WriteInt(questPtr, LOG_SUCCESS);                // Variable
+    self  = MEM_CpyInst(snaf);                          // Self
+    other = MEM_CpyInst(hero);                          // Other
+
+    // Call dialog condition function
+    MEM_CallByID(funcId);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore values
+    self  = MEM_CpyInst(slfBak);                        // Self
+    other = MEM_CpyInst(othBak);                        // Other
+    MEM_WriteInt(questPtr, questBak);                   // Variable
+
+    // Check return value
+    if (ret) {
+        return TRUE;
+    } else {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog condition failed");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -41,6 +41,7 @@ Content\Fixes\Session\fix026_LaresGuardAttacks.d
 Content\Fixes\Session\fix028_MordragNoEscort.d
 Content\Fixes\Session\fix029_BusterAcrobatics.d
 Content\Fixes\Session\fix031_WolfPlateDialog.d
+Content\Fixes\Session\fix038_SnafDialogNek.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
@@ -66,6 +67,7 @@ Content\Tests\test026.d
 Content\Tests\test028.d
 Content\Tests\test029.d
 Content\Tests\test031.d
+Content\Tests\test038.d
 Content\Tests\test050.d
 Content\Tests\test059.d
 


### PR DESCRIPTION
### Description
Fixes #38. The Nek dialog is now properly available even if the recipe quest is closed.

### Test
Run automatic test with `test 38`.

Here too, the German translation of the changelog is still missing. @AmProsius can you complete that?
