### PR TITLE
#40: Aleph does not offer the keys again

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 * Fix #28: Mordrag no longer escorts the player to the New Camp if the player forcibly threw him out of the Old Camp.
 * Fix #29: Buster no longer teaches Acrobatics if the player already gained the skill.
 * Fix #31: Wolf can't be offered Minecrawler's Armor Plates any longer if the player already gave him the requested amount.
+* Fix #40: Aleph doesn't offer to sell the key anymore when the player already obtained it.
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #59: Vendors don't re-equip their weapon when the player sells them a more powerful one. However, due to important game mechanics, they will still equip a weapon if they didn't have a weapon of that type (meelee, ranged) equipped before.
 
@@ -43,5 +44,6 @@
 * Fix #28: Mordrag bringt den Spieler nicht mehr zum Neuen Lager, wenn dieser ihn vorher verprügelt und aus dem Alten Lager vertireben hat.
 * Fix #29: Buster bringt dem Spieler nicht mehr Akrobatik bei, wenn dieser das Talent bereits gelernt hat.
 * Fix #31: Wolf können keine Minecrawlerpanzerplatten mehr angeboten werden, wenn der Spieler ihm schon die erforderliche Anzahl gebracht hat.
+* Fix #40: Aleph bietet den Schlüssel nun nicht noch einmal an, wenn der Spieler ihn schon erhalten hat.
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.
 * Fix #59: Händler rüsten nicht mehr ihre Waffe um, wenn der Spieler ihnen eine stärkere verkauft. Aufgrund einer wichtigen Spielmechanik wird allerdings eine Waffe ausgerüstet, sofern der Händler vorher noch keine Waffe diese Art (Nahkampf, Fernkampf) ausgerüstet hatte.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix040_AlephKeyDialog.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix040_AlephKeyDialog.d
@@ -1,0 +1,27 @@
+/*
+ * #40 Aleph's key dialog doesn't disappear
+ */
+func int Ninja_G1CP_040_AlephKeyDialog() {
+    if (MEM_FindParserSymbol("VLK_585_Aleph_DIRTY_Condition") != -1)
+    && (MEM_FindParserSymbol("VLK_585_Aleph_SCHUPPEN") != -1) {
+        HookDaedalusFuncS("VLK_585_Aleph_DIRTY_Condition", "Ninja_G1CP_040_AlephKeyDialog_Hook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int Ninja_G1CP_040_AlephKeyDialog_Hook() {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Add the new condition (other conditions remain untouched)
+    if (Npc_KnowsInfo(hero, MEM_FindParserSymbol("VLK_585_Aleph_SCHUPPEN"))) {
+        return FALSE;
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -27,6 +27,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_028_MordragNoEscort();                               // #28
         Ninja_G1CP_029_BusterAcrobatics();                              // #29
         Ninja_G1CP_031_WolfPlateDialog();                               // #31
+        Ninja_G1CP_040_AlephKeyDialog();                                // #40
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
         Ninja_G1CP_InitEnd();
     };

--- a/src/Ninja/G1CP/Content/Tests/test040.d
+++ b/src/Ninja/G1CP/Content/Tests/test040.d
@@ -1,0 +1,48 @@
+/*
+ * #40 Aleph's key dialog doesn't disappear
+ *
+ * The necessary dialogs including the one from the new condition are set to told and the dialog function is called.
+ *
+ * Expected behavior: The condition function will return FALSE.
+ */
+func int Ninja_G1CP_Test_040() {
+    // Check if the dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("VLK_585_Aleph_DIRTY_Condition");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'VLK_585_Aleph_DIRTY_Condition' not found");
+        return FALSE;
+    };
+
+    // Backup values
+    var int told1Bak; told1Bak = Npc_KnowsInfo(hero, MEM_FindParserSymbol("GRD_271_ULBERT_DRUNK"));   // Told status
+    var int told2Bak; told2Bak = Npc_KnowsInfo(hero, MEM_FindParserSymbol("GRD_261_Brandick_ALEPH")); // Told status
+    var int told3Bak; told3Bak = Npc_KnowsInfo(hero, MEM_FindParserSymbol("VLK_585_Aleph_SCHUPPEN")); // Told status
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);                                                     // Self
+    var C_Npc othBak; othBak = MEM_CpyInst(other);                                                    // Other
+
+    // Set new values
+    Ninja_G1CP_SetInfoTold("GRD_271_ULBERT_DRUNK", TRUE);                                             // Told status
+    Ninja_G1CP_SetInfoTold("GRD_261_Brandick_ALEPH", TRUE);                                           // Told status
+    Ninja_G1CP_SetInfoTold("VLK_585_Aleph_SCHUPPEN", TRUE);                                           // Told status
+    self  = MEM_NullToInst();                                                                         // Self
+    other = MEM_CpyInst(hero);                                                                        // Other
+
+    // Call dialog condition function
+    MEM_CallByID(funcId);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore values
+    self  = MEM_CpyInst(slfBak);                                                                      // Self
+    other = MEM_CpyInst(othBak);                                                                      // Other
+    Ninja_G1CP_SetInfoTold("GRD_271_ULBERT_DRUNK", told1Bak);                                         // Told status
+    Ninja_G1CP_SetInfoTold("GRD_261_Brandick_ALEPH", told2Bak);                                       // Told status
+    Ninja_G1CP_SetInfoTold("VLK_585_Aleph_SCHUPPEN", told3Bak);                                       // Told status
+
+    // Check return value
+    if (ret) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog condition failed");
+        return FALSE;
+    } else {
+        return TRUE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -41,6 +41,7 @@ Content\Fixes\Session\fix026_LaresGuardAttacks.d
 Content\Fixes\Session\fix028_MordragNoEscort.d
 Content\Fixes\Session\fix029_BusterAcrobatics.d
 Content\Fixes\Session\fix031_WolfPlateDialog.d
+Content\Fixes\Session\fix040_AlephKeyDialog.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
@@ -66,6 +67,7 @@ Content\Tests\test026.d
 Content\Tests\test028.d
 Content\Tests\test029.d
 Content\Tests\test031.d
+Content\Tests\test040.d
 Content\Tests\test050.d
 Content\Tests\test059.d
 


### PR DESCRIPTION
### Description
Fixes #40. The dialog option (after snitching on Aleph) now disappears,

### Test
Run automatic test with `test 40`.
