### PR TITLE
#60: Fix Jesse's quest

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@
 * Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #59: Vendors don't re-equip their weapon when the player sells them a more powerful one. However, due to important game mechanics, they will still equip a weapon if they didn't have a weapon of that type (meelee, ranged) equipped before.
+* Fix #60: Jesse's quest is now available.
 
 ## DE
 * Fix #1: NSCs wachen nicht mehr sofort auf, nachdem sie ins Bett gegangen sind, sondern bleiben liegen.
@@ -49,3 +50,4 @@
 * Fix #38: Snaf spricht nun auch über Nek, wenn die Quest "Snafs Rezept" abgeschlossen wurde. 
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.
 * Fix #59: Händler rüsten nicht mehr ihre Waffe um, wenn der Spieler ihnen eine stärkere verkauft. Aufgrund einer wichtigen Spielmechanik wird allerdings eine Waffe ausgerüstet, sofern der Händler vorher noch keine Waffe diese Art (Nahkampf, Fernkampf) ausgerüstet hatte.
+* Fix #60: Jesse's Quest ist nun verfügbar.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix060_JesseQuest.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix060_JesseQuest.d
@@ -1,0 +1,54 @@
+/*
+ * #60 Jesse's quest not available
+ */
+func int Ninja_G1CP_060_JesseQuest() {
+    var int applied; applied = FALSE;
+
+    // Find all necessary symbols
+    var int funcId; funcId = MEM_FindParserSymbol("DIA_Jesse_Mission_Condition");
+    var int cond1Id; cond1Id = MEM_FindParserSymbol("DIA_Jesse_Mission");
+    var int cond2Id; cond2Id = MEM_FindParserSymbol("DIA_Jesse_Warn");
+    var int funcExt; funcExt = MEM_FindParserSymbol("Npc_KnowsInfo");
+
+    // Check if all needed functions exist
+    if (funcId != -1) && (cond1Id != -1) && (cond2Id != -1) {
+
+        // Get the byte code of the dialog condition function
+        var int tokens; tokens = MEM_ArrayCreate();
+        var int params; params = MEM_ArrayCreate();
+        var int positions; positions = MEM_ArrayCreate();
+        MEMINT_TokenizeFunction(funcID, tokens, params, positions);
+        var int len; len = MEM_ArraySize(tokens);
+
+        // Iterate over the tokens
+        repeat(i, len); var int i;
+
+            // Find "DIA_Jesse_Mission"
+            if (MEM_ArrayRead(params, i) == cond1Id)
+            && (i+2 < len) { // Prevent error below
+
+                // Verify the context: Npc_KnowsInfo(xxxx, "DIA_Jesse_Mission") without ! in front
+                if (MEM_ArrayRead(tokens, i)   == zPAR_TOK_PUSHINT)
+                && (MEM_ArrayRead(tokens, i+1) == zPAR_TOK_CALLEXTERN)
+                && (MEM_ArrayRead(params, i+1) == funcExt)
+                && (MEM_ArrayRead(tokens, i+2) != zPAR_OP_UN_NOT) {
+
+                    // Overwrite "DIA_Jesse_Mission" with "DIA_Jesse_Warn"
+                    var int pos; pos = MEM_ArrayRead(positions, i)+1; // Tok+1 = Param
+                    MEM_WriteInt(pos, cond2Id);
+
+                    // That's all
+                    applied = TRUE;
+                    break;
+                };
+            };
+        end;
+
+        // Free all the arrays
+        MEM_ArrayFree(tokens);
+        MEM_ArrayFree(params);
+        MEM_ArrayFree(positions);
+    };
+
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -30,6 +30,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_036_FiskFenceQuest();                                // #36
         Ninja_G1CP_038_SnafDialogNek();                                 // #38
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
+        Ninja_G1CP_060_JesseQuest();                                    // #60
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test060.d
+++ b/src/Ninja/G1CP/Content/Tests/test060.d
@@ -1,0 +1,45 @@
+/*
+ * #60 Jesse's quest not available
+ *
+ * The required dialog is set to told and the condition function of the dialog is called.
+ *
+ * Expected behavior: The condition function will return TRUE.
+ */
+func int Ninja_G1CP_Test_060() {
+    // Check if the dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("DIA_Jesse_Mission_Condition");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'DIA_Jesse_Mission_Condition' not found");
+        return FALSE;
+    };
+
+    // Backup values
+    var int told1Bak; told1Bak = Npc_KnowsInfo(hero, MEM_FindParserSymbol("DIA_Jesse_Warn"));    // Told status
+    var int told2Bak; told2Bak = Npc_KnowsInfo(hero, MEM_FindParserSymbol("DIA_Jesse_Mission")); // Told status
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);                                                // Self
+    var C_Npc othBak; othBak = MEM_CpyInst(other);                                               // Other
+
+    // Set new values
+    Ninja_G1CP_SetInfoTold("DIA_Jesse_Warn", TRUE);                                              // Told status
+    Ninja_G1CP_SetInfoTold("DIA_Jesse_Mission", FALSE);                                          // Told status
+    self  = MEM_NullToInst();                                                                    // Self
+    other = MEM_CpyInst(hero);                                                                   // Other
+
+    // Call dialog condition function
+    MEM_CallByID(funcId);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore values
+    self  = MEM_CpyInst(slfBak);                                                                 // Self
+    other = MEM_CpyInst(othBak);                                                                 // Other
+    Ninja_G1CP_SetInfoTold("DIA_Jesse_Warn", told1Bak);                                          // Told status
+    Ninja_G1CP_SetInfoTold("DIA_Jesse_Mission", told2Bak);                                       // Told status
+
+    // Check return value
+    if (ret) {
+        return TRUE;
+    } else {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog condition failed");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -44,6 +44,7 @@ Content\Fixes\Session\fix031_WolfPlateDialog.d
 Content\Fixes\Session\fix036_FiskFenceQuest.d
 Content\Fixes\Session\fix038_SnafDialogNek.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
+Content\Fixes\Session\fix060_JesseQuest.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d
@@ -72,6 +73,7 @@ Content\Tests\test036.d
 Content\Tests\test038.d
 Content\Tests\test050.d
 Content\Tests\test059.d
+Content\Tests\test060.d
 
 // Initialization
 Content\initOnce.d


### PR DESCRIPTION
### Description
Fixes #60. Jesse's quest can now be triggered.

### Test
Run automatic test with `test 60`.

### Additional Info
The quest does not have a name and is also not tracked in the quest log. Therefore its (non-existing) name is not listed in the changelog.
