### PR TITLE
#43: Fix whitespace of learning print (EN)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@
 * Fix #31: Wolf can't be offered Minecrawler's Armor Plates any longer if the player already gave him the requested amount.
 * Fix #36: Fisk's quest "New Fence for Fisk" is now available regardless of how the quest "Thorus' Quest" is (successfully) completed.
 * Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
+* Fix #43: The screen information about skill learning now contains proper whitespace.
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #59: Vendors don't re-equip their weapon when the player sells them a more powerful one. However, due to important game mechanics, they will still equip a weapon if they didn't have a weapon of that type (meelee, ranged) equipped before.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,7 +22,7 @@
 * Fix #31: Wolf can't be offered Minecrawler's Armor Plates any longer if the player already gave him the requested amount.
 * Fix #36: Fisk's quest "New Fence for Fisk" is now available regardless of how the quest "Thorus' Quest" is (successfully) completed.
 * Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
-* Fix #43: The screen information about skill learning now contains proper whitespace.
+* Fix #43: The dialog choices about learning skills now contain proper whitespace.
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #59: Vendors don't re-equip their weapon when the player sells them a more powerful one. However, due to important game mechanics, they will still equip a weapon if they didn't have a weapon of that type (meelee, ranged) equipped before.
 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix043_EN_SkillMissingWhitespace.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix043_EN_SkillMissingWhitespace.d
@@ -1,0 +1,25 @@
+/*
+ * #43 Missing whitespace for skill point(s)
+ */
+func int Ninja_G1CP_043_EN_SkillMissingWhitespace() {
+    var int symb1Ptr; symb1Ptr = MEM_GetSymbol("NAME_LearnPostfixS");
+    var int symb2Ptr; symb2Ptr = MEM_GetSymbol("NAME_LearnPostfixP");
+
+    if (symb1Ptr) && (symb2Ptr) {
+        symb1Ptr = MEM_ReadInt(symb1Ptr + zCParSymbol_content_offset);
+        symb2Ptr = MEM_ReadInt(symb2Ptr + zCParSymbol_content_offset);
+
+        // Check if the strings are as expected
+        if (Hlp_StrCmp(MEM_ReadString(symb1Ptr), "skill point)"))
+        && (Hlp_StrCmp(MEM_ReadString(symb2Ptr), "skill points)")) {
+
+            // Only then, fix them
+            MEM_WriteString(symb1Ptr, " skill point)");
+            MEM_WriteString(symb2Ptr, " skill points)");
+
+            return TRUE;
+        };
+    };
+
+    return FALSE;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -29,6 +29,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_031_WolfPlateDialog();                               // #31
         Ninja_G1CP_036_FiskFenceQuest();                                // #36
         Ninja_G1CP_038_SnafDialogNek();                                 // #38
+        Ninja_G1CP_043_EN_SkillMissingWhitespace();                     // #43
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
         Ninja_G1CP_InitEnd();
     };

--- a/src/Ninja/G1CP/Content/Tests/test043.d
+++ b/src/Ninja/G1CP/Content/Tests/test043.d
@@ -3,7 +3,7 @@
  *
  * The skill learn print function is called.
  *
- * Expected behavior: The whitespace will be correctly printed to the screen.
+ * Expected behavior: The whitespace will be correctly added to the string.
  */
 func int Ninja_G1CP_Test_043() {
     // Check language first
@@ -15,7 +15,7 @@ func int Ninja_G1CP_Test_043() {
     // Check if function exists
     var int funcId; funcId = MEM_FindParserSymbol("B_BuildLearnString");
     if (funcId == 1) {
-        Ninja_G1CP_TestsuiteErrorDetail("Skill learn print function not found");
+        Ninja_G1CP_TestsuiteErrorDetail("Skill learn string function not found");
         return FALSE;
     };
 

--- a/src/Ninja/G1CP/Content/Tests/test043.d
+++ b/src/Ninja/G1CP/Content/Tests/test043.d
@@ -1,0 +1,36 @@
+/*
+ * #43 Missing whitespace for skill point(s)
+ *
+ * The skill learn print function is called.
+ *
+ * Expected behavior: The whitespace will be correctly printed to the screen.
+ */
+func int Ninja_G1CP_Test_043() {
+    // Check language first
+    if (Ninja_G1CP_Lang != 0) {
+        Ninja_G1CP_TestsuiteErrorDetail("Test only applicable for the English localization");
+        return TRUE; // True?
+    };
+
+    // Check if function exists
+    var int funcId; funcId = MEM_FindParserSymbol("B_BuildLearnString");
+    if (funcId == 1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Skill learn print function not found");
+        return FALSE;
+    };
+
+    // Call the function
+    MEM_PushStringParam("Test 43"); // text
+    MEM_PushIntParam(20);           // lp
+    MEM_PushIntParam(10);           // ore
+    MEM_CallByID(funcId);
+    var string output; output = MEM_PopStringResult();
+
+    // Test the output
+    if (Hlp_StrCmp(output, "Test 43 (10 ore, 20 skill points)")) {
+        return TRUE;
+    } else {
+        Ninja_G1CP_TestsuiteErrorDetail(ConcatStrings("Output incorrect: ", output));
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -43,6 +43,7 @@ Content\Fixes\Session\fix029_BusterAcrobatics.d
 Content\Fixes\Session\fix031_WolfPlateDialog.d
 Content\Fixes\Session\fix036_FiskFenceQuest.d
 Content\Fixes\Session\fix038_SnafDialogNek.d
+Content\Fixes\Session\fix043_EN_SkillMissingWhitespace.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 
 // Game save fixes
@@ -70,6 +71,7 @@ Content\Tests\test029.d
 Content\Tests\test031.d
 Content\Tests\test036.d
 Content\Tests\test038.d
+Content\Tests\test043.d
 Content\Tests\test050.d
 Content\Tests\test059.d
 


### PR DESCRIPTION
### Description
Fixes #43. The screen information about learning skills now contains proper whitespace. This fix is for English localization only and should be tested for English (unfixed), English (fixed) and for another localization, where the fix does not apply.

### Test
Run automatic test with `test 43`. The test will throw an error if the localization is not English, but will pass.

### Additional Info
I only added the fix to the English section of the changelog.md.
