### PR TITLE
#21: Prevent Fletcher from reopening quest

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,7 @@
 * Fix #18: Bloodwyn doesn't ask for protection money anymore if the player has already joined a camp.
 * Fix #19: Scorpio can no longer be asked "Can you teach me to fight?" after he fled from the Old Camp to Cavalorn. Note: The player can still learn how to fight from him since that is a different dialog option.
 * Fix #20: Kirgo now correctly gives a beer to the player.
-* Fix #21: Fletcher now no longer reopens the quest "Vanished Guard".
+* Fix #21: Fletcher no longer reopens the quest "Vanished Guard" if it was closed before talking to him.
 * Fix #22: Y'Berion now attacks the player instead of repeating himself calling the guards.
 * Fix #24: Cor Kalom now correctly closes the quest "Taking Weeds to Gomez" instead of "The Weed Monopoly".
 * Fix #25: Saturas no longer offers to sell a High Robe of Water if the player already obtained one.
@@ -46,6 +46,7 @@
 * Fix #18: Bloodwyn verlangt kein Schutzgeld mehr vom Spieler, sobald dieser sich einem Lager angeschlossen hat.
 * Fix #19: Scorpio kann nicht mehr gefragt werden: "Kannst du mir beibringen zu kämpfen?", nachdem er aus dem Alten Lager zu Cavalorn geflohen ist. Hinweis: Der Spieler kann immer noch von ihm Nahkampf lernen, da dies eine andere Dialogoption ist.
 * Fix #20: Kirgo gibt dem Spieler nun korrekterweise ein Bier.
+* Fix #21: Fletcher öffnet die Quest "Verschwundener Gardist" nicht mehr, wenn sie bereits abgeschlossen wurde, bevor der Spieler mit ihm gesprochen hat.
 * Fix #22: Y'Berion greift den Spieler nun an, statt in einer Dialogschleife die Wachen zu rufen.
 * Fix #24: Cor Kalom schließt nun korrekterweise die Quest "Kraut zu Gomez bringen" statt "Das Krautmonopol".
 * Fix #25: Saturas bietet nun keine Große Wasserrobe mehr an, wenn der Spieler bereits eine erworben hat.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@
 * Fix #18: Bloodwyn doesn't ask for protection money anymore if the player has already joined a camp.
 * Fix #19: Scorpio can no longer be asked "Can you teach me to fight?" after he fled from the Old Camp to Cavalorn. Note: The player can still learn how to fight from him since that is a different dialog option.
 * Fix #20: Kirgo now correctly gives a beer to the player.
+* Fix #21: Fletcher now no longer reopens the quest "Vanished Guard".
 * Fix #22: Y'Berion now attacks the player instead of repeating himself calling the guards.
 * Fix #24: Cor Kalom now correctly closes the quest "Taking Weeds to Gomez" instead of "The Weed Monopoly".
 * Fix #25: Saturas no longer offers to sell a High Robe of Water if the player already obtained one.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix021_FletcherClosedQuest.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix021_FletcherClosedQuest.d
@@ -57,22 +57,15 @@ func int Ninja_G1CP_021_FletcherClosedQuest() {
 };
 
 /*
- * Give the desired log status, check if changing it is allowed
+ * Determine if changing the status of the topic is allowed
  */
-func int Ninja_G1CP_021_AllowTopicCall(var int status) {
+func int Ninja_G1CP_021_AllowTopicCall(var string topic) {
+    // Define possibly missing symbols locally
     const int GIL_NONE    = 0;
-    const int LOG_RUNNING = 1;
     const int LOG_SUCCESS = 2;
 
-    // Find "Sly_LostNek"
-    var int Sly_LostNek; Sly_LostNek = 0;
-    var int symbPtr; symbPtr = MEM_GetSymbol("Sly_LostNek");
-    if (symbPtr) {
-        Sly_LostNek = MEM_ReadInt(symbPtr + zCParSymbol_content_offset);
-    };
-
-    // Allow to create topic if ...
-    return (status != LOG_RUNNING) || ((Sly_LostNek != LOG_SUCCESS) && (Npc_GetTrueGuild(hero) == GIL_NONE));
+    // Allow to open topic if ...
+    return (Ninja_G1CP_GetTopicStatus(topic) != LOG_SUCCESS) && (Npc_GetTrueGuild(hero) == GIL_NONE);
 };
 
 /*
@@ -83,10 +76,8 @@ func void Ninja_G1CP_021_CreateTopic(var string topic, var int section) {
 
     // Define possibly missing symbols locally
     const int LOG_MISSION = 0;
-    const int LOG_RUNNING = 1;
 
-    if (Ninja_G1CP_021_AllowTopicCall(LOG_RUNNING)) // There is no status for Log_CreateTopic
-    || (section != LOG_MISSION) {
+    if (Ninja_G1CP_021_AllowTopicCall(topic)) || (section != LOG_MISSION) {
         Log_CreateTopic(topic, section);
     };
 };
@@ -94,11 +85,14 @@ func void Ninja_G1CP_021_CreateTopic(var string topic, var int section) {
 /*
  * Wrapper function for Ninja_G1CP_021_SetTopicStatus
  */
-func void Ninja_G1CP_021_SetTopicStatus(var string topic, var int status) {
+func void Ninja_G1CP_021_SetTopicStatus(var string topic, var int newStatus) {
     Ninja_G1CP_ReportFuncToSpy();
 
-    if (Ninja_G1CP_021_AllowTopicCall(status)) {
-        Log_SetTopicStatus(topic, status);
+    // Define possibly missing symbols locally
+    const int LOG_RUNNING = 1;
+
+    if (Ninja_G1CP_021_AllowTopicCall(topic)) || (newStatus != LOG_RUNNING) {
+        Log_SetTopicStatus(topic, newStatus);
     };
 };
 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix021_FletcherClosedQuest.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix021_FletcherClosedQuest.d
@@ -1,0 +1,104 @@
+/*
+ * #21 Fletcher reopens closed quest
+ */
+func int Ninja_G1CP_021_FletcherClosedQuest() {
+    var int applied1; applied1 = FALSE;
+    var int applied2; applied2 = FALSE;
+
+    // Check if necessary symbols exist
+    var int funcId; funcId = MEM_FindParserSymbol("DIA_Fletcher_WoNek_Info");
+    if (funcId == -1) || (MEM_FindParserSymbol("Sly_LostNek") == -1) {
+        return FALSE;
+    };
+
+    var int matches;
+    var int s;
+    var int funcOffset;
+
+    // Find "Log_CreateTopic(xxxx, xxxx)" in the function
+    s = SB_New();
+    SBc(zPAR_TOK_CALLEXTERN); SBw(MEM_FindParserSymbol("Log_CreateTopic"));
+    matches = Ninja_G1CP_FindInFunc(funcId, SB_GetStream(), SB_Length());
+    SB_Destroy();
+
+    funcOffset = MEM_GetFuncOffset(Ninja_G1CP_021_CreateTopic);
+
+    // Iterate over all matches
+    repeat(i, MEM_ArraySize(matches)); var int i;
+
+        // Overwrite "Log_CreateTopic(xxxx, xxxx)" with "Ninja_G1CP_021_CreateTopic(xxxx, xxxx)"
+        var int pos; pos = MEM_ArrayRead(matches, i);
+        MEM_WriteByte(pos, zPAR_TOK_CALL);
+        MEM_WriteInt(pos+1, funcOffset);
+
+        applied1 += 1;
+    end;
+
+    // Find "Log_SetTopicStatus(xxxx, xxxx)" in the function
+    s = SB_New();
+    SBc(zPAR_TOK_CALLEXTERN); SBw(MEM_FindParserSymbol("Log_SetTopicStatus"));
+    matches = Ninja_G1CP_FindInFunc(funcId, SB_GetStream(), SB_Length());
+    SB_Destroy();
+
+    funcOffset = MEM_GetFuncOffset(Ninja_G1CP_021_SetTopicStatus);
+
+    // Iterate over all matches
+    repeat(i, MEM_ArraySize(matches)); var int i;
+
+        // Overwrite "Log_SetTopicStatus(xxxx, xxxx)" with "Ninja_G1CP_021_SetTopicStatus(xxxx, xxxx)"
+        var int pos; pos = MEM_ArrayRead(matches, i);
+        MEM_WriteByte(pos, zPAR_TOK_CALL);
+        MEM_WriteInt(pos+1, funcOffset);
+
+        applied2 += 1;
+    end;
+
+    return (applied1) && (applied2);
+};
+
+/*
+ * Give the desired log status, check if changing it is allowed
+ */
+func int Ninja_G1CP_021_AllowTopicCall(var int status) {
+    const int GIL_NONE    = 0;
+    const int LOG_RUNNING = 1;
+    const int LOG_SUCCESS = 2;
+
+    // Find "Sly_LostNek"
+    var int Sly_LostNek; Sly_LostNek = 0;
+    var int symbPtr; symbPtr = MEM_GetSymbol("Sly_LostNek");
+    if (symbPtr) {
+        Sly_LostNek = MEM_ReadInt(symbPtr + zCParSymbol_content_offset);
+    };
+
+    // Allow to create topic if ...
+    return (status != LOG_RUNNING) || ((Sly_LostNek != LOG_SUCCESS) && (Npc_GetTrueGuild(hero) == GIL_NONE));
+};
+
+/*
+ * Wrapper function for Log_CreateTopic
+ */
+func void Ninja_G1CP_021_CreateTopic(var string topic, var int section) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Define possibly missing symbols locally
+    const int LOG_MISSION = 0;
+    const int LOG_RUNNING = 1;
+
+    if (Ninja_G1CP_021_AllowTopicCall(LOG_RUNNING)) // There is no status for Log_CreateTopic
+    || (section != LOG_MISSION) {
+        Log_CreateTopic(topic, section);
+    };
+};
+
+/*
+ * Wrapper function for Ninja_G1CP_021_SetTopicStatus
+ */
+func void Ninja_G1CP_021_SetTopicStatus(var string topic, var int status) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    if (Ninja_G1CP_021_AllowTopicCall(status)) {
+        Log_SetTopicStatus(topic, status);
+    };
+};
+

--- a/src/Ninja/G1CP/Content/Misc/topic.d
+++ b/src/Ninja/G1CP/Content/Misc/topic.d
@@ -1,0 +1,69 @@
+/*
+ * Function to get the log topic status
+ */
+func int Ninja_G1CP_GetTopicStatus(var string topic) {
+    // Iterate over all topics (irrespective of their section)
+    var int list; list = oCLogManager_Ptr;
+    var zCList l;
+    while(list);
+        l = _^(list);
+        list = l.next;
+        if (l.data) {
+
+            // Check for match
+            var oCLogTopic logTopic; logTopic = _^(l.data);
+            if (Hlp_StrCmp(logTopic.m_strDescription, topic)) {
+                return logTopic.m_enuStatus;
+            };
+        };
+    end;
+
+    // Not found
+    return -1;
+};
+
+/*
+ * Remove a topic from the log completely
+ */
+func void Ninja_G1CP_RemoveTopic(var string topic) {
+    // Iterate over all topics (irrespective of their section)
+    var int list; list = oCLogManager_Ptr;
+    var int prev; prev = 0;
+    var zCList l;
+    while(list);
+        l = _^(list);
+        if (l.data) {
+
+            // Check for match
+            var oCLogTopic logTopic; logTopic = _^(l.data);
+            if (Hlp_StrCmp(logTopic.m_strDescription, topic)) {
+
+                // Remove this element from the list
+                var int data; data = l.data;
+                var int next; next = l.next;
+                l.next = 0; // Important before calling the destructor below. Otherwise the entire list is deleted
+                if (prev) {
+                    l = _^(prev);
+                    l.next = next;
+                };
+
+                // Destroy the topic and the list element
+                const int oCLogTopic___oCLogTopic        = 7530272; //0x72E720
+                const int zCList_oCLogTopic___destructor = 7532848; //0x72F130
+                const int call = 0;
+                const int one = -1; // Set all bits, because char
+                if (CALL_Begin(call)) {
+                    CALL__thiscall(_@(data), oCLogTopic___oCLogTopic);
+                    CALL_PtrParam(_@(one));
+                    CALL__thiscall(_@(list), zCList_oCLogTopic___destructor);
+                    call = CALL_End();
+                };
+
+                return;
+            };
+        };
+
+        prev = list;
+        list = l.next;
+    end;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -21,6 +21,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_018_BloodwynProtectionMoney();                       // #18
         Ninja_G1CP_019_ScorpioFightDialog();                            // #19
         Ninja_G1CP_020_KirgoGivesBeer();                                // #20
+        Ninja_G1CP_021_FletcherClosedQuest();                           // #21
         Ninja_G1CP_022_YBerionAttacks();                                // #22
         Ninja_G1CP_024_CorKalomWrongQuest();                            // #24
         Ninja_G1CP_025_SaturasSellsRobe();                              // #25

--- a/src/Ninja/G1CP/Content/Tests/test021.d
+++ b/src/Ninja/G1CP/Content/Tests/test021.d
@@ -21,14 +21,7 @@ func int Ninja_G1CP_Test_021() {
         passed = FALSE;
     };
 
-    // Obtain symbols
-    var int questStatusPtr; questStatusPtr = MEM_GetSymbol("Sly_LostNek");
-    if (!questStatusPtr) {
-        Ninja_G1CP_TestsuiteErrorDetail("Variable 'Sly_LostNek' not found");
-        passed = FALSE;
-    };
-    questStatusPtr += zCParSymbol_content_offset;
-
+    // Obtain log topic name
     var string CH1_LostNek;
     var int topicNamePtr; topicNamePtr = MEM_GetSymbol("CH1_LostNek");
     if (topicNamePtr) {
@@ -44,12 +37,10 @@ func int Ninja_G1CP_Test_021() {
     };
 
     // Back up the values
-    var int questStatusBak; questStatusBak = MEM_ReadInt(questStatusPtr);
     var int topicStatusBak; topicStatusBak = Ninja_G1CP_GetTopicStatus(CH1_LostNek);
     var int guildTrueBak; guildTrueBak = Npc_GetTrueGuild(hero);
 
     // Set the variables
-    MEM_WriteInt(questStatusPtr, LOG_SUCCESS);
     Log_CreateTopic(CH1_LostNek, LOG_MISSION);
     Log_SetTopicStatus(CH1_LostNek, LOG_SUCCESS);
     Npc_SetTrueGuild(hero, GIL_NONE);
@@ -78,7 +69,6 @@ func int Ninja_G1CP_Test_021() {
 
     // Restore the variables
     Npc_SetTrueGuild(hero, guildTrueBak);
-    MEM_WriteInt(questStatusPtr, questStatusBak);
     if (topicStatusBak == -1) {
         Ninja_G1CP_RemoveTopic(CH1_LostNek);
     } else {

--- a/src/Ninja/G1CP/Content/Tests/test021.d
+++ b/src/Ninja/G1CP/Content/Tests/test021.d
@@ -1,0 +1,95 @@
+/*
+ * #21 Fletcher reopens closed quest
+ *
+ * The "Sly_LostNek" quest is set to successful and the dialog function is called.
+ *
+ * Expected behavior: The log entry is not moved to the "running" section.
+ */
+func int Ninja_G1CP_Test_021() {
+    // Define possibly missing symbols locally
+    const int GIL_NONE    = 0;
+    const int LOG_MISSION = 0;
+    const int LOG_RUNNING = 1;
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("DIA_Fletcher_WoNek_Info");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'DIA_Fletcher_WoNek_Info' not found");
+        passed = FALSE;
+    };
+
+    // Obtain symbols
+    var int questStatusPtr; questStatusPtr = MEM_GetSymbol("Sly_LostNek");
+    if (!questStatusPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'Sly_LostNek' not found");
+        passed = FALSE;
+    };
+    questStatusPtr += zCParSymbol_content_offset;
+
+    var string CH1_LostNek;
+    var int topicNamePtr; topicNamePtr = MEM_GetSymbol("CH1_LostNek");
+    if (topicNamePtr) {
+        CH1_LostNek = MEM_ReadString(MEM_ReadInt(topicNamePtr + zCParSymbol_content_offset));
+    } else {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'CH1_LostNek' not found");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Back up the values
+    var int questStatusBak; questStatusBak = MEM_ReadInt(questStatusPtr);
+    var int topicStatusBak; topicStatusBak = Ninja_G1CP_GetTopicStatus(CH1_LostNek);
+    var int guildTrueBak; guildTrueBak = Npc_GetTrueGuild(hero);
+
+    // Set the variables
+    MEM_WriteInt(questStatusPtr, LOG_SUCCESS);
+    Log_CreateTopic(CH1_LostNek, LOG_MISSION);
+    Log_SetTopicStatus(CH1_LostNek, LOG_SUCCESS);
+    Npc_SetTrueGuild(hero, GIL_NONE);
+
+    // Backup self and other
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);
+    var C_Npc othBak; othBak = MEM_CpyInst(other);
+
+    // Set self and other
+    self  = MEM_CpyInst(hero);
+    other = MEM_CpyInst(hero);
+
+    // Just run the dialog and see what happens
+    MEM_CallByID(funcId);
+
+    // Restore self and other
+    self  = MEM_CpyInst(slfBak);
+    other = MEM_CpyInst(othBak);
+
+    // Stop the output units
+    Npc_ClearAIQueue(hero);
+    AI_StandUpQuick(hero);
+
+    // Check the variables now
+    var int topicStatusAfter; topicStatusAfter = Ninja_G1CP_GetTopicStatus(CH1_LostNek);
+
+    // Restore the variables
+    Npc_SetTrueGuild(hero, guildTrueBak);
+    MEM_WriteInt(questStatusPtr, questStatusBak);
+    if (topicStatusBak == -1) {
+        Ninja_G1CP_RemoveTopic(CH1_LostNek);
+    } else {
+        Log_SetTopicStatus(CH1_LostNek, topicStatusBak);
+    };
+
+    // Confirm the fix
+    if (topicStatusAfter == LOG_RUNNING) {
+        Ninja_G1CP_TestsuiteErrorDetail("Mission 'CH1_LostNek' was wrongfully set to running");
+        passed = FALSE;
+    };
+
+    return passed;
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -21,6 +21,7 @@ Content\Report\reportFuncToSpy.d
 Content\Misc\findInFunc.d
 Content\Misc\aivar.d
 Content\Misc\info.d
+Content\Misc\topic.d
 Content\Misc\Npc_CanSeeVob.d
 
 // Session fixes
@@ -37,6 +38,7 @@ Content\Fixes\Session\fix017_JackalProtectionMoney.d
 Content\Fixes\Session\fix018_BloodwynProtectionMoney.d
 Content\Fixes\Session\fix019_ScorpioFightDialog.d
 Content\Fixes\Session\fix020_KirgoGivesBeer.d
+Content\Fixes\Session\fix021_FletcherClosedQuest.d
 Content\Fixes\Session\fix022_YBerionAttacks.d
 Content\Fixes\Session\fix024_CorKalomWrongQuest.d
 Content\Fixes\Session\fix025_SaturasSellsRobe.d
@@ -70,6 +72,7 @@ Content\Tests\test017.d
 Content\Tests\test018.d
 Content\Tests\test019.d
 Content\Tests\test020.d
+Content\Tests\test021.d
 Content\Tests\test022.d
 Content\Tests\test024.d
 Content\Tests\test025.d


### PR DESCRIPTION
### Description
Fixes #21. Fletch now leaves the quest closed if it is already.

### Test
Run automatic test with `test 21`.

**Not ready for merge:** The German translation of the changelog is missing.
