### PR TITLE
#79: Wolf's training dialog is now properly triggered

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@
 * Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #59: Vendors don't re-equip their weapon when the player sells them a more powerful one. However, due to important game mechanics, they will still equip a weapon if they didn't have a weapon of that type (meelee, ranged) equipped before.
+* Fix #79: Wolf now only trains dexterity if the player is part of the New Camp.
 
 ## DE
 * Fix #1: NSCs wachen nicht mehr sofort auf, nachdem sie ins Bett gegangen sind, sondern bleiben liegen.
@@ -49,3 +50,4 @@
 * Fix #38: Snaf spricht nun auch über Nek, wenn die Quest "Snafs Rezept" abgeschlossen wurde. 
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.
 * Fix #59: Händler rüsten nicht mehr ihre Waffe um, wenn der Spieler ihnen eine stärkere verkauft. Aufgrund einer wichtigen Spielmechanik wird allerdings eine Waffe ausgerüstet, sofern der Händler vorher noch keine Waffe diese Art (Nahkampf, Fernkampf) ausgerüstet hatte.
+* Fix #79: Wolf lehrt nun nur dann Geschicklichkeit, wenn der Spieler teil des Neuen Lagers ist.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix079_WolfDexDialog.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix079_WolfDexDialog.d
@@ -1,0 +1,75 @@
+/*
+ * #79 Wolf teaches guards dexterity instead of bandits/mercs
+ */
+func int Ninja_G1CP_079_WolfDexDialog() {
+    var int applied; applied = FALSE;
+
+    // Find all necessary symbols
+    var int funcId; funcId = MEM_FindParserSymbol("ORG_855_Wolf_Teach_Condition");
+    var int cond1Id; cond1Id = MEM_FindParserSymbol("GIL_GRD");
+    var int cond2Id; cond2Id = MEM_GetSymbol("C_NpcBelongsToNewCamp");
+    var int funcExt; funcExt = MEM_FindParserSymbol("Npc_GetTrueGuild");
+
+    // Check if all needed functions exist
+    if (funcId != -1) && (cond1Id != -1) && (cond2Id) {
+
+        // Get symbol content of GIL_GRD
+        var int symbPtr; symbPtr = MEM_GetSymbolByIndex(cond1Id);
+        if (!symbPtr) {
+            return FALSE;
+        };
+        var int GIL_GRD; GIL_GRD = MEM_ReadInt(symbPtr + zCParSymbol_content_offset);
+
+        // Get the byte code of the dialog condition function
+        var int tokens; tokens = MEM_ArrayCreate();
+        var int params; params = MEM_ArrayCreate();
+        var int positions; positions = MEM_ArrayCreate();
+        MEMINT_TokenizeFunction(funcID, tokens, params, positions);
+        var int len; len = MEM_ArraySize(tokens);
+
+        // Iterate over the tokens
+        repeat(i, len); var int i;
+
+            var int tok; tok = MEM_ArrayRead(tokens, i);
+            var int par; par = MEM_ArrayRead(params, i);
+
+            // Find "GIL_GRD"
+            if (((par == cond1Id) && (tok  == zPAR_TOK_PUSHVAR))  // GIL_GRD (constant)
+            ||  ((par == GIL_GRD) && (tok  == zPAR_TOK_PUSHINT))) // GIL_GRD (literal integer)
+            && (i+3 < len) { // Prevent error below
+
+                // Verify the context: (Npc_GetTrueGuild(xxxx) == GIL_GRD)
+                if (MEM_ArrayRead(tokens, i+1) == zPAR_TOK_PUSHINST)
+                && (MEM_ArrayRead(tokens, i+2) == zPAR_TOK_CALLEXTERN)
+                && (MEM_ArrayRead(params, i+2) == funcExt)
+                && (MEM_ArrayRead(tokens, i+3) == zPAR_OP_EQUAL) {
+
+                    /* Overwrite the entire condition: (C_NpcBelongsToNewCamp(xxxx) == TRUE)
+
+                        Pos  Original                                       Overwrite to
+                         0   zPAR_TOK_PUSHVAR/INT   GIL_GRD                 zPAR_TOK_PUSHVAR   TRUE
+                         5   zPAR_TOK_PUSHINST      xxxx
+                        10   zPAR_TOK_CALLEXTERN    Npc_GetTrueGuild        zPAR_TOK_CALL      C_NpcBelongsToNewCamp
+                        15   zPAR_OP_EQUAL
+                    */
+                    var int pos; pos = MEM_ArrayRead(positions, i);
+                    MEM_WriteByte(pos,    zPAR_TOK_PUSHVAR);
+                    MEM_WriteInt( pos+1,  MEM_FindParserSymbol("TRUE"));
+                    MEM_WriteByte(pos+10, zPAR_TOK_CALL);
+                    MEM_WriteInt( pos+11, MEM_ReadInt(cond2Id + zCParSymbol_content_offset));
+
+                    // That's all
+                    applied = TRUE;
+                    break;
+                };
+            };
+        end;
+
+        // Free all the arrays
+        MEM_ArrayFree(tokens);
+        MEM_ArrayFree(params);
+        MEM_ArrayFree(positions);
+    };
+
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -30,6 +30,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_036_FiskFenceQuest();                                // #36
         Ninja_G1CP_038_SnafDialogNek();                                 // #38
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
+        Ninja_G1CP_079_WolfDexDialog();                                 // #79
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test079.d
+++ b/src/Ninja/G1CP/Content/Tests/test079.d
@@ -1,0 +1,90 @@
+/*
+ * #79 Wolf teaches guards dexterity instead of bandits/mercs
+ *
+ * The hero's guild is reset and assigned to the new camp. The condition function of the dialog is called for each.
+ *
+ * Expected behavior: The condition function will return FALSE for the first and TRUE for the second pass.
+ */
+func int Ninja_G1CP_Test_079() {
+    var int symbPtr;
+    var int GIL_GRD;
+    var int GIL_ORG;
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if the dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("ORG_855_Wolf_Teach_Condition");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'ORG_855_Wolf_Teach_Condition' not found");
+        passed = FALSE;
+    };
+
+    // Check if guild exists
+    symbPtr = MEM_GetSymbol("GIL_GRD");
+    if (!symbPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Symbol 'GIL_GRD' not found");
+        passed = FALSE;
+    } else {
+        GIL_GRD = MEM_ReadInt(symbPtr + zCParSymbol_content_offset);
+    };
+
+    // Check if guild exists
+    symbPtr = MEM_GetSymbol("GIL_ORG");
+    if (!symbPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Symbol 'GIL_ORG' not found");
+        passed = FALSE;
+    } else {
+        GIL_ORG = MEM_ReadInt(symbPtr + zCParSymbol_content_offset);
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Backup values
+    var int guildBak; guildBak = hero.guild;                     // True guild
+    var int guildTrueBak; guildTrueBak = Npc_GetTrueGuild(hero); // Guild
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);                // Self
+    var C_Npc othBak; othBak = MEM_CpyInst(other);               // Other
+
+    // Set self and other
+    self  = MEM_NullToInst();
+    other = MEM_CpyInst(hero);
+
+    // Do two passes (first one should yield true, second false)
+    var int ret1;
+    var int ret2;
+
+    // First pass
+    hero.guild = GIL_GRD;
+    Npc_SetTrueGuild(hero, GIL_GRD);
+
+    // Call dialog condition function
+    MEM_CallByID(funcId);
+    ret1 = MEM_PopIntResult();
+    if (ret1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function returned true for GIL_GRD");
+    };
+
+    // Second pass
+    hero.guild = GIL_ORG;
+    Npc_SetTrueGuild(hero, GIL_ORG);
+
+    // Call dialog condition function
+    MEM_CallByID(funcId);
+    ret2 = MEM_PopIntResult();
+    if (!ret2) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function returned false for GIL_ORG");
+    };
+
+    // Restore values
+    self  = MEM_CpyInst(slfBak);           // Self
+    other = MEM_CpyInst(othBak);           // Other
+    hero.guild = guildBak;                 // Guild
+    Npc_SetTrueGuild(hero, guildTrueBak);  // True guild
+
+    // Pass on return value
+    return (!ret1) && (ret2);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -44,6 +44,7 @@ Content\Fixes\Session\fix031_WolfPlateDialog.d
 Content\Fixes\Session\fix036_FiskFenceQuest.d
 Content\Fixes\Session\fix038_SnafDialogNek.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
+Content\Fixes\Session\fix079_WolfDexDialog.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d
@@ -72,6 +73,7 @@ Content\Tests\test036.d
 Content\Tests\test038.d
 Content\Tests\test050.d
 Content\Tests\test059.d
+Content\Tests\test079.d
 
 // Initialization
 Content\initOnce.d


### PR DESCRIPTION
### Description
Fixes #79. Wolf now trains the player dexterity if they are part of the New Camp, but no longer if the player is part of the Guard.

### Test
Run automatic test with `test 79`. The test can fail in two ways: If the dialog condition returns true, when the player is a guard, or if it returns false, when the player is part of the New Camp.
