### PR TITLE
NPCs cannot use ladders when following the player

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,7 @@
 * Fix #109: The player now correctly loses 10 ore if he chooses to pay protection money to Bloodwyn later.
 * Fix #111: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal.
 * Fix #112: The player now correctly loses 10 ore if he chooses to pay protection money to Jackal later.
+* Fix #136: NPCs now use ladders properly when following the player.
 
 ## DE
 
@@ -89,3 +90,4 @@
 * Fix #109: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Bloodwyn zahlt.
 * Fix #111: Der Spieler verliert nun tatsächlich 10 Erz, wenn er Schutzgeld an Jackal zahlt.
 * Fix #112: Der Spieler verliert nun tatsächlich 10 Erz, wenn er später doch Schutzgeld an Jackal zahlt.
+* Fix #136: NSCs benutzen Leitern nun korrekt, wenn sie dem Spieler folgen.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix136_FollowLadder.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix136_FollowLadder.d
@@ -1,0 +1,27 @@
+/*
+ * #136 NPCs cannot use ladders when following the player
+ */
+func int Ninja_G1CP_136_FollowLadder() {
+    if (MEM_FindParserSymbol("B_FollowPC_AssessSC") != -1) {
+        HookDaedalusFuncS("B_FollowPC_AssessSC", "Ninja_G1CP_136_FollowLadder_PercHook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+func void Ninja_G1CP_136_FollowLadder_PercHook() {
+    Ninja_G1CP_ReportFuncToSpy();
+
+    // Define possibly missing symbols locally
+    const int BS_FLAG_INTERRUPTABLE = 32768;
+    const int BS_CLIMB              = 9 | BS_FLAG_INTERRUPTABLE;
+
+    // Disable this perception when climbing a ladder
+    if (Ninja_G1CP_BodyStateContains(self, BS_CLIMB)) {
+        return;
+    };
+
+    // Call original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -47,6 +47,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_109_BloodwynProtectionMoneyPayLater();               // #109
         Ninja_G1CP_111_JackalProtectionMoneyPay();                      // #111
         Ninja_G1CP_112_JackalProtectionMoneyPayLater();                 // #112
+        Ninja_G1CP_136_FollowLadder();                                  // #136
         Ninja_G1CP_InitEnd();
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test136.d
+++ b/src/Ninja/G1CP/Content/Tests/test136.d
@@ -1,0 +1,20 @@
+/*
+ * #136 NPCs cannot use ladders when following the player
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: Gorn should be able to climb up the ladder to reach the PC without interruptions.
+ */
+func void Ninja_G1CP_Test_136() {
+    if (Ninja_G1CP_TestsuiteAllowManual) {
+        // Teleport the player to the entrance of the Free Mine
+        if (!Hlp_StrCmp(MEM_World.worldFilename, "FREEMINE.ZEN")) {
+            const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
+            CALL_zStringPtrParam("FM_20");
+            CALL_zStringPtrParam("FREEMINE.ZEN");
+            CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
+        } else {
+            AI_Teleport(hero, "FM_20");
+        };
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -65,6 +65,7 @@ Content\Fixes\Session\fix102_JesseProtectionMoneyPay.d
 Content\Fixes\Session\fix109_BloodwynProtectionMoneyPayLater.d
 Content\Fixes\Session\fix111_JackalProtectionMoneyPay.d
 Content\Fixes\Session\fix112_JackalProtectionMoneyPayLater.d
+Content\Fixes\Session\fix136_FollowLadder.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix050_Pillar.d
@@ -110,6 +111,7 @@ Content\Tests\test102.d
 Content\Tests\test109.d
 Content\Tests\test111.d
 Content\Tests\test112.d
+Content\Tests\test136.d
 
 // Initialization
 Content\initOnce.d


### PR DESCRIPTION
**Describe the bug**
NPCs don't use ladders properly when they are following the player.

**Expected behavior**
NPCs now use ladders properly when they are following the player.

**Steps to reproduce the issue**
1. Enter the Free Mine with Gorn.
2. Let Gorn run off the main platform.

**Testing**
Run a manual test with `test 136`.

**Additional context**
When Gorn runs off the platform, he struggles to come up again. He starts using the ladder, but falls down midways.

![ScreenShot_2021_2_20_23_20_25](https://user-images.githubusercontent.com/2817152/108609982-41406e00-73d2-11eb-90f0-6b24e6ab53a7.jpg)