### PR TITLE
#12: Prevent double XP for ranged combat

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 * Fix #7: NPCs no longer practice weapon training without a weapon.
 * Fix #9: NPCs no longer freeze while fleeing.
 * Fix #10: Followers adjust their walking speed according to the player. However, the player must be in sight of the follower if the player starts running after walking.
+* Fix #12: The player no longer receives double XP when killing an NPC with a ranged weapon after already beaten the NPC in melee combat.
 * Fix #15: The player doesn't lose Strength as part of the quest "Horatio the Peasant" if he had more than 100 Strength.
 * Fix #16: Thorus can't be bribed if the player has already obtained the permit to pass the guards. Also the option to bribe Thorus disappears after the player has bribed him.
 * Fix #17: Jackal doesn't ask for protection money anymore if the player has already joined a camp.
@@ -36,6 +37,7 @@
 * Fix #7: NSCs trainieren nicht mehr ohne eine Waffe in der Hand.
 * Fix #9: NSCs frieren nicht mehr beim Fliehen ein.
 * Fix #10: Begleiter passen ihre Laufgeschwindigkeit dem Spieler an. Der Spieler muss allerdings in Sichtweite des Begleiters sein, wenn er anfängt zu rennen, nachdem er vorher gegangen ist.
+* Fix #12: Der Spieler erhält nicht mehr ein zweites Mal Erfahrungspunkte durch Erlegen eines NPC im Fernkampf, wenn dieser zuvor schon im Nahkampf besiegt wurde.
 * Fix #15: Der Spieler verliert keine Stärke mehr im Zuge der Quest "Horatio der Bauer", wenn er vorher mehr als 100 Stärke hatte.
 * Fix #16: Thorus kann nicht mehr bestochen werden, wenn der Spieler bereits Zugang zur Burg hat. Außerdem verschwindet der Bestechen-Dialog, wenn der Spieler ihn bereits bestochen hat.
 * Fix #17: Jackal verlangt kein Schutzgeld mehr vom Spieler, sobald dieser sich einem Lager angeschlossen hat.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix012_RangedDoubleXP.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix012_RangedDoubleXP.d
@@ -11,10 +11,10 @@ func int Ninja_G1CP_012_RangedDoubleXP() {
     var int cond3Id; cond3Id = MEM_FindParserSymbol("AIV_WASDEFEATEDBYSC");
     var int funcExt; funcExt = MEM_FindParserSymbol("Npc_WasInState");
 
-    // Check if all needed functions exist
+    // Check if all needed symbols exist
     if (funcId != -1) && (cond1Id != -1) && (cond3Id != -1) {
 
-        // Get the byte code of the dialog condition function
+        // Get the byte code of the function
         var int tokens; tokens = MEM_ArrayCreate();
         var int params; params = MEM_ArrayCreate();
         var int positions; positions = MEM_ArrayCreate();
@@ -24,7 +24,7 @@ func int Ninja_G1CP_012_RangedDoubleXP() {
         // Iterate over the tokens
         repeat(i, len); var int i;
 
-            // Find "Npc_WasInState"
+            // Find "ZS_Unconscious"
             if (MEM_ArrayRead(params, i) == cond1Id)
             && (i+2 < len) { // Prevent errors below
 
@@ -55,7 +55,7 @@ func int Ninja_G1CP_012_RangedDoubleXP() {
 };
 
 /*
- * Intercepting condition function
+ * Intercepting function
  */
 func int Ninja_G1CP_012_RangedDoubleXP_Condition(var C_Npc slf, var int state) {
     Ninja_G1CP_ReportFuncToSpy();

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix012_RangedDoubleXP.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix012_RangedDoubleXP.d
@@ -1,0 +1,76 @@
+/*
+ * #12 Double exp when killing an NPC with a ranged weapon
+ */
+func int Ninja_G1CP_012_RangedDoubleXP() {
+    var int applied; applied = FALSE;
+
+    // Find all necessary symbols
+    var int funcId; funcId = MEM_FindParserSymbol("B_DeathXP");
+    var int cond1Id; cond1Id = MEM_FindParserSymbol("ZS_Unconscious");
+    var int cond2Id; cond2Id = MEM_GetSymbol("Ninja_G1CP_012_RangedDoubleXP_Condition");
+    var int cond3Id; cond3Id = MEM_FindParserSymbol("AIV_WASDEFEATEDBYSC");
+    var int funcExt; funcExt = MEM_FindParserSymbol("Npc_WasInState");
+
+    // Check if all needed functions exist
+    if (funcId != -1) && (cond1Id != -1) && (cond3Id != -1) {
+
+        // Get the byte code of the dialog condition function
+        var int tokens; tokens = MEM_ArrayCreate();
+        var int params; params = MEM_ArrayCreate();
+        var int positions; positions = MEM_ArrayCreate();
+        MEMINT_TokenizeFunction(funcID, tokens, params, positions);
+        var int len; len = MEM_ArraySize(tokens);
+
+        // Iterate over the tokens
+        repeat(i, len); var int i;
+
+            // Find "Npc_WasInState"
+            if (MEM_ArrayRead(params, i) == cond1Id)
+            && (i+2 < len) { // Prevent errors below
+
+                // Verify immediate context: Npc_WasInState(xxxx, ZS_Unconscious)
+                if (MEM_ArrayRead(tokens, i) == zPAR_TOK_PUSHINT)
+                && (MEM_ArrayRead(tokens, i+1) == zPAR_TOK_CALLEXTERN) && (MEM_ArrayRead(params, i+1) == funcExt)
+                && (MEM_ArrayRead(tokens, i+2) != zPAR_OP_UN_NOT) {
+
+                    // Overwrite "Npc_WasInState" with "Ninja_G1CP_012_RangedDoubleXP_Condition"
+                    var int pos; pos = MEM_ArrayRead(positions, i+1);
+                    MEM_WriteByte(pos, zPAR_TOK_CALL);
+                    MEM_WriteInt(pos+1, MEM_ReadInt(cond2Id + zCParSymbol_content_offset));
+
+                    // That's all
+                    applied = TRUE;
+                    break;
+                };
+            };
+        end;
+
+        // Free all the arrays
+        MEM_ArrayFree(tokens);
+        MEM_ArrayFree(params);
+        MEM_ArrayFree(positions);
+    };
+
+    return applied;
+};
+
+/*
+ * Intercepting condition function
+ */
+func int Ninja_G1CP_012_RangedDoubleXP_Condition(var C_Npc slf, var int state) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Original condition: Npc_WasInState(self, ZS_Unconscious)
+    var int cond1;
+    MEM_PushInstParam(slf);
+    MEM_PushIntParam(state);
+    MEM_Call(Npc_WasInState);
+    cond1 = MEM_PopIntResult();
+
+    // Additional condition: self.aivar[AIV_WASDEFEATEDBYSC]
+    var int cond2;
+    cond2 = Ninja_G1CP_GetAIVar(slf, "AIV_WASDEFEATEDBYSC", 0);
+
+    // Either one of the conditions
+    return (cond1) || (cond2);
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -14,6 +14,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_007_PracticeSwordWithWeapon();                       // #7
         Ninja_G1CP_009_FixFlee();                                       // #9
         Ninja_G1CP_010_FollowWalkMode();                                // #10
+        Ninja_G1CP_012_RangedDoubleXP();                                // #12
         Ninja_G1CP_015_HoratioStrength();                               // #15
         Ninja_G1CP_016_ThorusBribeDialog();                             // #16
         Ninja_G1CP_017_JackalProtectionMoney();                         // #17

--- a/src/Ninja/G1CP/Content/Tests/test012.d
+++ b/src/Ninja/G1CP/Content/Tests/test012.d
@@ -41,10 +41,6 @@ func void Ninja_G1CP_Test_012() {
     };
 };
 
-
-/*
- * The actual test will run through the NPC's AI state (see below)
- */
 instance Ninja_G1CP_Test_012_Npc(C_Npc) {
     name          = "Test 12";
     attribute[0]  = 2;

--- a/src/Ninja/G1CP/Content/Tests/test012.d
+++ b/src/Ninja/G1CP/Content/Tests/test012.d
@@ -1,0 +1,56 @@
+/*
+ * #12 Double exp when killing an NPC with a ranged weapon
+ *
+ * A test NPC is inserted and the hero is given a bow and some arrows
+ *
+ * Expected behavior: The NPC will not give XP again when first downed by hand and then killed with bow and arrow
+ */
+func void Ninja_G1CP_Test_012() {
+    if (!Ninja_G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Check symbols first
+    if (MEM_FindParserSymbol("B_DeathXP") == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Function 'B_DeathXP' not found");
+        return;
+    };
+    if (MEM_FindParserSymbol("AIV_WASDEFEATEDBYSC") == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'AIV_WASDEFEATEDBYSC' not found");
+        return;
+    };
+
+    // Insert test NPC
+    var string wp; wp = Npc_GetNearestWP(hero);
+    Wld_InsertNpc(Ninja_G1CP_Test_012_Npc, wp);
+    var C_Npc test; test = Hlp_GetNpc(Ninja_G1CP_Test_012_Npc);
+    if (!Hlp_IsValidNpc(test)) {
+        Ninja_G1CP_TestsuiteErrorDetail("Failed to insert NPC");
+        return;
+    };
+
+    // Give bow and arrow to player
+    var int symbId;
+    symbId = MEM_FindParserSymbol("ItRw_Bow_Small_01");
+    if (symbId != -1) {
+        CreateInvItem(hero, symbId);
+    };
+    symbId = MEM_FindParserSymbol("ItAmArrow");
+    if (symbId != -1) {
+        CreateInvItems(hero, symbId, 20);
+    };
+};
+
+
+/*
+ * The actual test will run through the NPC's AI state (see below)
+ */
+instance Ninja_G1CP_Test_012_Npc(C_Npc) {
+    name          = "Test 12";
+    attribute[0]  = 2;
+    attribute[1]  = 2;
+    senses        = 7;
+    senses_range  = 2000;
+    Mdl_SetVisual(self, "HUMANS.MDS");
+    Mdl_SetVisualBody(self, "HUM_BODY_NAKED0", 1, 1, "Hum_Head_Fighter", 1, 1, -1);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -30,6 +30,7 @@ Content\Fixes\Session\fix003_RegainDroppedWeapon.d
 Content\Fixes\Session\fix007_PracticeSwordWithWeapon.d
 Content\Fixes\Session\fix009_FixFlee.d
 Content\Fixes\Session\fix010_FollowWalkMode.d
+Content\Fixes\Session\fix012_RangedDoubleXP.d
 Content\Fixes\Session\fix015_HoratioStrength.d
 Content\Fixes\Session\fix016_ThorusBribeDialog.d
 Content\Fixes\Session\fix017_JackalProtectionMoney.d
@@ -61,6 +62,7 @@ Content\Tests\test003.d
 Content\Tests\test007.d
 Content\Tests\test009.d
 Content\Tests\test010.d
+Content\Tests\test012.d
 Content\Tests\test015.d
 Content\Tests\test016.d
 Content\Tests\test017.d


### PR DESCRIPTION
### Description
Fixes #12. The player no longer receives double XP when killing an NPC in ranged combat.

### Test
Run manual test with `test 12`. This test only supplies a helpless NPC to work on.
