### PR TITLE
#102: Fix paying ore for Jesse

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,7 +37,7 @@
 * Fix #60: Jesse's quest is now available.
 * Fix #78: Human NPCs now correctly recognize orcs as enemies. This fixes Baal Lukor's behavior in the orc graveyard.
 * Fix #79: Wolf now only trains dexterity if the player is part of the New Camp.
-* Fix #102: The player now correctly loses 10 ore if he chooses to pay for Jesse.
+* Fix #102: The player now correctly loses 10 ore if he chooses to pay protection money for Jesse.
 
 ## DE
 * Fix #1: NSCs wachen nicht mehr sofort auf, nachdem sie ins Bett gegangen sind, sondern bleiben liegen.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,7 @@
 * Fix #60: Jesse's quest is now available.
 * Fix #78: Human NPCs now correctly recognize orcs as enemies. This fixes Baal Lukor's behavior in the orc graveyard.
 * Fix #79: Wolf now only trains dexterity if the player is part of the New Camp.
+* Fix #102: The player now correctly loses 10 ore if he chooses to pay for Jesse.
 
 ## DE
 * Fix #1: NSCs wachen nicht mehr sofort auf, nachdem sie ins Bett gegangen sind, sondern bleiben liegen.
@@ -74,3 +75,4 @@
 * Fix #60: Jesses Quest ist nun verfügbar.
 * Fix #78: Menschliche NPCs erkennen Orks nun als Gegner an. Damit ist Baal Lukors Wahrnehmung im Orkfriedhof korrigiert.
 * Fix #79: Wolf lehrt nun nur dann Geschicklichkeit, wenn der Spieler teil des Neuen Lagers ist.
+* Fix #102: Der Spieler verliert nun tatsächlich 10 Erz, wenn er Schutzgeld für Jesse zahlt.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix102_JesseProtectionMoneyPay.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix102_JesseProtectionMoneyPay.d
@@ -1,11 +1,11 @@
 /*
  * #102 The player doesn't lose ore when paying for Jesse
  */
-func int Ninja_G1CP_102_PayForJesse() {
+func int Ninja_G1CP_102_JesseProtectionMoneyPay() {
     if (MEM_FindParserSymbol("Info_Bloodwyn_PayForJesse_Info") != -1)
     && (MEM_FindParserSymbol("Jesse_PayForMe")                 != -1)
     && (MEM_FindParserSymbol("ItMiNugget")                     != -1) {
-        HookDaedalusFuncS("Info_Bloodwyn_PayForJesse_Info", "Ninja_G1CP_102_PayForJesse_Hook");
+        HookDaedalusFuncS("Info_Bloodwyn_PayForJesse_Info", "Ninja_G1CP_102_JesseProtectionMoneyPay_Hook");
         return TRUE;
     } else {
         return FALSE;
@@ -15,7 +15,7 @@ func int Ninja_G1CP_102_PayForJesse() {
 /*
  * This function intercepts the dialog to introduce more actions
  */
-func void Ninja_G1CP_102_PayForJesse_Hook() {
+func void Ninja_G1CP_102_JesseProtectionMoneyPay_Hook() {
     Ninja_G1CP_ReportFuncToSpy();
 
     // Define possibly missing symbols locally

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix102_PayForJesse.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix102_PayForJesse.d
@@ -1,0 +1,64 @@
+/*
+ * #102 The player doesn't lose ore when paying for Jesse
+ */
+func int Ninja_G1CP_102_PayForJesse() {
+    if (MEM_FindParserSymbol("Info_Bloodwyn_PayForJesse_Info") != -1)
+    && (MEM_FindParserSymbol("Jesse_PayForMe")                 != -1)
+    && (MEM_FindParserSymbol("ItMiNugget")                     != -1) {
+        HookDaedalusFuncS("Info_Bloodwyn_PayForJesse_Info", "Ninja_G1CP_102_PayForJesse_Hook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts the dialog to introduce more actions
+ */
+func void Ninja_G1CP_102_PayForJesse_Hook() {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Define possibly missing symbols locally
+    const int LOG_SUCCESS = 2;
+
+    // Status before
+    var int amountOreBefore;
+    var int topicStatusBefore;
+
+    // Remember how much ore the player has before the dialog
+    var int oreId; oreId = MEM_FindParserSymbol("ItMiNugget");
+    if (oreId != -1) {
+        amountOreBefore = Npc_HasItems(hero, oreId);
+    };
+
+    // Remember the log topic status before the dialog
+    var int topicPtr; topicPtr = MEM_GetSymbol("Jesse_PayForMe");
+    if (topicPtr) {
+        topicPtr += zCParSymbol_content_offset;
+        topicStatusBefore = MEM_ReadInt(topicPtr);
+    };
+
+    // Continue with the original function
+    ContinueCall();
+
+    // Check if the topic was changed to successful, but no ore was deduced
+    if (topicPtr) && (oreId != -1) {
+        var int topicStatusAfter; topicStatusAfter = MEM_ReadInt(topicPtr);
+        if (topicStatusAfter == LOG_SUCCESS) && (topicStatusAfter != topicStatusBefore)
+        && (Npc_HasItems(hero, oreId) == amountOreBefore) {
+            var int funcId; funcId = MEM_FindParserSymbol("B_GiveInvItems");
+            if (funcId != -1) {
+                // B_GiveInvItems(hero, self, ItMiNugget, 10)
+                PassArgumentN(hero);
+                PassArgumentN(self);
+                MEM_PushIntParam(oreId);
+                MEM_PushIntParam(10); // This is a guess!
+                MEM_CallById(funcId);
+            } else {
+                // In case "B_GiveInvItems" does not exist
+                Npc_RemoveInvItems(hero, oreId, 10);
+                CreateInvItems(self, oreId, 10);
+            };
+        };
+    };
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -43,7 +43,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_060_JesseQuest();                                    // #60
         Ninja_G1CP_078_HumanAttackOrc();                                // #78
         Ninja_G1CP_079_WolfDexDialog();                                 // #79
-        Ninja_G1CP_102_PayForJesse();                                   // #102
+        Ninja_G1CP_102_JesseProtectionMoneyPay();                       // #102
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -43,6 +43,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_060_JesseQuest();                                    // #60
         Ninja_G1CP_078_HumanAttackOrc();                                // #78
         Ninja_G1CP_079_WolfDexDialog();                                 // #79
+        Ninja_G1CP_102_PayForJesse();                                   // #102
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test102.d
+++ b/src/Ninja/G1CP/Content/Tests/test102.d
@@ -1,0 +1,151 @@
+/*
+ * #102 The player doesn't lose ore when paying for Jesse
+ *
+ * The dialog function is called (the dialog lines are aborted) twice: Once with enough and once with too little amount
+ * of ore.
+ *
+ * Expected behavior: The player will not give ore on the first pass but on the second one.
+ */
+func int Ninja_G1CP_Test_102() {
+    // Create possibly missing symbols locally
+    const int LOG_RUNNING = 1;
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Find Bloodwyn first
+    var int symbId; symbId = MEM_FindParserSymbol("GRD_233_Bloodwyn");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'GRD_233_Bloodwyn' not found");
+        passed = FALSE;
+    };
+
+    // Check if Bloodwyn exists in the world
+    var C_Npc bloodwyn; bloodwyn = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(bloodwyn)) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'GRD_233_Bloodwyn' not valid");
+        passed = FALSE;
+    };
+
+    // Check if the dialog function exists
+    var int funcId; funcId = MEM_FindParserSymbol("Info_Bloodwyn_PayForJesse_Info");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'Info_Bloodwyn_PayForJesse_Info' not found");
+        passed = FALSE;
+    };
+
+    // Check if the variable exists
+    var int topicPtr; topicPtr = MEM_GetSymbol("Jesse_PayForMe");
+    if (!topicPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'Jesse_PayForMe' not found");
+        passed = FALSE;
+    };
+    topicPtr += zCParSymbol_content_offset;
+
+    // Check if the ore item exists
+    var int oreId; oreId = MEM_FindParserSymbol("ItMiNugget");
+    if (oreId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItMiNugget' not found");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Backup values
+    var int topicBak; topicBak = MEM_ReadInt(topicPtr);
+    var int amountBefore; amountBefore = Npc_HasItems(hero, oreId);
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);
+    var C_Npc othBak; othBak = MEM_CpyInst(other);
+
+    // Remove all ore
+    if (amountBefore > 0) {
+        Npc_RemoveInvItems(hero, oreId, amountBefore);
+    };
+
+    // Set the topic status variable to LOG_RUNNING
+    MEM_WriteInt(topicPtr, LOG_RUNNING);
+
+    // Set self and other
+    self  = MEM_CpyInst(bloodwyn);
+    other = MEM_CpyInst(hero);
+
+    // Two passes
+    var int amountPass1;
+    var int amountPass2;
+    var string msg;
+
+    // First pass: Not enough ore, amount stays the same
+    CreateInvItems(hero, oreId, 8);
+
+    // Just run the dialog and see what happens
+    MEM_CallByID(funcId);
+
+    // Check the amount
+    amountPass1 = Npc_HasItems(hero, oreId);
+    if (amountPass1 > 8) {
+        msg = ConcatStrings("The hero wrongfully payed ", IntToString(8 - amountPass1));
+        msg = ConcatStrings(msg, " ore");
+        Ninja_G1CP_TestsuiteErrorDetail(msg);
+    } else if (amountPass1 < 8) {
+        msg = ConcatStrings("The hero wrongfully received ", IntToString(amountPass1 - 8));
+        msg = ConcatStrings(msg, " ore");
+        Ninja_G1CP_TestsuiteErrorDetail(msg);
+    };
+
+    // Reset
+    if (amountPass1 > 0) {
+        Npc_RemoveInvItems(hero, oreId, amountPass1);
+    };
+    MEM_WriteInt(topicPtr, LOG_RUNNING);
+
+    // Second pass: Enough ore, amount is decrease by 10
+    CreateInvItems(hero, oreId, 20); // Have at least 10 (to see if the amount decreases)
+
+    // Just run the dialog and see what happens
+    MEM_CallByID(funcId);
+
+    // Check the amount
+    amountPass2 = Npc_HasItems(hero, oreId);
+    if (amountPass2 == 20) {
+        Ninja_G1CP_TestsuiteErrorDetail("The hero wrongfully kept all ore");
+    } else if (amountPass2 < 10) {
+        msg = ConcatStrings("The hero wrongfully payed ", IntToString(10 - amountPass2));
+        msg = ConcatStrings(msg, " ore too much");
+        Ninja_G1CP_TestsuiteErrorDetail(msg);
+    } else if (amountPass2 > 20) {
+        msg = ConcatStrings("The hero wrongfully received ", IntToString(amountPass2 - 20));
+        msg = ConcatStrings(msg, " ore");
+        Ninja_G1CP_TestsuiteErrorDetail(msg);
+    } else if (amountPass2 > 10) {
+        msg = ConcatStrings("The hero wrongfully payed ", IntToString(amountPass2 - 10));
+        msg = ConcatStrings(msg, " ore too little");
+        Ninja_G1CP_TestsuiteErrorDetail(msg);
+    };
+
+    // Remove all ore
+    if (amountPass2 > 0) {
+        Npc_RemoveInvItems(hero, oreId, amountPass2);
+    };
+
+    // Restore self and other
+    self  = MEM_CpyInst(slfBak);
+    other = MEM_CpyInst(othBak);
+
+    // Stop the output units
+    Npc_ClearAIQueue(hero);
+    AI_StandUpQuick(hero);
+
+    // Restore any ore
+    if (amountBefore > 0) {
+        CreateInvItems(hero, oreId, amountBefore);
+    };
+
+    // Revert topic status
+    MEM_WriteInt(topicPtr, topicBak);
+
+    // Return success
+    return (amountPass1 == 8) && (amountPass2 == 10);
+};

--- a/src/Ninja/G1CP/Content/Tests/test102.d
+++ b/src/Ninja/G1CP/Content/Tests/test102.d
@@ -13,20 +13,6 @@ func int Ninja_G1CP_Test_102() {
     // Check status of the test
     var int passed; passed = TRUE;
 
-    // Find Bloodwyn first
-    var int symbId; symbId = MEM_FindParserSymbol("GRD_233_Bloodwyn");
-    if (symbId == -1) {
-        Ninja_G1CP_TestsuiteErrorDetail("NPC 'GRD_233_Bloodwyn' not found");
-        passed = FALSE;
-    };
-
-    // Check if Bloodwyn exists in the world
-    var C_Npc bloodwyn; bloodwyn = Hlp_GetNpc(symbId);
-    if (!Hlp_IsValidNpc(bloodwyn)) {
-        Ninja_G1CP_TestsuiteErrorDetail("NPC 'GRD_233_Bloodwyn' not valid");
-        passed = FALSE;
-    };
-
     // Check if the dialog function exists
     var int funcId; funcId = MEM_FindParserSymbol("Info_Bloodwyn_PayForJesse_Info");
     if (funcId == -1) {
@@ -69,7 +55,8 @@ func int Ninja_G1CP_Test_102() {
     MEM_WriteInt(topicPtr, LOG_RUNNING);
 
     // Set self and other
-    self  = MEM_CpyInst(bloodwyn);
+    GetItemHelper();
+    self  = MEM_CpyInst(Item_Helper);
     other = MEM_CpyInst(hero);
 
     // Two passes

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -61,6 +61,7 @@ Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 Content\Fixes\Session\fix060_JesseQuest.d
 Content\Fixes\Session\fix078_HumanAttackOrc.d
 Content\Fixes\Session\fix079_WolfDexDialog.d
+Content\Fixes\Session\fix102_PayForJesse.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d
@@ -102,6 +103,7 @@ Content\Tests\test059.d
 Content\Tests\test060.d
 Content\Tests\test078.d
 Content\Tests\test079.d
+Content\Tests\test102.d
 
 // Initialization
 Content\initOnce.d

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -61,7 +61,7 @@ Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 Content\Fixes\Session\fix060_JesseQuest.d
 Content\Fixes\Session\fix078_HumanAttackOrc.d
 Content\Fixes\Session\fix079_WolfDexDialog.d
-Content\Fixes\Session\fix102_PayForJesse.d
+Content\Fixes\Session\fix102_JesseProtectionMoneyPay.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d


### PR DESCRIPTION
### Description
Fixes #102. The player now loses 10 ore when paying for Jesse.

### Test
Run automatic test with `test 102`.
