### PR TITLE
#39: Fix Fingers teaching dialog choices

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,7 @@
 * Fix #31: Wolf can't be offered Minecrawler's Armor Plates any longer if the player already gave him the requested amount.
 * Fix #36: Fisk's quest "New Fence for Fisk" is now available regardless of how the quest "Thorus' Quest" is (successfully) completed.
 * Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
+* Fix #39: Fingers no longer offers to teach level two of pickpocketing and lock picking before level one has been learned.
 * Fix #40: Aleph doesn't offer to sell the key anymore when the player already obtained it.
 * Fix #43: The dialog choices about learning skills now contain proper whitespace.
 * Fix #49: The description of the dungeon key is corrected to "Opens the dungeons of the old camp.".
@@ -58,6 +59,7 @@
 * Fix #31: Wolf können keine Minecrawlerpanzerplatten mehr angeboten werden, wenn der Spieler ihm schon die erforderliche Anzahl gebracht hat.
 * Fix #36: Fisks Quest "Neuer Hehler für Fisk" is nun immer erhältlich, egal, wie Thorus' Quest "Auftrag von Thorus" (erfolgreich) beendet wurde.  
 * Fix #38: Snaf spricht nun auch über Nek, wenn die Quest "Snafs Rezept" abgeschlossen wurde. 
+* Fix #39: Fingers bringt dem Spieler nicht mehr Taschendiebstahl und Schlösserknacken auf Stufe zwei bei, wenn Stufe eins jeweils noch nicht gelernt wurde.
 * Fix #40: Aleph bietet den Schlüssel nun nicht noch einmal an, wenn der Spieler ihn schon erhalten hat.
 * Fix #49: Die Beschreibung des Kerkerschlüssels ist korrigiert zu "öffnet den Kerker des Alten Lagers.".
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix039_FingersTeachDialog.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix039_FingersTeachDialog.d
@@ -1,0 +1,70 @@
+/*
+ * #39 Fingers teaches advanced skills too soon
+ */
+func int Ninja_G1CP_039_FingersTeachDialog() {
+    // Check if all necessary symbols exist
+    var int funcId;  funcId  = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Info");
+    var int cond1Id; cond1Id = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Pickpocket2");
+    var int cond2Id; cond2Id = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Pickpocket");
+    var int cond3Id; cond3Id = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Lockpick2");
+    var int cond4Id; cond4Id = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Lockpick");
+    var int cond5Id; cond5Id = MEM_FindParserSymbol("NPC_TALENT_PICKPOCKET");
+    var int cond6Id; cond6Id = MEM_FindParserSymbol("NPC_TALENT_PICKLOCK");
+    if (cond1Id == -1) || (cond2Id == -1) || (cond3Id == -1)
+    || (cond4Id == -1) || (cond5Id == -1) || (cond6Id == -1) || (funcId == -1) {
+        return FALSE;
+    };
+
+    // Get the symbol indices of the functions
+    var int addChoiceId; addChoiceId = MEM_GetFuncId(Info_AddChoice);
+    var int interceptId; interceptId = MEM_GetFuncId(Ninja_G1CP_039_AllowAddChoice);
+
+    // Replace all function calls to "Info_AddChoice"
+    return Ninja_G1CP_ReplaceCallInFunc(funcId, addChoiceId, interceptId) > 0;
+};
+
+/*
+ * Intercept any calls to "Info_AddChoice" in "DIA_Fingers_Lehrer_Info"
+ */
+func void Ninja_G1CP_039_AllowAddChoice(var int dia, var string choice, var int fncId) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Get the necessary symbols (existence verified by function above)
+    const int diaId = -1;
+    const int pp2Id = -1;
+    const int pp1Id = -1;
+    const int lp2Id = -1;
+    const int lp1Id = -1;
+    const int NPC_TALENT_PICKPOCKET = -1;
+    const int NPC_TALENT_PICKLOCK   = -1;
+    if (diaId == -1) {
+        diaId = MEM_FindParserSymbol("DIA_Fingers_Lehrer");
+        pp2Id = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Pickpocket2");
+        pp1Id = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Pickpocket");
+        lp2Id = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Lockpick2");
+        lp1Id = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Lockpick");
+        NPC_TALENT_PICKPOCKET = MEM_ReadInt(MEM_GetSymbol("NPC_TALENT_PICKPOCKET") + zCParSymbol_content_offset);
+        NPC_TALENT_PICKLOCK = MEM_ReadInt(MEM_GetSymbol("NPC_TALENT_PICKLOCK") + zCParSymbol_content_offset);
+    };
+
+    // Sanity check
+    if (dia == diaId) {
+        // Add choices only when matching skill
+        if (fncId == pp2Id) && (Npc_GetTalentSkill(hero, NPC_TALENT_PICKPOCKET) != 1) {
+            return;
+        } else if (fncId == pp1Id) && (Npc_GetTalentSkill(hero, NPC_TALENT_PICKPOCKET) != 0) {
+            return;
+        } else if (fncId == lp2Id) && (Npc_GetTalentSkill(hero, NPC_TALENT_PICKLOCK) != 1) {
+            return;
+        } else if (fncId == lp1Id) && (Npc_GetTalentSkill(hero, NPC_TALENT_PICKLOCK) != 0) {
+            return;
+        };
+    };
+
+    // Otherwise proceed
+    // Info_AddChoice(dia, choice, fncId);
+    MEM_PushIntParam(dia);
+    MEM_PushStringParam(choice);
+    MEM_PushIntParam(fncId); // Cannot re-push function correctly
+    MEM_Call(Info_AddChoice);
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -32,6 +32,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_031_WolfPlateDialog();                               // #31
         Ninja_G1CP_036_FiskFenceQuest();                                // #36
         Ninja_G1CP_038_SnafDialogNek();                                 // #38
+        Ninja_G1CP_039_FingersTeachDialog();                            // #39
         Ninja_G1CP_040_AlephKeyDialog();                                // #40
         Ninja_G1CP_043_EN_SkillMissingWhitespace();                     // #43
         Ninja_G1CP_049_DungeonKeyText();                                // #49

--- a/src/Ninja/G1CP/Content/Tests/test039.d
+++ b/src/Ninja/G1CP/Content/Tests/test039.d
@@ -1,0 +1,55 @@
+/*
+ * #39 Fingers teaches advanced skills too soon
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: The hero is merely teleported to Fletcher, the available dialog choices should match the skills.
+ */
+func void Ninja_G1CP_Test_039() {
+    if (!Ninja_G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("DIA_Fingers_Lehrer_Info");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'DIA_Fingers_Lehrer_Info' not found");
+        passed = FALSE;
+    };
+
+    // Find Fingers
+    var int symbId; symbId = MEM_FindParserSymbol("STT_331_Fingers");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'STT_331_Fingers' not found");
+        passed = FALSE;
+    };
+
+    // Check if Fingers exists in the world
+    var C_Npc fingers; fingers = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(fingers)) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'STT_331_Fingers' not valid");
+        passed = FALSE;
+    };
+
+    // Check if variable exists
+    var int canTeachPtr; canTeachPtr = MEM_GetSymbol("Fingers_CanTeach");
+    if (!canTeachPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'Fingers_CanTeach' not found");
+        passed = FALSE;
+    };
+    canTeachPtr += zCParSymbol_content_offset;
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return;
+    };
+
+    // Set unlock the dialog
+    MEM_WriteInt(canTeachPtr, TRUE);
+
+    // Teleport the hero to Silas
+    AI_Teleport(hero, fingers.wp);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -49,6 +49,7 @@ Content\Fixes\Session\fix030_SilasTrade.d
 Content\Fixes\Session\fix031_WolfPlateDialog.d
 Content\Fixes\Session\fix036_FiskFenceQuest.d
 Content\Fixes\Session\fix038_SnafDialogNek.d
+Content\Fixes\Session\fix039_FingersTeachDialog.d
 Content\Fixes\Session\fix040_AlephKeyDialog.d
 Content\Fixes\Session\fix043_EN_SkillMissingWhitespace.d
 Content\Fixes\Session\fix049_DungeonKeyText.d
@@ -84,6 +85,7 @@ Content\Tests\test030.d
 Content\Tests\test031.d
 Content\Tests\test036.d
 Content\Tests\test038.d
+Content\Tests\test039.d
 Content\Tests\test040.d
 Content\Tests\test043.d
 Content\Tests\test049.d


### PR DESCRIPTION
### Description
Fixes #39. Fingers now teaches according to the players skill

### Test
Run manual test with `test 39`. This test is very tedious. The player is only teleported to Fingers and the dialog unlocked. To test, the user has to learn all the skills (use `insert ch` to get enough learning points) and check if the dialog choices appear according to the player's skill.
