### PR TITLE
#126: Remove trade menu during Shark's quest dialog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,7 @@
 * Fix #109: The player now correctly loses 10 ore if he chooses to pay protection money to Bloodwyn later.
 * Fix #111: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal.
 * Fix #112: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal later.
+* Fix #126: Sharky's dialog option for Fisk's quest "New Fence for Fisk" no longer opens the trading menu.
 
 ## DE
 
@@ -89,3 +90,4 @@
 * Fix #109: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Bloodwyn zahlt.
 * Fix #111: Der Spieler verliert nun tatsächlich 10 Erz, wenn er Schutzgeld an Jackal zahlt.
 * Fix #112: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Jackal zahlt.
+* Fix #126: Sharkys Dialog zu Fisks Quest "Neuer Hehler für Fisk" öffnet nicht mehr das Handelsmenü.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix126_SharkyTrade.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix126_SharkyTrade.d
@@ -1,0 +1,55 @@
+/*
+ * #126 The trading menu is opened after Sharky is appointed as new fence
+ */
+func int Ninja_G1CP_126_SharkyTrade() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int symbId; symbId = MEM_FindParserSymbol("Org_843_Sharky_Fisk");
+    var int infoPermSymbId; infoPermSymbId = MEM_FindParserSymbol("C_Info.trade");
+    if (symbId == -1) || (infoPermSymbId == -1) {
+        return FALSE;
+    };
+
+    // Find "trade = xxx" in the instance function
+    const int bytes[3] = {zPAR_TOK_PUSHVAR<<24, 0, zPAR_OP_IS};
+    bytes[1] = infoPermSymbId;
+    var int matches; matches = Ninja_G1CP_FindInFunc(symbId, _@(bytes)+3, 6);
+
+    // Iterate over all matches
+    repeat(i, MEM_ArraySize(matches)); var int i;
+        var int pos; pos = MEM_ArrayRead(matches, i);
+
+        // Check context: "trade = 1" or "trade = symbol containing 1"
+        if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHVAR) {
+            var int varId; varId = MEM_ReadInt(pos-4);
+            if (varId <= 0) || (varId >= currSymbolTableLength) {
+                continue;
+            };
+            var int varSymbPtr; varSymbPtr = MEM_GetSymbolByIndex(varId);
+            if (!varSymbPtr) {
+                continue;
+            };
+            if (MEM_ReadInt(varSymbPtr + zCParSymbol_content_offset) != 1) {
+                continue;
+            };
+        } else if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHINT) {
+            if (MEM_ReadInt(pos-4) != 1) {
+                continue;
+            };
+        } else {
+            continue;
+        };
+
+        // Overwrite "trade = 1" with "trade = 0"
+        MEMINT_OverrideFunc_Ptr = pos-5;
+        MEMINT_OFTokPar(zPAR_TOK_PUSHINT, 0);
+
+        applied += 1;
+    end;
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -47,6 +47,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_109_BloodwynProtectionMoneyPayLater();               // #109
         Ninja_G1CP_111_JackalProtectionMoneyPay();                      // #111
         Ninja_G1CP_112_JackalProtectionMoneyPayLater();                 // #112
+        Ninja_G1CP_126_SharkyTrade();                                   // #126
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test126.d
+++ b/src/Ninja/G1CP/Content/Tests/test126.d
@@ -1,0 +1,59 @@
+/*
+ * #126 The trading menu is opened after Sharky is appointed as new fence
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: Sharky will not open the trade menu when talking about Fisk's quest.
+ */
+func void Ninja_G1CP_Test_126() {
+    if (!Ninja_G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Define possibly missing symbols locally
+    const int LOG_RUNNING = 1;
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if the dialog exists
+    var int funcId; funcId = MEM_FindParserSymbol("Org_843_Sharky_Fisk");
+    if (funcId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Info 'Org_843_Sharky_Fisk' not found");
+        passed = FALSE;
+    };
+
+    // Check if variable exists
+    var int questPtr; questPtr = MEM_GetSymbol("Fisk_GetNewHehler");
+    if (!questPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'Fisk_GetNewHehler' not found");
+        passed = FALSE;
+    };
+    questPtr += zCParSymbol_content_offset;
+
+    // Find Sharky
+    var int symbId; symbId = MEM_FindParserSymbol("Org_843_Sharky");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'Org_843_Sharky' not found");
+        return;
+    };
+
+    // Check if Sharky exists in the world
+    var C_Npc sharky; sharky = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(sharky)) {
+        Ninja_G1CP_TestsuiteErrorDetail("NPC 'Org_843_Sharky' not valid");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return;
+    };
+
+    // Enable the dialog by setting the quest marker to running
+    MEM_WriteInt(questPtr, LOG_RUNNING);
+    Ninja_G1CP_SetInfoTold("Org_843_Sharky_Fisk", FALSE);
+
+    // Teleport the hero to Sharky
+    AI_Teleport(hero, sharky.wp);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -65,6 +65,7 @@ Content\Fixes\Session\fix102_JesseProtectionMoneyPay.d
 Content\Fixes\Session\fix109_BloodwynProtectionMoneyPayLater.d
 Content\Fixes\Session\fix111_JackalProtectionMoneyPay.d
 Content\Fixes\Session\fix112_JackalProtectionMoneyPayLater.d
+Content\Fixes\Session\fix126_SharkyTrade.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d
@@ -110,6 +111,7 @@ Content\Tests\test102.d
 Content\Tests\test109.d
 Content\Tests\test111.d
 Content\Tests\test112.d
+Content\Tests\test126.d
 
 // Initialization
 Content\initOnce.d


### PR DESCRIPTION
### Description
Fixes #126. Fix trade menu for Sharky.

### Test
Run manual test with `test 126`. The PC is teleported to Sharky and the dialog option is available for manual testing.
