### PR TITLE
#158: Fix the ore value of the third speed potion

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,7 @@
 * Fix #109: The player now correctly loses 10 ore if he chooses to pay protection money to Bloodwyn later.
 * Fix #111: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal.
 * Fix #112: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal later.
+* Fix #158: The Potion of Haste now has the correct ore value.
 
 ## DE
 
@@ -89,3 +90,4 @@
 * Fix #109: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Bloodwyn zahlt.
 * Fix #111: Der Spieler verliert nun tatsächlich 10 Erz, wenn er Schutzgeld an Jackal zahlt.
 * Fix #112: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Jackal zahlt.
+* Fix #158: Der Kaufwert des Tranks der Eile ist korrigiert.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix158_SpeedPotion3Value.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix158_SpeedPotion3Value.d
@@ -1,0 +1,74 @@
+/*
+ * #158 Potion of Haste has wrong ore value
+ */
+func int Ninja_G1CP_158_SpeedPotion3Value() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int symbId; symbId = MEM_FindParserSymbol("ItFo_Potion_Haste_03");
+    var int itemValueSymbId; itemValueSymbId = MEM_FindParserSymbol("C_ITEM.value");
+    var int value1SymbId; value1SymbId = MEM_FindParserSymbol("Value_Haste1");
+    var int value1SymbPtr; value1SymbPtr = MEM_GetSymbol("Value_Haste1");
+    var int value3SymbPtr; value3SymbPtr = MEM_GetSymbol("Value_Haste3");
+    if (symbId == -1) || (itemValueSymbId == -1) || (!value3SymbPtr) { // Only those three are strictly required
+        return FALSE;
+    };
+
+    // Get content of potion values
+    var int Value_Haste3; Value_Haste3 = MEM_ReadInt(value3SymbPtr + zCParSymbol_content_offset);
+    var int Value_Haste1;
+    if (value1SymbPtr) {
+        // Find value from constant
+        Value_Haste1 = MEM_ReadInt(value1SymbPtr + zCParSymbol_content_offset);
+    } else if (Itm_GetPtr(MEM_FindParserSymbol("ItFo_Potion_Haste_01"))) {
+        // If not found, determine from level one speed potion
+        Value_Haste1 = item.value;
+    } else {
+        // If neither is found, we cannot compare and be sure that the potion values are not intended
+        return FALSE;
+    };
+
+    // Find "value = xxx" in the instance function
+    const int bytes[3] = {zPAR_TOK_PUSHVAR<<24, 0, zPAR_OP_IS};
+    bytes[1] = itemValueSymbId;
+    var int matches; matches = Ninja_G1CP_FindInFunc(symbId, _@(bytes)+3, 6);
+
+    // Iterate over all matches
+    repeat(i, MEM_ArraySize(matches)); var int i;
+        var int pos; pos = MEM_ArrayRead(matches, i);
+
+        // Check context: "value = Value_Haste1" (literal) or "value = symbol equal to Value_Haste1"
+        if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHVAR) {
+            var int varId; varId = MEM_ReadInt(pos-4);
+            if (varId != value1SymbId) {
+                if (varId <= 0) || (varId >= currSymbolTableLength) {
+                    continue;
+                };
+                var int varSymbPtr; varSymbPtr = MEM_GetSymbolByIndex(varId);
+                if (!varSymbPtr) {
+                    continue;
+                };
+                if (MEM_ReadInt(varSymbPtr + zCParSymbol_content_offset) != Value_Haste1) {
+                    continue;
+                };
+            };
+        } else if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHINT) {
+            if (MEM_ReadInt(pos-4) != Value_Haste1) {
+                continue;
+            };
+        } else {
+            continue;
+        };
+
+        // Overwrite "value = Value_Haste1" with "value = Value_Haste3" (literal)
+        MEMINT_OverrideFunc_Ptr = pos-5;
+        MEMINT_OFTokPar(zPAR_TOK_PUSHINT, Value_Haste3);
+
+        applied += 1;
+    end;
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -47,6 +47,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_109_BloodwynProtectionMoneyPayLater();               // #109
         Ninja_G1CP_111_JackalProtectionMoneyPay();                      // #111
         Ninja_G1CP_112_JackalProtectionMoneyPayLater();                 // #112
+        Ninja_G1CP_158_SpeedPotion3Value();                             // #158
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test158.d
+++ b/src/Ninja/G1CP/Content/Tests/test158.d
@@ -1,0 +1,39 @@
+/*
+ * #158 Potion of Haste has wrong ore value
+ *
+ * The value of the item "ItFo_Potion_Haste_03" is inspected programmatically
+ *
+ * Expected behavior: The item will have the correct value
+ */
+func int Ninja_G1CP_Test_158() {
+    // Check if item exists
+    var int symbId; symbId = MEM_FindParserSymbol("ItFo_Potion_Haste_03");
+    if (symbId == -1) {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItFo_Potion_Haste_03' not found");
+        return FALSE;
+    };
+
+    // Check if variable exists
+    var int symbPtr; symbPtr = MEM_GetSymbol("Value_Haste3");
+    if (!symbPtr) {
+        Ninja_G1CP_TestsuiteErrorDetail("Variable 'Value_Haste3' not found");
+        return FALSE;
+    };
+    var int Value_Haste3; Value_Haste3 = MEM_ReadInt(symbPtr + zCParSymbol_content_offset);
+
+    // Create the potion locally
+    if (Itm_GetPtr(symbId)) {
+        if (item.value == Value_Haste3) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Category incorrect: value = '";
+            msg = ConcatStrings(msg, IntToString(item.value));
+            msg = ConcatStrings(msg, "'");
+            Ninja_G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        Ninja_G1CP_TestsuiteErrorDetail("Item 'ItFo_Potion_Haste_03' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -65,6 +65,7 @@ Content\Fixes\Session\fix102_JesseProtectionMoneyPay.d
 Content\Fixes\Session\fix109_BloodwynProtectionMoneyPayLater.d
 Content\Fixes\Session\fix111_JackalProtectionMoneyPay.d
 Content\Fixes\Session\fix112_JackalProtectionMoneyPayLater.d
+Content\Fixes\Session\fix158_SpeedPotion3Value.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d
@@ -110,6 +111,7 @@ Content\Tests\test102.d
 Content\Tests\test109.d
 Content\Tests\test111.d
 Content\Tests\test112.d
+Content\Tests\test158.d
 
 // Initialization
 Content\initOnce.d


### PR DESCRIPTION
### Description
Fixes #158. The second speed potion (Potion of Haste) has the correct ore value.

### Test
Run automatic test with `test 158`. This test will be important to check with mods that might have already fixed the issue.

### Additional Information
This fix will only take effect when the Potion of Haste has the *same* ore value as the Potion of Swiftness. This way it is ensured that a mod did not deliberately changed the ore value.