### PR TITLE
#122: Fix Cavalorn's daily routine

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,7 @@
 * Fix #109: The player now correctly loses 10 ore if he chooses to pay protection money to Bloodwyn later.
 * Fix #111: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal.
 * Fix #112: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal later.
+* Fix #122: Cavalron now correctly sleeps in his hut at night and stands outside at daytime.
 
 ## DE
 
@@ -89,3 +90,4 @@
 * Fix #109: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Bloodwyn zahlt.
 * Fix #111: Der Spieler verliert nun tatsächlich 10 Erz, wenn er Schutzgeld an Jackal zahlt.
 * Fix #112: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Jackal zahlt.
+* Fix #122: Cavalron schläft nun nachts tatsächlich in seiner Hütte und steht tagsüber draußen.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix122_CavalornDailyRoutine.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix122_CavalornDailyRoutine.d
@@ -1,0 +1,111 @@
+/*
+ * #122 Cavalorn WPs for his routine are reversed
+ */
+func int Ninja_G1CP_122_CavalornDailyRoutine() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int funcId; funcId = MEM_FindParserSymbol("Rtn_start_336");
+    var int sleepSymbPtr; sleepSymbPtr = MEM_GetSymbol("TA_Sleep");
+    var int standSymbPtr; standSymbPtr = MEM_GetSymbol("TA_StandAround");
+    if (funcId == -1) || (!sleepSymbPtr) || (!standSymbPtr) {
+        return FALSE;
+    };
+
+    // Find function calls in "Rtn_start_336"
+    const int bytes[2] = {zPAR_TOK_CALL<<24, 0};
+
+    // Find all calls to TA_Sleep"
+    bytes[1] = MEM_ReadInt(sleepSymbPtr + zCParSymbol_content_offset);
+    var int sleepMatches; sleepMatches = Ninja_G1CP_FindInFunc(funcId, _@(bytes)+3, 5);
+
+    // Find all calls to "TA_StandAround"
+    bytes[1] = MEM_ReadInt(standSymbPtr + zCParSymbol_content_offset);
+    var int standMatches; standMatches = Ninja_G1CP_FindInFunc(funcId, _@(bytes)+3, 5);
+
+    // Narrow down the context
+    var int i; i = 0;
+    var int pos;
+    var int varId;
+    var int varSymbPtr;
+    var zCPar_Symbol symb;
+    var string str;
+
+    // Confirm that the waypoint is "OW_CAVALORN_01"
+    while(i < MEM_ArraySize(sleepMatches));
+        pos = MEM_ArrayRead(sleepMatches, i);
+        if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHVAR) {
+            varId = MEM_ReadInt(pos-4);
+            if (varId > 0) && (varId < currSymbolTableLength) {
+                varSymbPtr = MEM_GetSymbolByIndex(varId);
+                if (varSymbPtr) {
+                    symb = _^(varSymbPtr);
+                    if ((symb.bitfield & zCPar_Symbol_bitfield_type) == zPAR_TYPE_STRING) {
+                        str = MEM_ReadString(symb.content);
+                        if (Hlp_StrCmp(str, "OW_CAVALORN_01")) {
+                            i += 1;
+                            continue;
+                        };
+                    };
+                };
+            };
+        };
+
+        // If not matched, remove that match (array will no longer be ordered!)
+        MEM_ArrayRemoveIndex(sleepMatches, i);
+    end;
+
+    // Confirm that the waypoint is "OW_SAWHUT_SLEEP_01"
+    while(i < MEM_ArraySize(standMatches));
+        pos = MEM_ArrayRead(standMatches, i);
+        if (MEM_ReadByte(pos-5) == zPAR_TOK_PUSHVAR) {
+            varId = MEM_ReadInt(pos-4);
+            if (varId > 0) && (varId < currSymbolTableLength) {
+                varSymbPtr = MEM_GetSymbolByIndex(varId);
+                if (varSymbPtr) {
+                    symb = _^(varSymbPtr);
+                    if ((symb.bitfield & zCPar_Symbol_bitfield_type) == zPAR_TYPE_STRING) {
+                        str = MEM_ReadString(symb.content);
+                        if (Hlp_StrCmp(str, "OW_SAWHUT_SLEEP_01")) {
+                            i += 1;
+                            continue;
+                        };
+                    };
+                };
+            };
+        };
+
+        // If not matched, remove that match (array will no longer be ordered!)
+        MEM_ArrayRemoveIndex(standMatches, i);
+    end;
+
+    // Check if any matches are left
+    if (MEM_ArraySize(sleepMatches) > 0) && (MEM_ArraySize(standMatches) > 0) {
+        // Get symbol indices of the strings
+        const string wpSleep = "OW_SAWHUT_SLEEP_01";
+        const string wpStand = "OW_CAVALORN_01";
+        var int wpSleepSymbId; wpSleepSymbId = MEM_FindParserSymbol("Ninja_G1CP_122_CavalornDailyRoutine.wpSleep");
+        var int wpStandSymbId; wpStandSymbId = MEM_FindParserSymbol("Ninja_G1CP_122_CavalornDailyRoutine.wpStand");
+
+        // Switch the waypoints in all remaining occurrences
+        repeat(i, MEM_ArraySize(sleepMatches));
+            pos = MEM_ArrayRead(sleepMatches, i);
+            MEMINT_OverrideFunc_Ptr = pos-5;
+            MEMINT_OFTokPar(zPAR_TOK_PUSHVAR, wpSleepSymbId);
+        end;
+        repeat(i, MEM_ArraySize(standMatches));
+            pos = MEM_ArrayRead(standMatches, i);
+            MEMINT_OverrideFunc_Ptr = pos-5;
+            MEMINT_OFTokPar(zPAR_TOK_PUSHVAR, wpStandSymbId);
+        end;
+
+        // Successful
+        applied = TRUE;
+    };
+
+    // Free the arrays
+    MEM_ArrayFree(sleepMatches);
+    MEM_ArrayFree(standMatches);
+
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -47,6 +47,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_109_BloodwynProtectionMoneyPayLater();               // #109
         Ninja_G1CP_111_JackalProtectionMoneyPay();                      // #111
         Ninja_G1CP_112_JackalProtectionMoneyPayLater();                 // #112
+        Ninja_G1CP_122_CavalornDailyRoutine();                          // #122
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test122.d
+++ b/src/Ninja/G1CP/Content/Tests/test122.d
@@ -1,0 +1,22 @@
+/*
+ * #122 Cavalorn WPs for his routine are reversed
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ * Consecutive calls of this test will alternate the time between day time and night time.
+ *
+ * Expected behavior: Cavalorn will be sleeping in his bed at night time and stand by the camp fire during day time.
+ */
+func void Ninja_G1CP_Test_122() {
+    if (Ninja_G1CP_TestsuiteAllowManual) {
+        // Set the time
+        const int night = 0;
+        night = !night;
+        if (night) {
+            Wld_SetTime(0, 0);
+            AI_Teleport(hero, "OW_SAWHUT_SLEEP_01");
+        } else {
+            Wld_SetTime(12, 0);
+            AI_Teleport(hero, "OW_CAVALORN_01");
+        };
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -65,6 +65,7 @@ Content\Fixes\Session\fix102_JesseProtectionMoneyPay.d
 Content\Fixes\Session\fix109_BloodwynProtectionMoneyPayLater.d
 Content\Fixes\Session\fix111_JackalProtectionMoneyPay.d
 Content\Fixes\Session\fix112_JackalProtectionMoneyPayLater.d
+Content\Fixes\Session\fix122_CavalornDailyRoutine.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d
@@ -110,6 +111,7 @@ Content\Tests\test102.d
 Content\Tests\test109.d
 Content\Tests\test111.d
 Content\Tests\test112.d
+Content\Tests\test122.d
 
 // Initialization
 Content\initOnce.d


### PR DESCRIPTION
### Description
Fixes #122.

### Test
Run manual test with `test 122`. Consecutive calls of this test will alternate the time between day time and night time. This allows to check if Cavalorn's daily routine is fully corrected.
