### PR TITLE
#44: List bug meat as food

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,7 @@
 * Fix #39: Fingers no longer offers to teach level two of pickpocketing and lock picking before level one has been learned.
 * Fix #40: Aleph doesn't offer to sell the key anymore when the player already obtained it.
 * Fix #42: Two guards in the Old Camp no longer have two END dialog options.
+* Fix #44: Bugmeat is now listed as food in the inventory.
 * Fix #49: The description of the dungeon key is corrected to "Opens the dungeons of the old camp.".
 * Fix #50: The pillar in the Monastery Ruins now falls in the right directions and has collision.
 * Fix #60: Jesse's quest is now available.
@@ -81,6 +82,7 @@
 * Fix #39: Fingers bringt dem Spieler nicht mehr Taschendiebstahl und Schlösserknacken auf Stufe zwei bei, wenn Stufe eins jeweils noch nicht gelernt wurde.
 * Fix #40: Aleph bietet den Schlüssel nun nicht noch einmal an, wenn der Spieler ihn schon erhalten hat.
 * Fix #42: Zwei Gardisten des Alten Lagers haben nun nicht mehr zwei ENDE Dialogoptionen.
+* Fix #44: Wanzenfleisch ist nun unter "Essen" im Inventar zu finden.
 * Fix #49: Die Beschreibung des Kerkerschlüssels ist korrigiert zu "öffnet den Kerker des Alten Lagers.".
 * Fix #50: Die Säule in der Klosterruine fällt jetzt in die richtige Richtung und hat Kollision.
 * Fix #60: Jesses Quest ist nun verfügbar.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix044_BugmeatCategory.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix044_BugmeatCategory.d
@@ -1,0 +1,70 @@
+/*
+ * #44 Bugmeat in the wrong inventory category
+ */
+func int Ninja_G1CP_044_BugmeatCategory() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int symbId; symbId = MEM_FindParserSymbol("ItAt_Meatbug_01");
+    var int itemMainflagSymbId; itemMainflagSymbId = MEM_FindParserSymbol("C_ITEM.mainflag");
+    if (symbId == -1) || (itemMainflagSymbId == -1) {
+        return FALSE;
+    };
+
+    // Define possibly missing symbols locally
+    const int ITEM_KAT_NONE = 1 << 0;
+    const int ITEM_KAT_FOOD = 1 << 5;
+
+    // Update ITEM_KAT_FOOD and ITEM_KAT_NONE if found (highly unlikely that they differ but let's be safe)
+    var int symbPtr;
+    symbPtr = MEM_GetSymbol("ITEM_KAT_NONE");
+    if (symbPtr) {
+        ITEM_KAT_NONE = MEM_ReadInt(symbPtr + zCParSymbol_content_offset);
+    };
+    symbPtr = MEM_GetSymbol("ITEM_KAT_FOOD");
+    if (symbPtr) {
+        ITEM_KAT_FOOD = MEM_ReadInt(symbPtr + zCParSymbol_content_offset);
+    };
+
+    // Find "mainflag = xxx" in the instance function
+    const int bytes[3] = {zPAR_TOK_PUSHVAR<<24, 0, zPAR_OP_IS};
+    bytes[1] = itemMainflagSymbId;
+    var int matches; matches = Ninja_G1CP_FindInFunc(symbId, _@(bytes)+3, 6);
+
+    // Iterate over all matches
+    repeat(i, MEM_ArraySize(matches)); var int i;
+        var int pos; pos = MEM_ArrayRead(matches, i);
+
+        // Check context: "mainflag = ITEM_KAT_NONE" (literal) or "mainflag = symbol equal to ITEM_KAT_NONE"
+        if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHVAR) {
+            var int varId; varId = MEM_ReadInt(pos-4);
+            if (varId <= 0) || (varId >= currSymbolTableLength) {
+                continue;
+            };
+            var int varSymbPtr; varSymbPtr = MEM_GetSymbolByIndex(varId);
+            if (!varSymbPtr) {
+                continue;
+            };
+            if (MEM_ReadInt(varSymbPtr + zCParSymbol_content_offset) != ITEM_KAT_NONE) {
+                continue;
+            };
+        } else if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHINT) {
+            if (MEM_ReadInt(pos-4) != ITEM_KAT_NONE) {
+                continue;
+            };
+        } else {
+            continue;
+        };
+
+        // Overwrite "mainflag = ITEM_KAT_NONE" with "mainflag = ITEM_KAT_FOOD" (literal)
+        MEMINT_OverrideFunc_Ptr = pos-5;
+        MEMINT_OFTokPar(zPAR_TOK_PUSHINT, ITEM_KAT_FOOD);
+
+        applied += 1;
+    end;
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -38,6 +38,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_040_AlephKeyDialog();                                // #40
         Ninja_G1CP_042_GuardExitDialog();                               // #42
         Ninja_G1CP_043_EN_SkillMissingWhitespace();                     // #43
+        Ninja_G1CP_044_BugmeatCategory();                               // #44
         Ninja_G1CP_049_DungeonKeyText();                                // #49
         Ninja_G1CP_059_FixEquipBestWeapons();                           // #59
         Ninja_G1CP_060_JesseQuest();                                    // #60

--- a/src/Ninja/G1CP/Content/Tests/test044.d
+++ b/src/Ninja/G1CP/Content/Tests/test044.d
@@ -1,0 +1,34 @@
+/*
+ * #44 Bugmeat in the wrong inventory category
+ *
+ * The mainflag (item category) of the item "ItAt_Meatbug_01" is inspected programmatically
+ *
+ * Expected behavior: The item will have the correct mainflag
+ */
+func int Ninja_G1CP_Test_044() {
+    // Define possibly missing symbols locally
+    const int ITEM_KAT_FOOD = 1 << 5;
+
+    // Check if item exists
+    var int symbId; symbId = MEM_FindParserSymbol("ItAt_Meatbug_01");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItAt_Meatbug_01' not found");
+        return FALSE;
+    };
+
+    // Create the key locally
+    if (Itm_GetPtr(symbId)) {
+        if (item.mainflag == ITEM_KAT_FOOD) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Category incorrect: mainflag = '";
+            msg = ConcatStrings(msg, IntToString(item.mainflag));
+            msg = ConcatStrings(msg, "'");
+            Ninja_G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItAt_Meatbug_01' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -56,6 +56,7 @@ Content\Fixes\Session\fix039_FingersTeachDialog.d
 Content\Fixes\Session\fix040_AlephKeyDialog.d
 Content\Fixes\Session\fix042_GuardExitDialog.d
 Content\Fixes\Session\fix043_EN_SkillMissingWhitespace.d
+Content\Fixes\Session\fix044_BugmeatCategory.d
 Content\Fixes\Session\fix049_DungeonKeyText.d
 Content\Fixes\Session\fix059_FixEquipBestWeapons.d
 Content\Fixes\Session\fix060_JesseQuest.d
@@ -100,6 +101,7 @@ Content\Tests\test039.d
 Content\Tests\test040.d
 Content\Tests\test042.d
 Content\Tests\test043.d
+Content\Tests\test044.d
 Content\Tests\test049.d
 Content\Tests\test050.d
 Content\Tests\test059.d


### PR DESCRIPTION
### Description
Fixes #44. List bug meat as food.

### Test
Run automatic test with `test 44`. An additional manual check for the item might be nice. I already did that partially.
Insert code: `insert itat_meatbug_01`.
