### PR TITLE
#42: Remove duplicate EXIT dialog from guards

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,7 @@
 * Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
 * Fix #39: Fingers no longer offers to teach level two of pickpocketing and lock picking before level one has been learned.
 * Fix #40: Aleph doesn't offer to sell the key anymore when the player already obtained it.
+* Fix #42: Two guards in the Old Camp no longer have two END dialog options.
 * Fix #43: The dialog choices about learning skills now contain proper whitespace.
 * Fix #49: The description of the dungeon key is corrected to "Opens the dungeons of the old camp.".
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
@@ -62,6 +63,7 @@
 * Fix #38: Snaf spricht nun auch über Nek, wenn die Quest "Snafs Rezept" abgeschlossen wurde. 
 * Fix #39: Fingers bringt dem Spieler nicht mehr Taschendiebstahl und Schlösserknacken auf Stufe zwei bei, wenn Stufe eins jeweils noch nicht gelernt wurde.
 * Fix #40: Aleph bietet den Schlüssel nun nicht noch einmal an, wenn der Spieler ihn schon erhalten hat.
+* Fix #42: Zwei Gardisten des Alten Lagers haben nun nicht mehr zwei ENDE Dialogoptionen.
 * Fix #49: Die Beschreibung des Kerkerschlüssels ist korrigiert zu "öffnet den Kerker des Alten Lagers.".
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.
 * Fix #59: Händler rüsten nicht mehr ihre Waffe um, wenn der Spieler ihnen eine stärkere verkauft. Aufgrund einer wichtigen Spielmechanik wird allerdings eine Waffe ausgerüstet, sofern der Händler vorher noch keine Waffe diese Art (Nahkampf, Fernkampf) ausgerüstet hatte.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix042_GuardExitDialog.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix042_GuardExitDialog.d
@@ -1,0 +1,97 @@
+/*
+ * #42 Guards have duplicated END dialog
+ */
+
+/*
+ * Check the content of a given function against: { return 1; }
+ */
+func int Ninja_G1CP_042_ConfirmByteCode(var int funcId) {
+    if (funcId <= 0) || (funcId >= currSymbolTableLength) {
+        return FALSE;
+    };
+    var zCPar_Symbol symb; symb = _^(MEM_GetSymbolByIndex(funcId));
+    var int pos; pos = symb.content + currParserStackAddress;
+
+    // Ends with return
+    if (MEM_ReadByte(pos+5) == zPAR_TOK_RET) {
+        // And pushes a non-zero value onto the stack
+        if (MEM_ReadByte(pos) == zPAR_TOK_PUSHINT) && (MEM_ReadInt(pos+1) != 0) {
+            return TRUE;
+        } else if (MEM_ReadByte(pos) == zPAR_TOK_PUSHVAR) {
+            // If it's a variable, check it's contents instead
+            var int varId; varId = MEM_ReadInt(pos+1);
+            if (varId > 0) && (varId < currSymbolTableLength) {
+                var int varSymbPtr; varSymbPtr = MEM_GetSymbolByIndex(varId);
+                if (varSymbPtr) {
+                    return (MEM_ReadInt(varSymbPtr + zCParSymbol_content_offset) != 0);
+                };
+            };
+        };
+    };
+
+    // Not found as expected
+    return FALSE;
+};
+
+/*
+ * The fix function called from initialization
+ *
+ * Usually, to fix the duplicate exit dialog, the exit dialogs of the individual NPCs are deleted. However, the issue
+ * might have been fixed by an underlying mod the other way around, by removing the ambient exit dialog (somehow). To
+ * keep both variants in mind, this fix here works both ways. The condition function of the individual exit dialogs (if
+ * present) is replaced to check if there is another exit dialog (this is only done very roughly based on exit dialogs
+ * we know).
+ */
+func int Ninja_G1CP_042_GuardExitDialog() {
+    var int applied1; applied1 = FALSE;
+    var int applied2; applied2 = FALSE;
+
+    // Find all necessary symbols
+    var int func1Id; func1Id = MEM_FindParserSymbol("DIA_Grd_218_Exit_Condition");
+    var int func2Id; func2Id = MEM_FindParserSymbol("DIA_Grd_245_Exit_Condition");
+
+    if (Ninja_G1CP_042_ConfirmByteCode(func1Id)) {
+        HookDaedalusFuncI(func1Id, MEM_GetFuncId(Ninja_G1CP_042_Grd_218_Cond));
+        applied1 = TRUE;
+    };
+
+    if (Ninja_G1CP_042_ConfirmByteCode(func2Id)) {
+        HookDaedalusFuncI(func2Id, MEM_GetFuncId(Ninja_G1CP_042_Grd_245_Cond));
+        applied2 = TRUE;
+    };
+
+    return (applied1) && (applied2);
+};
+
+/*
+ * The replacement functions with additional conditions
+ */
+func int Ninja_G1CP_042_NewCondition(var C_Npc slf) {
+    // Check all possible ambient guard EXIT dialogs (voices might have changed)
+    var int infoPtr[3];
+    infoPtr[0] = Ninja_G1CP_GetInfo("Info_Grd_6_EXIT");
+    infoPtr[1] = Ninja_G1CP_GetInfo("Info_Grd_7_EXIT");
+    infoPtr[2] = Ninja_G1CP_GetInfo("Info_Grd_13_EXIT");
+
+    // Check if they are assigned to this NPC
+    repeat(i, 3); var int i;
+        var int ptr; ptr = MEM_ReadStatArr(infoPtr, i);
+        if (ptr) {
+            var oCInfo info; info = _^(ptr);
+            if (info.npc == Hlp_GetInstanceId(slf)) {
+                return FALSE;
+            };
+        };
+    end;
+
+    // Does not have any exit dialog already: Keep this one
+    return TRUE;
+};
+func int Ninja_G1CP_042_Grd_218_Cond() {
+    Ninja_G1CP_ReportFuncToSpy();
+    return Ninja_G1CP_042_NewCondition(self);
+};
+func int Ninja_G1CP_042_Grd_245_Cond() {
+    Ninja_G1CP_ReportFuncToSpy();
+    return Ninja_G1CP_042_NewCondition(self);
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -34,6 +34,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_038_SnafDialogNek();                                 // #38
         Ninja_G1CP_039_FingersTeachDialog();                            // #39
         Ninja_G1CP_040_AlephKeyDialog();                                // #40
+        Ninja_G1CP_042_GuardExitDialog();                               // #42
         Ninja_G1CP_043_EN_SkillMissingWhitespace();                     // #43
         Ninja_G1CP_049_DungeonKeyText();                                // #49
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59

--- a/src/Ninja/G1CP/Content/Tests/test042.d
+++ b/src/Ninja/G1CP/Content/Tests/test042.d
@@ -1,0 +1,12 @@
+/*
+ * #42 Guards have duplicated END dialog
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: Both guards at the door to the ore barons house should only have one END dialog.
+ */
+func void Ninja_G1CP_Test_042() {
+    if (Ninja_G1CP_TestsuiteAllowManual) {
+        AI_Teleport(hero, "OCC_BARONS_LEFT_GUARD_CHANGE");
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -51,6 +51,7 @@ Content\Fixes\Session\fix036_FiskFenceQuest.d
 Content\Fixes\Session\fix038_SnafDialogNek.d
 Content\Fixes\Session\fix039_FingersTeachDialog.d
 Content\Fixes\Session\fix040_AlephKeyDialog.d
+Content\Fixes\Session\fix042_GuardExitDialog.d
 Content\Fixes\Session\fix043_EN_SkillMissingWhitespace.d
 Content\Fixes\Session\fix049_DungeonKeyText.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
@@ -88,6 +89,7 @@ Content\Tests\test036.d
 Content\Tests\test038.d
 Content\Tests\test039.d
 Content\Tests\test040.d
+Content\Tests\test042.d
 Content\Tests\test043.d
 Content\Tests\test049.d
 Content\Tests\test050.d


### PR DESCRIPTION
### Description
Fixes #42. The guards should now only have one exit dialog

### Test
Run manual test with `test 42`.
