### PR TITLE
#30: Silas now trades with the player more than once

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
 * Fix #26: Lares' guard now attacks the player instead of repeating himself telling the player to go.
 * Fix #28: Mordrag no longer escorts the player to the New Camp if the player forcibly threw him out of the Old Camp.
 * Fix #29: Buster no longer teaches Acrobatics if the player already gained the skill.
+* Fix #30: Silas now trades with the player more than once.
 * Fix #31: Wolf can't be offered Minecrawler's Armor Plates any longer if the player already gave him the requested amount.
 * Fix #36: Fisk's quest "New Fence for Fisk" is now available regardless of how the quest "Thorus' Quest" is (successfully) completed.
 * Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
@@ -51,6 +52,7 @@
 * Fix #26: Lares' Wache greift den Spieler nun an, statt ihm in einer Dialogschleife zu sagen, er solle verschwinden.
 * Fix #28: Mordrag bringt den Spieler nicht mehr zum Neuen Lager, wenn dieser ihn vorher verprügelt und aus dem Alten Lager vertireben hat.
 * Fix #29: Buster bringt dem Spieler nicht mehr Akrobatik bei, wenn dieser das Talent bereits gelernt hat.
+* Fix #30: Silas handelt mit dem Spieler nun mehr als nur einmal.
 * Fix #31: Wolf können keine Minecrawlerpanzerplatten mehr angeboten werden, wenn der Spieler ihm schon die erforderliche Anzahl gebracht hat.
 * Fix #36: Fisks Quest "Neuer Hehler für Fisk" is nun immer erhältlich, egal, wie Thorus' Quest "Auftrag von Thorus" (erfolgreich) beendet wurde.  
 * Fix #38: Snaf spricht nun auch über Nek, wenn die Quest "Snafs Rezept" abgeschlossen wurde. 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix030_SilasTrade.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix030_SilasTrade.d
@@ -1,0 +1,57 @@
+/*
+ * #30 Silas trades only one time
+ */
+func int Ninja_G1CP_030_SilasTrade() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int symbId; symbId = MEM_FindParserSymbol("DIA_Silas_Trade");
+    var int infoPermSymbId; infoPermSymbId = MEM_FindParserSymbol("C_Info.permanent");
+    if (symbId == -1) || (infoPermSymbId == -1) {
+        return FALSE;
+    };
+
+    // Find "permanent = xxx" in the instance function
+    var int s; s = SB_New();
+    SBc(zPAR_TOK_PUSHVAR); SBw(infoPermSymbId);
+    SBc(zPAR_OP_IS);
+    var int matches; matches = Ninja_G1CP_FindInFunc(symbId, SB_GetStream(), SB_Length());
+    SB_Destroy();
+
+    // Iterate over all matches
+    repeat(i, MEM_ArraySize(matches)); var int i;
+        var int pos; pos = MEM_ArrayRead(matches, i);
+
+        // Check context: permanent = 0 or to symbol containing 0
+        if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHVAR) {
+            var int varId; varId = MEM_ReadInt(pos-4);
+            if (varId <= 0) && (varId >= currSymbolTableLength) {
+                continue;
+            };
+            var int varSymbPtr; varSymbPtr = MEM_GetSymbolByIndex(varId);
+            if (!varSymbPtr) {
+                continue;
+            };
+            if (MEM_ReadInt(varSymbPtr + zCParSymbol_content_offset) != 0) {
+                continue;
+            };
+        } else if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHINT) {
+            if (MEM_ReadInt(pos-4) != 0) {
+                continue;
+            };
+        } else {
+            continue;
+        };
+
+        // Overwrite "permanent = 0" with "permanent = 1"
+        MEM_WriteByte(pos-5, zPAR_TOK_PUSHINT);
+        MEM_WriteInt(pos-4, 1);
+
+        applied += 1;
+    end;
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -27,6 +27,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_026_LaresGuardAttacks();                             // #26
         Ninja_G1CP_028_MordragNoEscort();                               // #28
         Ninja_G1CP_029_BusterAcrobatics();                              // #29
+        Ninja_G1CP_030_SilasTrade();                                    // #30
         Ninja_G1CP_031_WolfPlateDialog();                               // #31
         Ninja_G1CP_036_FiskFenceQuest();                                // #36
         Ninja_G1CP_038_SnafDialogNek();                                 // #38

--- a/src/Ninja/G1CP/Content/Tests/test030.d
+++ b/src/Ninja/G1CP/Content/Tests/test030.d
@@ -1,0 +1,44 @@
+/*
+ * #30 Silas trades only one time
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: Silas can trade multiple times.
+ */
+func void Ninja_G1CP_Test_030() {
+    if (!Ninja_G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if the dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("DIA_Silas_Trade");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Info 'DIA_Silas_Trade' not found");
+        passed = FALSE;
+    };
+
+    // Find Silas
+    var int symbId; symbId = MEM_FindParserSymbol("Org_841_Silas");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'Org_841_Silas' not found");
+        return;
+    };
+
+    // Check if Silas exists in the world
+    var C_Npc silas; silas = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(silas)) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'Org_841_Silas' not valid");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return;
+    };
+
+    // Teleport the hero to Silas
+    AI_Teleport(hero, silas.wp);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -43,6 +43,7 @@ Content\Fixes\Session\fix025_SaturasSellsRobe.d
 Content\Fixes\Session\fix026_LaresGuardAttacks.d
 Content\Fixes\Session\fix028_MordragNoEscort.d
 Content\Fixes\Session\fix029_BusterAcrobatics.d
+Content\Fixes\Session\fix030_SilasTrade.d
 Content\Fixes\Session\fix031_WolfPlateDialog.d
 Content\Fixes\Session\fix036_FiskFenceQuest.d
 Content\Fixes\Session\fix038_SnafDialogNek.d
@@ -76,6 +77,7 @@ Content\Tests\test025.d
 Content\Tests\test026.d
 Content\Tests\test028.d
 Content\Tests\test029.d
+Content\Tests\test030.d
 Content\Tests\test031.d
 Content\Tests\test036.d
 Content\Tests\test038.d


### PR DESCRIPTION
### Description
Fixes #30. It turns out, this fix does not impact game saves (i.e. does not have to be reverted and reapplied). That made it much easier.

### Test
Run manual test with `test 30`. The test requires to check manually if Silas now offers to trade more than once.
