### PR TITLE
#11: Fix passage guard reaction for drawn weapon

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 * Fix #7: NPCs no longer practice weapon training without a weapon.
 * Fix #9: NPCs no longer freeze while fleeing.
 * Fix #10: Followers adjust their walking speed according to the player. However, the player must be in sight of the follower if the player starts running after walking.
+* Fix #11: The player can no longer bypass NPCs that are guarding a passage by drawing the weapon.
 * Fix #12: The player no longer receives double XP when killing an NPC with a ranged weapon after already beaten the NPC in melee combat.
 * Fix #15: The player doesn't lose Strength as part of the quest "Horatio the Peasant" if he had more than 100 Strength.
 * Fix #16: Thorus can't be bribed if the player has already obtained the permit to pass the guards. Also the option to bribe Thorus disappears after the player has bribed him.
@@ -42,6 +43,7 @@
 * Fix #7: NSCs trainieren nicht mehr ohne eine Waffe in der Hand.
 * Fix #9: NSCs frieren nicht mehr beim Fliehen ein.
 * Fix #10: Begleiter passen ihre Laufgeschwindigkeit dem Spieler an. Der Spieler muss allerdings in Sichtweite des Begleiters sein, wenn er anfängt zu rennen, nachdem er vorher gegangen ist.
+* Fix #11: Der Spieler kann nicht mehr mit gezogener Waffe an Wachen vorbei gelangen.
 * Fix #12: Der Spieler erhält nicht mehr ein zweites Mal Erfahrungspunkte durch Erlegen eines NPC im Fernkampf, wenn dieser zuvor schon im Nahkampf besiegt wurde.
 * Fix #15: Der Spieler verliert keine Stärke mehr im Zuge der Quest "Horatio der Bauer", wenn er vorher mehr als 100 Stärke hatte.
 * Fix #16: Thorus kann nicht mehr bestochen werden, wenn der Spieler bereits Zugang zur Burg hat. Außerdem verschwindet der Bestechen-Dialog, wenn der Spieler ihn bereits bestochen hat.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix011_PassGuardsCombatMode.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix011_PassGuardsCombatMode.d
@@ -1,0 +1,97 @@
+/*
+ * #11 Player can pass guards in combat mode
+ */
+func int Ninja_G1CP_011_PassGuardsCombatMode() {
+    var int applied; applied = FALSE;
+
+    // Check if all necessary symbols exist
+    var int funcId; funcId = MEM_FindParserSymbol("B_AssessFighter");
+    var int checkInfoSymbPtr; checkInfoSymbPtr = MEM_GetSymbol("B_CheckForImportantInfo");
+    if (funcId == -1) || (!checkInfoSymbPtr) {
+        return FALSE;
+    };
+
+    // Get function offsets
+    var int checkInfoOffset; checkInfoOffset = MEM_ReadInt(checkInfoSymbPtr + zCParSymbol_content_offset);
+    var int interceptOffset; interceptOffset = MEM_GetFuncOffset(Ninja_G1CP_011_CheckInfo);
+
+    /* Expected byte code within the function
+        ...
+        zPAR_TOK_JUMPF           +20
+        zPAR_TOK_PUSH...         xxxx
+        zPAR_TOK_PUSH...         xxxx
+        zPAR_TOK_CALL            B_CheckForImportantInfo
+        ...
+    */
+
+    // Search for "B_CheckForImportantInfo(xxxx, xxxx)" in "B_AssessFighter"
+    const int bytes[2] = {zPar_TOK_CALL<<24, -1};
+    bytes[1] = checkInfoOffset;
+    var int matches; matches = Ninja_G1CP_FindInFunc(funcId, _@(bytes)+3, 5);
+
+    // Iterate over all occurrences of "B_CheckForImportantInfo(xxxx, xxxx)"
+    repeat(i, MEM_ArraySize(matches)); var int i;
+        // Check if it is enclosed in an if-block without processing the return value (jumps to immediately after)
+        var int pos; pos = MEM_ArrayRead(matches, i);
+        if (MEM_ReadByte(pos-15) == zPAR_TOK_JUMPF)
+        && (MEM_ReadInt(pos-14)  == pos+5 - currParserStackAddress) {
+            // Now we can almost guarantee that the return value is not popped
+
+            /* Write byte code to wrap the function call in an if-block and return if true
+                if (Ninja_G1CP_011_CheckInfo(xxxx, xxxx)) { // B_CheckForImportantInfo has issues (see below)
+                    return; // Abort the function "B_AssessFighter"
+                } else {
+                    jump to after the original function call // Continue in the function "B_AssessFighter"
+                };
+            */
+            var int ptr; ptr = MEM_Alloc(11);
+            MEMINT_OverrideFunc_Ptr = ptr;
+            MEMINT_OFTokPar(zPAR_TOK_CALL,  interceptOffset);
+            MEMINT_OFTokPar(zPAR_TOK_JUMPF, MEM_ReadInt(pos-14));
+            MEMINT_OFTok(zPAR_TOK_RET);
+
+            // Overwrite the call to jump to the above created byte code
+            MEMINT_OverrideFunc_Ptr = pos;
+            MEMINT_OFTokPar(zPAR_TOK_JUMP, ptr - currParserStackAddress);
+
+            /* The byte code will now look like this
+
+            B_AssessFighter:
+                zPAR_TOK_JUMPF           +20
+                zPAR_TOK_PUSH...         xxxx
+                zPAR_TOK_PUSH...         xxxx
+                zPAR_TOK_JUMP            new byte code
+
+            new byte code:
+                zPAR_TOK_CALL            Ninja_G1CP_011_CheckInfo
+                zPAR_TOK_JUMPF           back to where we came from
+                zPAR_TOK_RET
+            */
+
+            applied = TRUE;
+        };
+    end;
+
+    return applied;
+};
+
+/*
+ * Intercept the call to "B_CheckForImportantInfo" and inject new conditions for guards
+ */
+func int Ninja_G1CP_011_CheckInfo(var C_Npc slf, var C_Npc oth) {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // The original function call to "B_CheckForImportantInfo" has issues with distances to the player:
+    // It triggers a dialog even if the NPC is too far way. Instead, just check for infos (instead of triggering them).
+    var int cond1; cond1 = Npc_CheckInfo(slf, 1);
+
+    // Additional condition: Is the NPC a guard and is the player trespassing?
+    // Npc_IsInState(slf, ZS_GuardPassage)
+    MEM_PushInstParam(slf);
+    MEM_FindParserSymbol("ZS_GuardPassage"); // Cannot push integer
+    MEM_Call(Npc_IsInState);
+    var int cond2; cond2 = (MEM_PopIntResult()) && (Ninja_G1CP_GetAIVar(hero, "AIV_GUARDPASSAGE_STATUS", 0) > 0);
+
+    // Abort "B_AssessFighter" if either condition is met
+    return (cond1) || (cond2);
+};

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix011_PassGuardsCombatMode.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix011_PassGuardsCombatMode.d
@@ -81,9 +81,25 @@ func int Ninja_G1CP_011_PassGuardsCombatMode() {
 func int Ninja_G1CP_011_CheckInfo(var C_Npc slf, var C_Npc oth) {
     Ninja_G1CP_ReportFuncToSpy();
 
+    // Define possibly missing symbols locally
+    const int PERC_ASSESSTALK  = 19;
+    const int PERC_DIST_DIALOG = 0;
+    const int oCNpc__percRange = 9288224; //0x8DBA20
+    PERC_DIST_DIALOG = roundf(MEM_ReadIntArray(oCNpc__percRange, PERC_ASSESSTALK));
+
     // The original function call to "B_CheckForImportantInfo" has issues with distances to the player:
     // It triggers a dialog even if the NPC is too far way. Instead, just check for infos (instead of triggering them).
     var int cond1; cond1 = Npc_CheckInfo(slf, 1);
+
+    // Check if the player is in range to trigger the dialog (a check that is missing in "B_CheckForImportantInfo")
+    if (cond1) {
+        if (Npc_CanSeeNpcFreeLOS(slf, oth)) && (Npc_GetDistToNpc(slf, oth) < PERC_DIST_DIALOG) {
+            // B_CheckForImportantInfo(slf, oth)
+            MEM_PushInstParam(slf);
+            MEM_PushInstParam(oth);
+            MEM_CallByString("B_CheckForImportantInfo");
+        };
+    };
 
     // Additional condition: Is the NPC a guard and is the player trespassing?
     // Npc_IsInState(slf, ZS_GuardPassage)

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -14,6 +14,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_007_PracticeSwordWithWeapon();                       // #7
         Ninja_G1CP_009_FixFlee();                                       // #9
         Ninja_G1CP_010_FollowWalkMode();                                // #10
+        Ninja_G1CP_011_PassGuardsCombatMode();                          // #11
         Ninja_G1CP_012_RangedDoubleXP();                                // #12
         Ninja_G1CP_015_HoratioStrength();                               // #15
         Ninja_G1CP_016_ThorusBribeDialog();                             // #16

--- a/src/Ninja/G1CP/Content/Tests/test011.d
+++ b/src/Ninja/G1CP/Content/Tests/test011.d
@@ -1,0 +1,22 @@
+/*
+ * #11 Player can pass guards in combat mode
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: Guards will now no longer react to drawing a weapon if the player has no access to enter.
+ */
+func void Ninja_G1CP_Test_011() {
+    if (Ninja_G1CP_TestsuiteAllowManual) {
+        // Supply a weapon
+        if (!Npc_HasEquippedWeapon(hero))
+        && (!Npc_HasReadiedWeapon(hero)) {
+            var int weap; weap = MEM_FindParserSymbol("ItMw_1H_Sword_Old_01");
+            if (weap != -1) {
+                CreateInvItem(hero, weap);
+                EquipWeapon(hero, weap);
+            };
+        };
+        // Teleport the player in front of the gate guards
+        AI_Teleport(hero, "OCR_BEHIND_HUT_1");
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -31,6 +31,7 @@ Content\Fixes\Session\fix003_RegainDroppedWeapon.d
 Content\Fixes\Session\fix007_PracticeSwordWithWeapon.d
 Content\Fixes\Session\fix009_FixFlee.d
 Content\Fixes\Session\fix010_FollowWalkMode.d
+Content\Fixes\Session\fix011_PassGuardsCombatMode.d
 Content\Fixes\Session\fix012_RangedDoubleXP.d
 Content\Fixes\Session\fix015_HoratioStrength.d
 Content\Fixes\Session\fix016_ThorusBribeDialog.d
@@ -68,6 +69,7 @@ Content\Tests\test003.d
 Content\Tests\test007.d
 Content\Tests\test009.d
 Content\Tests\test010.d
+Content\Tests\test011.d
 Content\Tests\test012.d
 Content\Tests\test015.d
 Content\Tests\test016.d


### PR DESCRIPTION
### Description
Fixes #11.

The fix [suggested here](../issues/11#issuecomment-757133978) is not really tackling this specific problem of reacting to a drawn weapon, but rather:
1. It disables the reaction for **all** NPCs (not just the guards!) if the player was just warned by a passage guard.
1. It disables the reaction for **any** NPC that has important infos (a dialog)

Here the issues that arise from the above:
1. If the player draws a weapon near any guarded gate, *no* NPC will react. As soon as the player walks a bit away from the gate, NPC would suddenly react. This is a very strange behavior.
2. I first thought this is a very important thing to address: NPCs with important infos should talk to the player even if the weapon is drawn. But it's actually a very bad change. This would trigger dialogs in very inconvenient situations, e.g. in fights. Additionally, if the player draws their weapon and is trapped in a dialog, NPCs around will still wait for the player to remove their weapon. Once the dialog is over, the player is attacked and could not do anything about it.

The suggested fix is, in my opinion, rather problematic.

What I did here is a bit more targeted: The fix is only affecting guards where the player cannot pass - no other NPC.

### Test
Run manual test with `test 11`.
