### PR TITLE
#78: Humans recognize orcs as enemies

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,7 @@
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #59: Vendors don't re-equip their weapon when the player sells them a more powerful one. However, due to important game mechanics, they will still equip a weapon if they didn't have a weapon of that type (meelee, ranged) equipped before.
 * Fix #60: Jesse's quest is now available.
+* Fix #78: Human NPCs now correctly recognize orcs as enemies. This fixes Baal Lukor's behavior in the orc graveyard.
 * Fix #79: Wolf now only trains dexterity if the player is part of the New Camp.
 
 ## DE
@@ -63,4 +64,5 @@
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.
 * Fix #59: Händler rüsten nicht mehr ihre Waffe um, wenn der Spieler ihnen eine stärkere verkauft. Aufgrund einer wichtigen Spielmechanik wird allerdings eine Waffe ausgerüstet, sofern der Händler vorher noch keine Waffe diese Art (Nahkampf, Fernkampf) ausgerüstet hatte.
 * Fix #60: Jesses Quest ist nun verfügbar.
+* Fix #78: Menschliche NPCs erkennen Orks nun als Gegner an. Damit ist Baal Lukors Wahrnehmung im Orkfriedhof korrigiert.
 * Fix #79: Wolf lehrt nun nur dann Geschicklichkeit, wenn der Spieler teil des Neuen Lagers ist.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix078_HumanAttackOrc.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix078_HumanAttackOrc.d
@@ -1,0 +1,40 @@
+/*
+ * #78 Humans don't recognise orcs as monsters
+ */
+func int Ninja_G1CP_078_HumanAttackOrc() {
+    var int funcId;   funcId   = MEM_FindParserSymbol("C_NpcIsDangerousMonster");
+    var int needleId; needleId = MEM_FindParserSymbol("C_NpcIsMonster");
+    var int isOrcId;  isOrcId  = MEM_FindParserSymbol("C_NpcIsOrc");
+    var int replacId; replacId = MEM_GetFuncId(Ninja_G1CP_078_IsMonsterOrOrc);
+
+    if (funcId != -1) && (needleId != -1) && (isOrcId != -1) {
+        var int count; count = Ninja_G1CP_ReplaceCallInFunc(funcId, needleId, replacId);
+        return (count > 0);
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts all calls to "C_NpcIsMonster" in "C_NpcIsDangerousMonster"
+ */
+func int Ninja_G1CP_078_IsMonsterOrOrc(var C_Npc slf) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // These functions are confirmed to exist by the above function
+
+    // Original function call
+    var int cond1;
+    MEM_PushInstParam(slf);
+    MEM_CallByString("C_NpcIsMonster");
+    cond1 = MEM_PopIntResult();
+
+    // Additional condition
+    var int cond2;
+    MEM_PushInstParam(slf);
+    MEM_CallByString("C_NpcIsOrc");
+    cond2 = MEM_PopIntResult();
+
+    // Sneak in an additional condition
+    return (cond1) || (cond2);
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -37,6 +37,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_049_DungeonKeyText();                                // #49
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
         Ninja_G1CP_060_JesseQuest();                                    // #60
+        Ninja_G1CP_078_HumanAttackOrc();                                // #78
         Ninja_G1CP_079_WolfDexDialog();                                 // #79
         Ninja_G1CP_InitEnd();
     };

--- a/src/Ninja/G1CP/Content/Tests/test078.d
+++ b/src/Ninja/G1CP/Content/Tests/test078.d
@@ -1,0 +1,138 @@
+/*
+ * #78 Humans don't recognise orcs as monsters
+ *
+ * A human NPC, an orc warrior and an orc slave are inserted
+ *
+ * Expected behavior: The human NPC will attack the orc warrior (before the orc attacks), but leaves the orc slave alone
+ */
+
+/* Strength of the player */
+const int Ninja_G1CP_Test_078_HeroStrengthBak = 0;
+
+/*
+ * Test function
+ */
+func void Ninja_G1CP_Test_078() {
+    if (!Ninja_G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Check for orc warrior and orc slave
+    var int warriorId; warriorId = MEM_FindParserSymbol("OrcWarrior1");
+    if (warriorId == -1)  {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'OrcWarrior1' not found");
+        return;
+    };
+    var int slaveId; slaveId = MEM_FindParserSymbol("OrcSlave");
+    if (slaveId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'OrcSlave' not found");
+        return;
+    };
+
+    // Check for Ulumulu
+    var int ulumuluId; ulumuluId = MEM_FindParserSymbol("UluMulu");
+    if (ulumuluId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'UluMulu' not found");
+    };
+
+    // Require perceptions
+    var int percId; percId = MEM_FindParserSymbol("B_AssessEnemy");
+    if (percId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Function 'B_AssessEnemy' not found");
+    };
+
+    // Insert test NPC
+    var string wp; wp = Npc_GetNearestWP(hero);
+    Wld_InsertNpc(Ninja_G1CP_Test_078_Npc, wp);
+    var C_Npc test; test = Hlp_GetNpc(Ninja_G1CP_Test_078_Npc);
+    if (!Hlp_IsValidNpc(test)) {
+        Ninja_G1CP_TestsuiteErrorDetail("Failed to insert NPC");
+        return;
+    };
+
+    // Insert the orcs
+    wp = Npc_GetNextWP(hero);
+    Wld_InsertNpc(warriorId, wp);
+    test = Hlp_GetNpc(warriorId);
+    if (!Hlp_IsValidNpc(test)) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'OrcWarrior1' failed to insert");
+        return;
+    };
+    Wld_InsertNpc(slaveId, wp);
+    test = Hlp_GetNpc(slaveId);
+    if (!Hlp_IsValidNpc(test)) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'OrcSlave' failed to insert");
+        return;
+    };
+
+    // Give Ulumulu to player (enough strength too)
+    const int ATR_STRENGTH = 4;
+    Ninja_G1CP_Test_078_HeroStrengthBak = hero.attribute[ATR_STRENGTH];
+    if (hero.attribute[ATR_STRENGTH] < 100) {
+        hero.attribute[ATR_STRENGTH] = 100;
+    };
+    CreateInvItem(hero, ulumuluId);
+    EquipWeapon(hero, ulumuluId);
+};
+
+
+/*
+ * The actual test will run through the NPC's AI state (see below)
+ */
+instance Ninja_G1CP_Test_078_Npc(C_Npc) {
+    name          = "Test 78";
+    level         = 2000; // No coward
+    attribute[0]  = 2000;
+    attribute[1]  = 2000;
+    attribute[4]  = 1000; // Enough strength to carry any weapon
+    start_aistate = ZS_Ninja_G1CP_Test_078_NpcRountine;
+    fight_tactic  = 4; // FAI_HUMAN_MASTER
+    senses        = 7;
+    senses_range  = 4000;
+    Mdl_SetVisual(self, "HUMANS.MDS");
+    Mdl_SetVisualBody(self, "HUM_BODY_NAKED0", 1, 1, "Hum_Head_Fighter", 1, 1, -1);
+    EquipItem(self, MEM_FindParserSymbol("Scars_Schwert"));
+};
+
+
+/*
+ * AI state is stared once the NPC is properly inserted
+ */
+func void ZS_Ninja_G1CP_Test_078_NpcRountine() {
+    // Define possibly missing symbols locally
+    const int PERC_ASSESSENEMY = 2;
+
+    // Npc_PercEnable(self, PERC_ASSESSENEMY, B_AssessEnemy);
+    MEM_PushInstParam(self);
+    PERC_ASSESSENEMY;
+    MEM_FindParserSymbol("B_AssessEnemy");
+    MEM_Call(Npc_PercEnable);
+
+    Npc_SetPercTime(self, 0.5);
+};
+func int  ZS_Ninja_G1CP_Test_078_NpcRountine_Loop() {
+    var int detected;
+    if (Npc_GetStateTime(self) < 3) || (!detected) {
+        detected = FALSE;
+        Npc_PerceiveAll(self);
+        if (Wld_DetectNpc(self, MEM_FindParserSymbol("OrcWarrior1"), NOFUNC, -1)) {
+            if (Npc_CanSeeNpc(self, other)) {
+                detected = TRUE;
+            } else {
+                AI_TurnToNpc(self, other);
+            };
+        };
+    } else if (detected) {
+        return 1;
+    };
+    return 0;
+};
+func void ZS_Ninja_G1CP_Test_078_NpcRountine_End() {
+    // Delete the NPCs once done
+    MEM_WriteInt(_@(self.bodymass)+8, 0); // Clear start_aistate
+    AI_Function_I(hero, Wld_RemoveNpc, Ninja_G1CP_Test_078_Npc);
+    Wld_RemoveNpc(MEM_FindParserSymbol("OrcWarrior1"));
+    Wld_RemoveNpc(MEM_FindParserSymbol("OrcSlave"));
+    Npc_RemoveInvItem(hero, MEM_FindParserSymbol("UluMulu"));
+    hero.attribute[ATR_STRENGTH] = Ninja_G1CP_Test_078_HeroStrengthBak;
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -54,6 +54,7 @@ Content\Fixes\Session\fix043_EN_SkillMissingWhitespace.d
 Content\Fixes\Session\fix049_DungeonKeyText.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 Content\Fixes\Session\fix060_JesseQuest.d
+Content\Fixes\Session\fix078_HumanAttackOrc.d
 Content\Fixes\Session\fix079_WolfDexDialog.d
 
 // Game save fixes
@@ -90,6 +91,7 @@ Content\Tests\test049.d
 Content\Tests\test050.d
 Content\Tests\test059.d
 Content\Tests\test060.d
+Content\Tests\test078.d
 Content\Tests\test079.d
 
 // Initialization


### PR DESCRIPTION
### Description
Fixes #78. Human NPCs now recognize orcs as enemies. This should fix the quest in the orc grave yard.

### Test
Run manual test with `test 78`.

Additionally to the test suite, the fix should be check with Baal Lukor in the orc grave yard. I have not done that yet.
