### PR TITLE
#27: Update conditions for Drax to teach

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@
 * Fix #24: Cor Kalom now correctly closes the quest "Taking Weeds to Gomez" instead of "The Weed Monopoly".
 * Fix #25: Saturas no longer offers to sell a High Robe of Water if the player already obtained one.
 * Fix #26: Lares' guard now attacks the player instead of repeating himself telling the player to go.
+* Fix #27: Drax no longer teaches hunting skills before the player has given him a beer.
 * Fix #28: Mordrag no longer escorts the player to the New Camp if the player forcibly threw him out of the Old Camp.
 * Fix #29: Buster no longer teaches Acrobatics if the player already gained the skill.
 * Fix #30: Silas now trades with the player more than once.
@@ -54,6 +55,7 @@
 * Fix #24: Cor Kalom schließt nun korrekterweise die Quest "Kraut zu Gomez bringen" statt "Das Krautmonopol".
 * Fix #25: Saturas bietet nun keine Große Wasserrobe mehr an, wenn der Spieler bereits eine erworben hat.
 * Fix #26: Lares' Wache greift den Spieler nun an, statt ihm in einer Dialogschleife zu sagen, er solle verschwinden.
+* Fix #27: Drax bringt dem Spieler nicht mehr Jagdtalente bei bevor dieser ihm nicht ein Bier spendiert hat.
 * Fix #28: Mordrag bringt den Spieler nicht mehr zum Neuen Lager, wenn dieser ihn vorher verprügelt und aus dem Alten Lager vertireben hat.
 * Fix #29: Buster bringt dem Spieler nicht mehr Akrobatik bei, wenn dieser das Talent bereits gelernt hat.
 * Fix #30: Silas handelt mit dem Spieler nun mehr als nur einmal.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix027_DraxTeachingDialog.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix027_DraxTeachingDialog.d
@@ -1,0 +1,117 @@
+/*
+ * #27 Drax requires no beer for teaching hunting skills
+ *
+ * What this fix does:
+ * 1. Check if "zCPar_TOK_PUSHVAR  drax_Lehrer_frei" is in "Org_819_Drax_Scavenger_Info"
+ * 2. If yes, replace the "zCPar_TOK_PUSH..." before by a function call to return TRUE or the value itself
+ * 3. If yes, replace the function call "Log_CreateTopic" in "Org_819_Drax_Scavenger_Info" by a function
+ *    that checks for "LOG_NOTE" and does the same check as above
+ * 4. Optionally (if exists) replace the function call "B_LogEntry" to avoid a screen print (does not affect success)
+ */
+func int Ninja_G1CP_027_DraxTeachingDialog() {
+    var int applied1; applied1 = FALSE;
+    var int applied2; applied2 = FALSE;
+
+    // Get necessary symbol indices
+    var int funcId; funcId = MEM_FindParserSymbol("Org_819_Drax_Scavenger_Info");
+    var int condId; condId = MEM_FindParserSymbol("drax_bierbekommen");
+    var int varSymbId; varSymbId = MEM_FindParserSymbol("drax_Lehrer_frei");
+    if (funcId == -1) || (varSymbId == -1) || (condId == -1) {
+        return FALSE;
+    };
+
+    // Find "drax_Lehrer_frei = xxx" in the dialog function
+    const int bytes[3] = {zPAR_TOK_PUSHVAR<<24, -1, zPAR_OP_IS};
+    bytes[1] = varSymbId;
+    var int matches; matches = Ninja_G1CP_FindInFunc(funcId, _@(bytes)+3, 6);
+
+    // Replace the "xxx" in "drax_Lehrer_frei = xxx"
+    repeat(i, MEM_ArraySize(matches)); var int i;
+        var int pos; pos = MEM_ArrayRead(matches, i);
+        if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHINT) || (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHVAR) {
+            MEM_WriteByte(pos-5, zPAR_TOK_CALL);
+            MEM_WriteInt(pos-4, MEM_GetFuncOffset(Ninja_G1CP_027_SetVar));
+            applied1 = TRUE;
+        };
+    end;
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    // Replace function call "Log_CreateTopic" only if the above bytes were replaced successfully
+    if (applied1) {
+        var int createOldId; createOldId = MEM_GetFuncId(Log_CreateTopic);
+        var int createNewId; createNewId = MEM_GetFuncId(Ninja_G1CP_027_CreateTopic);
+        applied2 = Ninja_G1CP_ReplaceCallInFunc(funcId, createOldId, createNewId);
+    };
+
+    // Optionally replace function call "B_LogEntry" (if exists) for removing the screen print
+    if (applied2) {
+        var int logEntryOld; logEntryOld = MEM_FindParserSymbol("B_LogEntry");
+        var int logEntryNew; logEntryNew = MEM_GetFuncId(Ninja_G1CP_027_TopicEntry);
+        if (logEntryOld != -1) {
+            i = Ninja_G1CP_ReplaceCallInFunc(funcId, logEntryOld, logEntryNew);
+        };
+    };
+
+    // Return true if both operations were successful
+    return (applied1) && (applied2);
+};
+
+/*
+ * Intercept the assignment of "drax_Lehrer_frei"
+ * The fix will only work if "drax_bierbekommen" is assigned BEFORE "drax_Lehrer_frei" (true in the original).
+ */
+func int Ninja_G1CP_027_SetVar() {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Check if the truth value of the variable "drax_bierbekommen" (all symbols exist, confirmed by the function above)
+    if (MEM_ReadInt(MEM_GetSymbol("drax_bierbekommen") + zCParSymbol_content_offset)) {
+        return TRUE; // Teaching unlocked
+    } else {
+        return MEM_ReadInt(MEM_GetSymbol("drax_Lehrer_frei") + zCParSymbol_content_offset); // Variable as before
+    };
+};
+
+/*
+ * Wrapper function for "Log_CreateTopic"
+ * The fix will only work if "drax_bierbekommen" and "drax_Lehrer_frei" are assigned BEFORE (true in the original).
+ */
+func void Ninja_G1CP_027_CreateTopic(var string topic, var int section) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Define possibly missing symbols locally
+    const int LOG_NOTE = 1;
+
+    // Check if both "drax_bierbekommen" and "drax_Lehrer_frei" are true
+    if (section == LOG_NOTE) {
+        if (!MEM_ReadInt(MEM_GetSymbol("drax_bierbekommen") + zCParSymbol_content_offset))
+        || (!MEM_ReadInt(MEM_GetSymbol("drax_Lehrer_frei") + zCParSymbol_content_offset)) {
+            return;
+        };
+    };
+
+    // If allow, pass on the call
+    Log_CreateTopic(topic, section);
+};
+
+/*
+ * Wrapper function for "B_LogEntry"
+ * The entry will only be added if the topic already exists (and is a note)
+ */
+func void Ninja_G1CP_027_TopicEntry(var string topic, var string entry) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Define possibly missing symbols locally
+    const int LOG_NOTE = 1;
+
+    // Check if both topic exists (and is a note)
+    if (Ninja_G1CP_GetTopicSection(topic) != LOG_NOTE) {
+        return;
+    };
+
+    // If allow, pass on the call (symbol's existence is confirmed by the functions above)
+    MEM_PushStringParam(topic);
+    MEM_PushStringParam(entry);
+    MEM_CallByString("B_LogEntry");
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -26,6 +26,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_024_CorKalomWrongQuest();                            // #24
         Ninja_G1CP_025_SaturasSellsRobe();                              // #25
         Ninja_G1CP_026_LaresGuardAttacks();                             // #26
+        Ninja_G1CP_027_DraxTeachingDialog();                            // #27
         Ninja_G1CP_028_MordragNoEscort();                               // #28
         Ninja_G1CP_029_BusterAcrobatics();                              // #29
         Ninja_G1CP_030_SilasTrade();                                    // #30

--- a/src/Ninja/G1CP/Content/Tests/test027.d
+++ b/src/Ninja/G1CP/Content/Tests/test027.d
@@ -1,0 +1,151 @@
+/*
+ * #27 Drax requires no beer for teaching hunting skills
+ *
+ * The dialog function is twice. Once called without the hero having a beer and once with.
+ *
+ * Expected behavior: The variable "drax_Lehrer_frei" is set/not set and log entry is created/not created accordingly.
+ */
+func int Ninja_G1CP_Test_027() {
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("Org_819_Drax_Scavenger_Info");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'Org_819_Drax_Scavenger_Info' not found");
+        passed = FALSE;
+    };
+
+    // Check if the beer item exists
+    var int beerId; beerId = MEM_FindParserSymbol("ItFoBeer");
+    if (beerId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItFoBeer' not found");
+        passed = FALSE;
+    };
+
+    // Get variables
+    var int beerGivenPtr; beerGivenPtr = MEM_GetSymbol("drax_bierbekommen");
+    if (!beerGivenPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'drax_bierbekommen' not found");
+        passed = FALSE;
+    };
+    beerGivenPtr += zCParSymbol_content_offset;
+    var int teachingPtr; teachingPtr = MEM_GetSymbol("drax_Lehrer_frei");
+    if (!teachingPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'drax_Lehrer_frei' not found");
+        passed = FALSE;
+    };
+    teachingPtr += zCParSymbol_content_offset;
+
+    // Obtain log topic name
+    var string GE_TeacherOW;
+    var int topicNamePtr; topicNamePtr = MEM_GetSymbol("GE_TeacherOW");
+    if (topicNamePtr) {
+        GE_TeacherOW = MEM_ReadString(MEM_ReadInt(topicNamePtr + zCParSymbol_content_offset));
+    } else {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'GE_TeacherOW' not found");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Rename the log topic if it already exists
+    const string tempTopicName = "Ninja G1CP Test 27"; // Has to be a unique name with absolute certainty
+    Ninja_G1CP_RenameTopic(GE_TeacherOW, tempTopicName);
+
+    // Backup values
+    var int beersBefore; beersBefore = Npc_HasItems(hero, beerId);
+    var int beerGivenBak; beerGivenBak = MEM_ReadInt(beerGivenPtr);
+    var int teachingBak; teachingBak = MEM_ReadInt(teachingPtr);
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);
+    var C_Npc othBak; othBak = MEM_CpyInst(other);
+
+    // Backup self and other
+    self  = MEM_CpyInst(hero);
+    other = MEM_CpyInst(hero);
+
+    // Do two passes
+    var int pass1passed;
+    var int pass2passed;
+    var int topicCreated;
+    var int teachingUnlocked;
+
+    // First pass: No beer, variable should remain false and log entry not created
+
+    // Set variables
+    if (beersBefore > 0) {
+        Npc_RemoveInvItems(hero, beerId, beersBefore);
+    };
+    MEM_WriteInt(beerGivenPtr, FALSE);
+    MEM_WriteInt(teachingPtr, FALSE);
+
+    // Just run the dialog and see what happens
+    MEM_CallByID(funcId);
+
+    // Stop the output units
+    Npc_ClearAIQueue(hero);
+    AI_StandUpQuick(hero);
+
+    // Check the variable and log topic
+    topicCreated = Ninja_G1CP_GetTopic(GE_TeacherOW) != 0;
+    teachingUnlocked = MEM_ReadInt(teachingPtr);
+    if (topicCreated) {
+        Ninja_G1CP_TestsuiteErrorDetail("Log note 'GE_TeacherOW' was wrongfully created");
+    };
+    if (teachingUnlocked) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'drax_Lehrer_frei' was wrongfully set to true");
+    };
+    pass1passed = (!topicCreated) && (!teachingUnlocked);
+
+    // Remove possibly created log topic
+    Ninja_G1CP_RemoveTopic(GE_TeacherOW);
+
+    // Second pass: Has beer, variable should be set to true and log entry should be created
+
+    // Set variables
+    CreateInvItem(hero, beerId);
+    MEM_WriteInt(beerGivenPtr, FALSE);
+    MEM_WriteInt(teachingPtr, FALSE);
+
+    // Just run the dialog and see what happens
+    MEM_CallByID(funcId);
+
+    // Stop the output units
+    Npc_ClearAIQueue(hero);
+    AI_StandUpQuick(hero);
+
+    // Check the variable and log topic
+    topicCreated = Ninja_G1CP_GetTopic(GE_TeacherOW) != 0;
+    teachingUnlocked = MEM_ReadInt(teachingPtr);
+    if (!topicCreated) {
+        Ninja_G1CP_TestsuiteErrorDetail("Log note 'GE_TeacherOW' was not created");
+    };
+    if (!teachingUnlocked) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'drax_Lehrer_frei' was not set to true");
+    };
+    pass2passed = (topicCreated) && (teachingUnlocked);
+
+    // Remove possibly created log topic and remove any beers
+    Ninja_G1CP_RemoveTopic(GE_TeacherOW);
+    Npc_RemoveInvItems(hero, beerId, Npc_HasItems(hero, beerId));
+
+    // Clean up
+
+    // Restore self and other
+    self  = MEM_CpyInst(slfBak);
+    other = MEM_CpyInst(othBak);
+
+    // Revert values
+    MEM_WriteInt(teachingPtr, teachingBak);
+    MEM_WriteInt(beerGivenPtr, beerGivenBak);
+    Ninja_G1CP_RenameTopic(tempTopicName, GE_TeacherOW);
+    if (beersBefore > 0) {
+        CreateInvItems(hero, beerId, beersBefore);
+    };
+
+    // Confirm the fix
+    return (pass1passed) && (pass2passed);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -43,6 +43,7 @@ Content\Fixes\Session\fix022_YBerionAttacks.d
 Content\Fixes\Session\fix024_CorKalomWrongQuest.d
 Content\Fixes\Session\fix025_SaturasSellsRobe.d
 Content\Fixes\Session\fix026_LaresGuardAttacks.d
+Content\Fixes\Session\fix027_DraxTeachingDialog.d
 Content\Fixes\Session\fix028_MordragNoEscort.d
 Content\Fixes\Session\fix029_BusterAcrobatics.d
 Content\Fixes\Session\fix030_SilasTrade.d
@@ -80,6 +81,7 @@ Content\Tests\test022.d
 Content\Tests\test024.d
 Content\Tests\test025.d
 Content\Tests\test026.d
+Content\Tests\test027.d
 Content\Tests\test028.d
 Content\Tests\test029.d
 Content\Tests\test030.d


### PR DESCRIPTION
### Description
Fixes #27. The teaching dialog is no longer unlocked *and* the log entry is not created, before the player as provided a beer to Drax.

### Test
Run automatic test with `test 27`. Although the automatic test should cover everything, an additional manual confirmation may not hurt.
