### PR TITLE
#49: Fix the item text of the dungeon key

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@
 * Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
 * Fix #40: Aleph doesn't offer to sell the key anymore when the player already obtained it.
 * Fix #43: The dialog choices about learning skills now contain proper whitespace.
+* Fix #49: The description of the dungeon key is corrected to "Opens the dungeons of the old camp.".
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #59: Vendors don't re-equip their weapon when the player sells them a more powerful one. However, due to important game mechanics, they will still equip a weapon if they didn't have a weapon of that type (meelee, ranged) equipped before.
 * Fix #60: Jesse's quest is now available.
@@ -52,6 +53,7 @@
 * Fix #36: Fisks Quest "Neuer Hehler für Fisk" is nun immer erhältlich, egal, wie Thorus' Quest "Auftrag von Thorus" (erfolgreich) beendet wurde.  
 * Fix #38: Snaf spricht nun auch über Nek, wenn die Quest "Snafs Rezept" abgeschlossen wurde. 
 * Fix #40: Aleph bietet den Schlüssel nun nicht noch einmal an, wenn der Spieler ihn schon erhalten hat.
+* Fix #49: Die Beschreibung des Kerkerschlüssels ist korrigiert zu "öffnet den Kerker des Alten Lagers.".
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.
 * Fix #59: Händler rüsten nicht mehr ihre Waffe um, wenn der Spieler ihnen eine stärkere verkauft. Aufgrund einer wichtigen Spielmechanik wird allerdings eine Waffe ausgerüstet, sofern der Händler vorher noch keine Waffe diese Art (Nahkampf, Fernkampf) ausgerüstet hatte.
 * Fix #60: Jesses Quest ist nun verfügbar.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix049_DungeonKeyText.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix049_DungeonKeyText.d
@@ -1,0 +1,47 @@
+/*
+ * #49 Dungeon Key description faulty
+ */
+func int Ninja_G1CP_049_DungeonKeyText() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int symbId; symbId = MEM_FindParserSymbol("DungeonKey");
+    var int itemTextSymbId; itemTextSymbId = MEM_FindParserSymbol("C_ITEM.TEXT");
+    if (symbId == -1) || (itemTextSymbId == -1) {
+        return FALSE;
+    };
+
+    // Find "text = xxx" in the instance function
+    var int s; s = SB_New();
+    SBc(zPAR_TOK_PUSHVAR);   SBw(itemTextSymbId);
+    SBc(zPAR_TOK_ASSIGNSTR);
+    var int matches; matches = Ninja_G1CP_FindInFunc(symbId, SB_GetStream(), SB_Length());
+    SB_Destroy();
+
+    // We are looking for all overwritten text (at least 2 occurrences)
+    if (MEM_ArraySize(matches) >= 2) {
+
+        // Iterate over all matches
+        repeat(i, MEM_ArraySize(matches)); var int i; if (!i) { i = 1; }; // Skip the first occurrence
+
+            // Write the correct byte code at a new address: "text[i] = xxxx"
+            s = SB_New();
+            SBc(zPAR_TOK_PUSH_ARRAYVAR); SBw(itemTextSymbId); SBc(i);
+            SBc(zPAR_TOK_RET);
+            var int ptr; ptr = SB_GetStream();
+            SB_Release();
+
+            // Overwrite "text = xxx" with a call to the above bytes
+            var int pos; pos = MEM_ArrayRead(matches, i);
+            MEM_WriteByte(pos, zPAR_TOK_CALL);
+            MEM_WriteInt(pos+1, ptr - currParserStackAddress);
+
+            applied += 1;
+        end;
+    };
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -31,6 +31,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_038_SnafDialogNek();                                 // #38
         Ninja_G1CP_040_AlephKeyDialog();                                // #40
         Ninja_G1CP_043_EN_SkillMissingWhitespace();                     // #43
+        Ninja_G1CP_049_DungeonKeyText();                                // #49
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
         Ninja_G1CP_060_JesseQuest();                                    // #60
         Ninja_G1CP_079_WolfDexDialog();                                 // #79

--- a/src/Ninja/G1CP/Content/Tests/test049.d
+++ b/src/Ninja/G1CP/Content/Tests/test049.d
@@ -1,0 +1,43 @@
+/*
+ * #49 Dungeon Key description faulty
+ *
+ * The text of the item "DungeonKey" is inspected programmatically
+ *
+ * Expected behavior: The key will have the correct description (checked for English and German localization only)
+ */
+func int Ninja_G1CP_Test_049() {
+    // Check language first
+    if (Ninja_G1CP_Lang != 0) && (Ninja_G1CP_Lang != 1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Test applicable for English and German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_FindParserSymbol("DungeonKey");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'DungeonKey' not found");
+        return FALSE;
+    };
+
+    // Create the key locally
+    if (Itm_GetPtr(symbId)) {
+        // Static string arrays cannot be read directly
+        var string item_text_1; item_text_1 = MEM_ReadStatStringArr(item.text, 1);
+
+        if ((Hlp_StrCmp(item.text, "Opens the dungeons")) && (Hlp_StrCmp(item_text_1, "of the old camp.")))    // EN
+        || ((Hlp_StrCmp(item.text, "öffnet den Kerker"))  && (Hlp_StrCmp(item_text_1, "des Alten Lagers."))) { // DE
+            return TRUE;
+        } else {
+            var string msg; msg = "Text incorrect: text[0] = '";
+            msg = ConcatStrings(msg, item.text);
+            msg = ConcatStrings(msg, "' and text[1] = '");
+            msg = ConcatStrings(msg, item_text_1);
+            msg = ConcatStrings(msg, "'");
+            Ninja_G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'DungeonKey' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -47,6 +47,7 @@ Content\Fixes\Session\fix036_FiskFenceQuest.d
 Content\Fixes\Session\fix038_SnafDialogNek.d
 Content\Fixes\Session\fix040_AlephKeyDialog.d
 Content\Fixes\Session\fix043_EN_SkillMissingWhitespace.d
+Content\Fixes\Session\fix049_DungeonKeyText.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 Content\Fixes\Session\fix060_JesseQuest.d
 Content\Fixes\Session\fix079_WolfDexDialog.d
@@ -78,6 +79,7 @@ Content\Tests\test036.d
 Content\Tests\test038.d
 Content\Tests\test040.d
 Content\Tests\test043.d
+Content\Tests\test049.d
 Content\Tests\test050.d
 Content\Tests\test059.d
 Content\Tests\test060.d


### PR DESCRIPTION
### Description
Fixes #49. Interestingly, I found a way to fix this issue completely language independent. The exact wording does not matter: if the second line of text overwrites the first line, it will be corrected.

### Test
Run automatic test with `test 49`.

The test, however, only supports English and German localization. Both should be tested (I only tested English). Three additional tests are yet to be performed.

1. Test in German localization (especially important because of the umlaut 'ö' in the key text)
1. Do an additional _manual_ test where the key was in the world before the fix was applied, i.e. create a game save with the key inserted, then apply the fix, load the game and manually confirm that the key's text was updated.
1. Do a test on a mod that already fixed the issue.