### PR TITLE
#109: Pay Bloodwyn later

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,7 @@
 * Fix #60: Jesse's quest is now available.
 * Fix #78: Human NPCs now correctly recognize orcs as enemies. This fixes Baal Lukor's behavior in the orc graveyard.
 * Fix #79: Wolf now only trains dexterity if the player is part of the New Camp.
+* Fix #109: The player now correctly loses 10 ore if he chooses to pay protection money to Bloodwyn later.
 
 ## DE
 * Fix #1: NSCs wachen nicht mehr sofort auf, nachdem sie ins Bett gegangen sind, sondern bleiben liegen.
@@ -74,3 +75,4 @@
 * Fix #60: Jesses Quest ist nun verfügbar.
 * Fix #78: Menschliche NPCs erkennen Orks nun als Gegner an. Damit ist Baal Lukors Wahrnehmung im Orkfriedhof korrigiert.
 * Fix #79: Wolf lehrt nun nur dann Geschicklichkeit, wenn der Spieler teil des Neuen Lagers ist.
+* Fix #109: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Bloodwyn zahlt.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix109_BloodwynProtectionMoneyPayLater.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix109_BloodwynProtectionMoneyPayLater.d
@@ -1,10 +1,10 @@
 /*
  * #109 The player doesn't lose ore when paying protection money to Bloodwyn again
  */
-func int Ninja_G1CP_109_BloodwynProtectionMoneySecond() {
+func int Ninja_G1CP_109_BloodwynProtectionMoneyPayLater() {
     if (MEM_FindParserSymbol("Info_Bloodwyn_PayDay_PayAgain") != -1)
     && (MEM_FindParserSymbol("ItMiNugget")                    != -1) {
-        HookDaedalusFuncS("Info_Bloodwyn_PayDay_PayAgain", "Ninja_G1CP_109_BloodwynProtectionMoneySecond_Hook");
+        HookDaedalusFuncS("Info_Bloodwyn_PayDay_PayAgain", "Ninja_G1CP_109_BloodwynProtectionMoneyPayLater_Hook");
         return TRUE;
     } else {
         return FALSE;
@@ -14,7 +14,7 @@ func int Ninja_G1CP_109_BloodwynProtectionMoneySecond() {
 /*
  * This function intercepts the dialog to introduce more actions
  */
-func void Ninja_G1CP_109_BloodwynProtectionMoneySecond_Hook() {
+func void Ninja_G1CP_109_BloodwynProtectionMoneyPayLater_Hook() {
     Ninja_G1CP_ReportFuncToSpy();
 
     // Remember how much ore the player has before the dialog

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix109_BloodwynProtectionMoneySecond.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix109_BloodwynProtectionMoneySecond.d
@@ -1,0 +1,48 @@
+/*
+ * #109 The player doesn't lose ore when paying protection money to Bloodwyn again
+ */
+func int Ninja_G1CP_109_BloodwynProtectionMoneySecond() {
+    if (MEM_FindParserSymbol("Info_Bloodwyn_PayDay_PayAgain") != -1)
+    && (MEM_FindParserSymbol("ItMiNugget")                    != -1) {
+        HookDaedalusFuncS("Info_Bloodwyn_PayDay_PayAgain", "Ninja_G1CP_109_BloodwynProtectionMoneySecond_Hook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts the dialog to introduce more actions
+ */
+func void Ninja_G1CP_109_BloodwynProtectionMoneySecond_Hook() {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Remember how much ore the player has before the dialog
+    var int amountOreBefore;
+    var int oreId; oreId = MEM_FindParserSymbol("ItMiNugget");
+    if (oreId != -1) {
+        amountOreBefore = Npc_HasItems(hero, oreId);
+    };
+
+    // Continue with the original function
+    ContinueCall();
+
+    // Check if no ore was deduced
+    if (oreId != -1) {
+        if (Npc_HasItems(hero, oreId) == amountOreBefore) {
+            var int funcId; funcId = MEM_FindParserSymbol("B_GiveInvItems");
+            if (funcId != -1) {
+                // B_GiveInvItems(hero, self, ItMiNugget, 10)
+                PassArgumentN(hero);
+                PassArgumentN(self);
+                MEM_PushIntParam(oreId);
+                MEM_PushIntParam(10); // This is a guess!
+                MEM_CallById(funcId);
+            } else {
+                // In case "B_GiveInvItems" does not exist
+                Npc_RemoveInvItems(hero, oreId, 10);
+                CreateInvItems(self, oreId, 10);
+            };
+        };
+    };
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -43,7 +43,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_060_JesseQuest();                                    // #60
         Ninja_G1CP_078_HumanAttackOrc();                                // #78
         Ninja_G1CP_079_WolfDexDialog();                                 // #79
-        Ninja_G1CP_109_BloodwynProtectionMoneySecond();                 // #109
+        Ninja_G1CP_109_BloodwynProtectionMoneyPayLater();               // #109
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -43,6 +43,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_060_JesseQuest();                                    // #60
         Ninja_G1CP_078_HumanAttackOrc();                                // #78
         Ninja_G1CP_079_WolfDexDialog();                                 // #79
+        Ninja_G1CP_109_BloodwynProtectionMoneySecond();                 // #109
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test109.d
+++ b/src/Ninja/G1CP/Content/Tests/test109.d
@@ -1,0 +1,89 @@
+/*
+ * #109 The player doesn't lose ore when paying protection money to Bloodwyn again
+ *
+ * The dialog function is called (the dialog lines are aborted) with enough ore available.
+ *
+ * Expected behavior: The player will lose 10 ore.
+ */
+func int Ninja_G1CP_Test_109() {
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if the dialog function exists
+    var int funcId; funcId = MEM_FindParserSymbol("Info_Bloodwyn_PayDay_PayAgain");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Dialog function 'Info_Bloodwyn_PayDay_PayAgain' not found");
+        passed = FALSE;
+    };
+
+    // Check if the ore item exists
+    var int oreId; oreId = MEM_FindParserSymbol("ItMiNugget");
+    if (oreId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItMiNugget' not found");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Backup values
+    var int amountBefore; amountBefore = Npc_HasItems(hero, oreId);
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);
+    var C_Npc othBak; othBak = MEM_CpyInst(other);
+
+    // Remove all ore and then add 20
+    if (amountBefore > 0) {
+        Npc_RemoveInvItems(hero, oreId, amountBefore);
+    };
+    CreateInvItems(hero, oreId, 20);
+
+    // Set self and other
+    GetItemHelper();
+    self  = MEM_CpyInst(Item_Helper);
+    other = MEM_CpyInst(hero);
+
+    // Just run the dialog and see what happens
+    MEM_CallByID(funcId);
+
+    // Check the amount
+    var string msg;
+    var int amountAfter; amountAfter = Npc_HasItems(hero, oreId);
+    if (amountAfter == 20) {
+        Ninja_G1CP_TestsuiteErrorDetail("The hero wrongfully kept all ore");
+    } else if (amountAfter < 10) {
+        msg = ConcatStrings("The hero wrongfully payed ", IntToString(10 - amountAfter));
+        msg = ConcatStrings(msg, " ore too much");
+        Ninja_G1CP_TestsuiteErrorDetail(msg);
+    } else if (amountAfter > 20) {
+        msg = ConcatStrings("The hero wrongfully received ", IntToString(amountAfter - 20));
+        msg = ConcatStrings(msg, " ore");
+        Ninja_G1CP_TestsuiteErrorDetail(msg);
+    } else if (amountAfter > 10) {
+        msg = ConcatStrings("The hero wrongfully payed ", IntToString(amountAfter - 10));
+        msg = ConcatStrings(msg, " ore too little");
+        Ninja_G1CP_TestsuiteErrorDetail(msg);
+    };
+
+    // Remove all ore
+    if (amountAfter > 0) {
+        Npc_RemoveInvItems(hero, oreId, amountAfter);
+    };
+
+    // Restore self and other
+    self  = MEM_CpyInst(slfBak);
+    other = MEM_CpyInst(othBak);
+
+    // Stop the output units
+    Npc_ClearAIQueue(hero);
+    AI_StandUpQuick(hero);
+
+    // Restore any ore
+    if (amountBefore > 0) {
+        CreateInvItems(hero, oreId, amountBefore);
+    };
+
+    // Return success
+    return (amountAfter == 10);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -61,7 +61,7 @@ Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 Content\Fixes\Session\fix060_JesseQuest.d
 Content\Fixes\Session\fix078_HumanAttackOrc.d
 Content\Fixes\Session\fix079_WolfDexDialog.d
-Content\Fixes\Session\fix109_BloodwynProtectionMoneySecond.d
+Content\Fixes\Session\fix109_BloodwynProtectionMoneyPayLater.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -61,6 +61,7 @@ Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 Content\Fixes\Session\fix060_JesseQuest.d
 Content\Fixes\Session\fix078_HumanAttackOrc.d
 Content\Fixes\Session\fix079_WolfDexDialog.d
+Content\Fixes\Session\fix109_BloodwynProtectionMoneySecond.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d
@@ -102,6 +103,7 @@ Content\Tests\test059.d
 Content\Tests\test060.d
 Content\Tests\test078.d
 Content\Tests\test079.d
+Content\Tests\test109.d
 
 // Initialization
 Content\initOnce.d


### PR DESCRIPTION
### Description
Fixes #109. Paying Bloodwyn later costs ore.

### Test
Run automatic test with `test 109`.
