### PR TITLE
#8: Prevent NPCs to move in circles

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix008_NpcMoveCircle.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix008_NpcMoveCircle.d
@@ -1,0 +1,104 @@
+/*
+ * #8 NPCs move in circles
+ */
+func int Ninja_G1CP_008_NpcMoveCircle() {
+    var int applied1; applied1 = FALSE;
+    var int applied2; applied2 = FALSE;
+
+    // Find all necessary symbols
+    var int funcId; funcId = MEM_FindParserSymbol("ZS_StandAround_Loop");
+    var int bGotoFP_symbPtr; bGotoFP_symbPtr = MEM_GetSymbol("B_GotoFP");
+    var int hook1_symbPtr; hook1_symbPtr = MEM_GetSymbol("Ninja_G1CP_008_GotoAndAlignFP");
+    var int hook2_symbPtr; hook2_symbPtr = MEM_GetSymbol("Ninja_G1CP_008_TurnToNpcIfCanSee");
+    var int alignFP_id; alignFP_id = MEM_FindParserSymbol("AI_AlignToFP");
+    var int turnNpc_id; turnNpc_id = MEM_FindParserSymbol("AI_TurnToNpc");
+
+    // Check if all needed symbols exist
+    if (funcId != -1) && (bGotoFP_symbPtr) {
+
+        // Get the byte code of the function
+        var int tokens; tokens = MEM_ArrayCreate();
+        var int params; params = MEM_ArrayCreate();
+        var int positions; positions = MEM_ArrayCreate();
+        MEMINT_TokenizeFunction(funcID, tokens, params, positions);
+        var int len; len = MEM_ArraySize(tokens);
+
+        // Func offset
+        var int pos;
+        var int bGotoFP_offset; bGotoFP_offset = MEM_ReadInt(bGotoFP_symbPtr + zCParSymbol_content_offset);
+        var int hook1_offset; hook1_offset = MEM_ReadInt(hook1_symbPtr + zCParSymbol_content_offset);
+        var int hook2_offset; hook2_offset = MEM_ReadInt(hook2_symbPtr + zCParSymbol_content_offset);
+
+        // Iterate over the tokens
+        repeat(i, len); var int i;
+
+            // First change: Find "ZS_Unconscious"
+            if (MEM_ArrayRead(params, i) == bGotoFP_offset)
+            && (i+3 < len) { // Prevent errors below
+
+                // Verify immediate context: B_GotoFP(xxxx, xxxx); AI_AlignToFP(xxxx)
+                if (MEM_ArrayRead(tokens, i) == zPAR_TOK_CALL)
+                && (MEM_ArrayRead(tokens, i+2) == zPAR_TOK_CALLEXTERN) && (MEM_ArrayRead(params, i+2) == alignFP_id) {
+
+                    // Overwrite "B_GotoFP" with "Ninja_G1CP_008_GotoAndAlignFP"
+                    pos = MEM_ArrayRead(positions, i);
+                    var int to; to = MEM_ArrayRead(positions, i+3) - currParserStackAddress;
+                    MEM_WriteInt(pos+1,  hook1_offset);  // B_GotoFP
+                    MEM_WriteByte(pos+5, zPAR_TOK_JUMP); // zPAR_TOK_CALLEXTERN
+                    MEM_WriteInt(pos+6,  to);            // AI_AlignToFP
+
+                    applied1 += 1;
+                };
+                continue;
+            };
+
+            // Second change: Find "AI_TurnToNpc"
+            if (MEM_ArrayRead(params, i) == turnNpc_id) {
+
+                // Verify immediate context: AI_TurnToNpc(xxxx, xxxx)
+                if (MEM_ArrayRead(tokens, i) == zPAR_TOK_CALLEXTERN) {
+
+                    // Overwrite "AI_TurnToNpc" with "Ninja_G1CP_008_TurnToNpcIfCanSee"
+                    pos = MEM_ArrayRead(positions, i);
+                    MEM_WriteByte(pos,  zPAR_TOK_CALL); // zPAR_TOK_CALLEXTERN
+                    MEM_WriteInt(pos+1, hook2_offset);  // AI_TurnToNpc
+
+                    applied2 += 1;
+                };
+            };
+        end;
+
+        // Free all the arrays
+        MEM_ArrayFree(tokens);
+        MEM_ArrayFree(params);
+        MEM_ArrayFree(positions);
+    };
+
+    return (applied1) && (applied2);
+};
+
+/*
+ * Intercepting function
+ */
+func void Ninja_G1CP_008_GotoAndAlignFP(var C_Npc slf, var string fp) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Original condition: B_GotoFP(slf, fp)
+    MEM_PushInstParam(slf);
+    MEM_PushStringParam(fp);
+    MEM_CallByString("B_GotoFP");
+
+    // Wrap the alignment into an if-block
+    if (!Npc_IsOnFP(slf, fp)) {
+        AI_AlignToFP(slf);
+    };
+};
+func void Ninja_G1CP_008_TurnToNpcIfCanSee(var C_Npc slf, var C_Npc oth) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Wrap turn function into an if-block
+    if (!Npc_CanSeeNpc(slf, oth)) {
+        // Original condition
+        AI_TurnToNpc(slf, oth);
+    };
+};

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix008_NpcMoveCircle.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix008_NpcMoveCircle.d
@@ -32,7 +32,7 @@ func int Ninja_G1CP_008_NpcMoveCircle() {
         // Iterate over the tokens
         repeat(i, len); var int i;
 
-            // First change: Find "ZS_Unconscious"
+            // First change: Find "B_GotoFP"
             if (MEM_ArrayRead(params, i) == bGotoFP_offset)
             && (i+3 < len) { // Prevent errors below
 

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -12,6 +12,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_002_FixDoor();                                       // #2
         Ninja_G1CP_003_RegainDroppedWeapon();                           // #3
         Ninja_G1CP_007_PracticeSwordWithWeapon();                       // #7
+        Ninja_G1CP_008_NpcMoveCircle();                                 // #8
         Ninja_G1CP_009_FixFlee();                                       // #9
         Ninja_G1CP_010_FollowWalkMode();                                // #10
         Ninja_G1CP_015_HoratioStrength();                               // #15

--- a/src/Ninja/G1CP/Content/Tests/test008.d
+++ b/src/Ninja/G1CP/Content/Tests/test008.d
@@ -1,0 +1,14 @@
+/*
+ * #8 NPCs move in circles
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: NPCs should no longer move in circles.
+ */
+func void Ninja_G1CP_Test_008() {
+    if (Ninja_G1CP_TestsuiteAllowManual) {
+        // No idea where this bug is actually visible
+        Wld_SetTime(11, 0); // TODO
+        AI_Teleport(hero, "OCR_OUTSIDE_MCAMP_01"); // TODO
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -28,6 +28,7 @@ Content\Fixes\Session\fix001_FixNpcSleep.d
 Content\Fixes\Session\fix002_FixDoor.d
 Content\Fixes\Session\fix003_RegainDroppedWeapon.d
 Content\Fixes\Session\fix007_PracticeSwordWithWeapon.d
+Content\Fixes\Session\fix008_NpcMoveCircle.d
 Content\Fixes\Session\fix009_FixFlee.d
 Content\Fixes\Session\fix010_FollowWalkMode.d
 Content\Fixes\Session\fix015_HoratioStrength.d
@@ -59,6 +60,7 @@ Content\Tests\test001.d
 Content\Tests\test002.d
 Content\Tests\test003.d
 Content\Tests\test007.d
+Content\Tests\test008.d
 Content\Tests\test009.d
 Content\Tests\test010.d
 Content\Tests\test015.d


### PR DESCRIPTION
### Description
Fixes #8. NPCs should no longer move in circles when aligning in their daily routines.

### Test
Run manual test with `test 8`.

There is no working test for this issue yet, because I don't know where to reproduce this bug. We need to know a position in the world and time of day where the bug happens every time. See [here](https://github.com/AmProsius/gothic-1-community-patch/issues/8#issuecomment-774713219).
