### PR TITLE
#125: Fix item text of butcher sword

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -90,4 +90,4 @@
 * Fix #109: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Bloodwyn zahlt.
 * Fix #111: Der Spieler verliert nun tatsächlich 10 Erz, wenn er Schutzgeld an Jackal zahlt.
 * Fix #112: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Jackal zahlt.
-* Fix #125: Die Beschreibung des Schertes "Schlachter" ist korrigiert zu "Zweihandwaffe".
+* Fix #125: Die Beschreibung des Schertes "Schlachter" ist korrigiert zu "Einhandwaffe".

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,7 @@
 * Fix #109: The player now correctly loses 10 ore if he chooses to pay protection money to Bloodwyn later.
 * Fix #111: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal.
 * Fix #112: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal later.
+* Fix #125: The description of the sword "Butcher" now correctly lists it as one-handed weapon.
 
 ## DE
 
@@ -89,3 +90,4 @@
 * Fix #109: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Bloodwyn zahlt.
 * Fix #111: Der Spieler verliert nun tatsächlich 10 Erz, wenn er Schutzgeld an Jackal zahlt.
 * Fix #112: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Jackal zahlt.
+* Fix #125: Die Beschreibung des Schertes "Schlachter" ist korrigiert zu "Zweihandwaffe".

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix125_ButcherText.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix125_ButcherText.d
@@ -1,0 +1,68 @@
+/*
+ * #125 The Butcher is described as two-handed sword
+ */
+func int Ninja_G1CP_125_ButcherText() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int symbId; symbId = MEM_FindParserSymbol("ItMw_1H_Sword_Bastard_02");
+    var int itemTextSymbId; itemTextSymbId = MEM_FindParserSymbol("C_ITEM.TEXT");
+    var int oneHandedSymbId; oneHandedSymbId = MEM_FindParserSymbol("NAME_OneHanded");
+    var int twoHandedSymbId; twoHandedSymbId = MEM_FindParserSymbol("NAME_TwoHanded");
+    if (symbId == -1) || (itemTextSymbId == -1) || (oneHandedSymbId == -1) || (twoHandedSymbId == -1) {
+        return FALSE;
+    };
+
+    // Read string content
+    var string NAME_TwoHanded;
+    var int symbPtr; symbPtr = MEM_GetSymbolByIndex(twoHandedSymbId);
+    if (symbPtr) {
+        NAME_TwoHanded = MEM_ReadString(MEM_ReadInt(symbPtr + zCParSymbol_content_offset));
+    } else {
+        NAME_TwoHanded = "Ninja_G1CP_invalid_string"; // Make sure that string will not match!
+    };
+
+    // Find "text[4] = xxx" in the instance function
+    const int bytes[3] = {zPAR_TOK_PUSH_ARRAYVAR<<24, 0, 4 + (zPAR_TOK_ASSIGNSTR<<8)};
+    bytes[1] = itemTextSymbId;
+    var int matches; matches = Ninja_G1CP_FindInFunc(symbId, _@(bytes)+3, 7);
+
+    // Iterate over all matches
+    repeat(i, MEM_ArraySize(matches)); var int i;
+        var int pos; pos = MEM_ArrayRead(matches, i);
+
+        // Check context: "text[4] = NAME_TwoHanded" or "text[4] = symbol equal to NAME_TwoHanded"
+        if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHVAR) {
+            var int varId; varId = MEM_ReadInt(pos-4);
+            if (varId != twoHandedSymbId) {
+                if (varId <= 0) || (varId >= currSymbolTableLength) {
+                    continue;
+                };
+                var int varSymbPtr; varSymbPtr = MEM_GetSymbolByIndex(varId);
+                if (!varSymbPtr) {
+                    continue;
+                };
+                var zCPar_Symbol symb; symb = _^(varSymbPtr);
+                if ((symb.bitfield & zCPar_Symbol_bitfield_type) != zPAR_TYPE_STRING) {
+                    continue;
+                };
+                if (!Hlp_StrCmp(MEM_ReadString(symb.content), NAME_TwoHanded)) {
+                    continue;
+                };
+            };
+        } else {
+            continue;
+        };
+
+        // Overwrite "text[4] = NAME_TwoHanded" with "text[4] = NAME_OneHanded"
+        MEMINT_OverrideFunc_Ptr = pos-5;
+        MEMINT_OFTokPar(zPAR_TOK_PUSHVAR, oneHandedSymbId);
+
+        applied += 1;
+    end;
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -47,6 +47,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_109_BloodwynProtectionMoneyPayLater();               // #109
         Ninja_G1CP_111_JackalProtectionMoneyPay();                      // #111
         Ninja_G1CP_112_JackalProtectionMoneyPayLater();                 // #112
+        Ninja_G1CP_125_ButcherText();                                   // #125
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test125.d
+++ b/src/Ninja/G1CP/Content/Tests/test125.d
@@ -1,0 +1,41 @@
+/*
+ * #125 The Butcher is described as two-handed sword
+ *
+ * The text of the item "ItMw_1H_Sword_Bastard_02" is inspected programmatically
+ *
+ * Expected behavior: The sword will have the correct description (checked for English and German localization only)
+ */
+func int Ninja_G1CP_Test_125() {
+    // Check language first
+    if (Ninja_G1CP_Lang != 0) && (Ninja_G1CP_Lang != 1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Test applicable for English and German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_FindParserSymbol("ItMw_1H_Sword_Bastard_02");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItMw_1H_Sword_Bastard_02' not found");
+        return FALSE;
+    };
+
+    // Create the sword locally
+    if (Itm_GetPtr(symbId)) {
+        // Static string arrays cannot be read directly
+        var string item_text_4; item_text_4 = MEM_ReadStatStringArr(item.text, 4);
+
+        if (Hlp_StrCmp(item_text_4, "One-handed Weapon")) // EN
+        || (Hlp_StrCmp(item_text_4, "Einhandwaffe")) {    // DE
+            return TRUE;
+        } else {
+            var string msg; msg = "Text incorrect: text[4] = '";
+            msg = ConcatStrings(msg, item_text_4);
+            msg = ConcatStrings(msg, "'");
+            Ninja_G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItMw_1H_Sword_Bastard_02' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -65,6 +65,7 @@ Content\Fixes\Session\fix102_JesseProtectionMoneyPay.d
 Content\Fixes\Session\fix109_BloodwynProtectionMoneyPayLater.d
 Content\Fixes\Session\fix111_JackalProtectionMoneyPay.d
 Content\Fixes\Session\fix112_JackalProtectionMoneyPayLater.d
+Content\Fixes\Session\fix125_ButcherText.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d
@@ -110,6 +111,7 @@ Content\Tests\test102.d
 Content\Tests\test109.d
 Content\Tests\test111.d
 Content\Tests\test112.d
+Content\Tests\test125.d
 
 // Initialization
 Content\initOnce.d


### PR DESCRIPTION
### Description
Fixes #125. Correct the item text (description) of the butcher sword to one handed.

### Test
Run automatic test with `test 125`. This test only works for English and German localization. So far, I only tested it for English scripts.
