### PR TITLE
Gorn attacks the player in the Free Mine

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,7 @@
 * Fix #29: Buster no longer teaches Acrobatics if the player already gained the skill.
 * Fix #30: Silas now trades with the player more than once.
 * Fix #31: Wolf can't be offered Minecrawler's Armor Plates any longer if the player already gave him the requested amount.
+* Fix #32: Gorn no longer attacks the player on the raid of the Free Mine.
 * Fix #33: The quest "Shrike's Hut" can be closed no matter in which order the player gets to know about the quest and defeats Shrike.
 * Fix #36: Fisk's quest "New Fence for Fisk" is now available regardless of how the quest "Thorus' Quest" is (successfully) completed.
 * Fix #38: Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
@@ -91,6 +92,7 @@
 * Fix #29: Buster bringt dem Spieler nicht mehr Akrobatik bei, wenn dieser das Talent bereits gelernt hat.
 * Fix #30: Silas handelt mit dem Spieler nun mehr als nur einmal.
 * Fix #31: Wolf können keine Minecrawlerpanzerplatten mehr angeboten werden, wenn der Spieler ihm schon die erforderliche Anzahl gebracht hat.
+* Fix #32: Gorn greift den Spieler nicht mehr beim Überfall auf die Freie Mine an.
 * Fix #33: Die Quest "Shrike's Hütte" kann nun abgeschlossen werden, unabhängig davon, ob der Spieler zuerst von der Quest erfährt oder Shrike besiegt.
 * Fix #36: Fisks Quest "Neuer Hehler für Fisk" is nun immer erhältlich, egal, wie Thorus' Quest "Auftrag von Thorus" (erfolgreich) beendet wurde.  
 * Fix #38: Snaf spricht nun auch über Nek, wenn die Quest "Snafs Rezept" abgeschlossen wurde. 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix032_GornAttackFreeMine.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix032_GornAttackFreeMine.d
@@ -1,0 +1,152 @@
+/*
+ * #32 Gorn attacks the player in the Free Mine
+ */
+func int Ninja_G1CP_032_GornAttackFreeMine() {
+    if (MEM_FindParserSymbol("B_ReactToMemory")     != -1)
+    && (MEM_FindParserSymbol("B_AssessAndMemorize") != -1) {
+        HookDaedalusFuncS("B_ReactToMemory", "Ninja_G1CP_032_GornAttackFreeMine_GettingAwayWithMurder");
+        HookDaedalusFuncS("B_AssessAndMemorize", "Ninja_G1CP_032_GornAttackFreeMine_PeekMemorize");
+        return TRUE;
+    };
+    return FALSE;
+};
+
+/*
+ * Intercept "B_ReactToMemory" to selectively delete news and their reaction
+ */
+func void Ninja_G1CP_032_GornAttackFreeMine_GettingAwayWithMurder() {
+    // Define possibly missing symbols locally
+    const int NEWS_MURDER       = 200;
+    const int NEWS_ATTACK       = 195;
+    const int NEWS_DEFEAT       = 185;
+    const int NEWS_HASDEFEATED  = 170;
+    const int GIL_GRD           = 2;
+    const int GIL_STT           = 3;
+    const int GIL_VLK           = 5;
+
+    // Update the
+    const int updated = FALSE;
+    if (!updated) {
+        Ninja_G1CP_GetIntVar("NEWS_MURDER", 0, NEWS_MURDER);
+        Ninja_G1CP_GetIntVar("NEWS_ATTACK", 0, NEWS_ATTACK);
+        Ninja_G1CP_GetIntVar("NEWS_DEFEAT", 0, NEWS_DEFEAT);
+        Ninja_G1CP_GetIntVar("NEWS_HASDEFEATED", 0, NEWS_HASDEFEATED);
+        Ninja_G1CP_GetIntVar("GIL_GRD", 0, GIL_GRD);
+        Ninja_G1CP_GetIntVar("GIL_STT", 0, GIL_STT);
+        Ninja_G1CP_GetIntVar("GIL_VLK", 0, GIL_VLK);
+        updated = TRUE;
+    };
+
+    // Interested in Gorn (Free Mine) only
+    if (Hlp_GetInstanceID(self) == MEM_FindParserSymbol("PC_FighterFM")) {
+        var int murderNews; murderNews = Npc_HasNews(self, NEWS_MURDER, NULL, NULL);
+        if (murderNews) {
+            var C_Npc vic; vic = Npc_GetNewsVictim(self, murderNews);
+            if (vic.guild == GIL_VLK)
+            || (vic.guild == GIL_STT)
+            || (vic.guild == GIL_GRD) {
+                // And that, kids, is how you get away with murder
+                MEM_InfoBox("Got away with murder"); // DEBUG
+                Npc_DeleteNews(self, murderNews);
+            };
+        };
+
+
+        // ---------
+        //  Testing
+        // vvvvvvvv
+
+        if (self.aivar[AIV_BEENATTACKED]) {
+            MEM_InfoBox("Been attacked!");
+        };
+
+        var int defeatNews; defeatNews = Npc_HasNews(self, NEWS_DEFEAT, NULL, NULL);
+        if (defeatNews) {
+            var C_Npc defVic; defVic = Npc_GetNewsVictim(self, defeatNews);
+            var C_Npc defOff; defOff = Npc_GetNewsOffender(self, defeatNews);
+
+            var int s; s = SB_New();
+            SB("vic: ");
+            if (Hlp_IsValidNpc(defVic)) {
+                SB(defVic.name);
+            } else {
+                SB("None");
+            };
+            SBc(10); SBc(13);
+            SB("off: ");
+            if (Hlp_IsValidNpc(defOff)) {
+                SB(defOff.name);
+            } else {
+                SB("None");
+            };
+            MEM_InfoBox(SB_ToString());
+            SB_Destroy();
+        };
+
+        // ^^^^^^^^^
+        //  Testing
+        // ---------
+
+    };
+
+    // Continue with original function
+    ContinueCall();
+};
+
+/*
+ * Peek into "B_AssessAndMemorize" for tracing the origin of news
+ */
+func void Ninja_G1CP_032_GornAttackFreeMine_PeekMemorize(var int newsid, var int source, var C_Npc witness,
+                                                         var C_Npc offender, var C_Npc vict) {
+
+    var int fighterId; fighterId = MEM_FindParserSymbol("PC_FighterFM");
+
+    // if (newsid == NEWS_MURDER) {
+        if (Hlp_GetInstanceID(witness) == fighterId)
+        || (Hlp_GetInstanceID(offender) == fighterId)
+        || (Hlp_GetInstanceID(vict) == fighterId) {
+
+            // Get the origin of the call
+            var int callerID; callerID = MEM_GetFuncIDByOffset(MEM_GetCallerStackPos());
+            var string callerName; callerName = MEM_ReadString(MEM_GetSymbolByIndex(callerID));
+
+            // Build message
+            var int s; s = SB_New();
+            SB("nId: "); SBi(newsid); SBc(10); SBc(13);
+            SB("src: "); SBi(source); SBc(10); SBc(13);
+            SB("wit: ");
+            if (Hlp_IsValidNpc(witness)) {
+                SB(witness.name);
+            } else {
+                SB("None");
+            };
+            SBc(10); SBc(13);
+            SB("off: ");
+            if (Hlp_IsValidNpc(offender)) {
+                SB(offender.name);
+            } else {
+                SB("None");
+            };
+            SBc(10); SBc(13);
+            SB("vic: ");
+            if (Hlp_IsValidNpc(vict)) {
+                SB(vict.name);
+            } else {
+                SB("None");
+            };
+            SBc(10); SBc(13);
+            SB("fnc: "); SB(callerName);
+            MEM_InfoBox(SB_ToString());
+            MEM_Info(SB_ToString());
+            SB_Destroy();
+        };
+    // };
+
+    // Call the original function
+    PassArgumentI(newsid);
+    PassArgumentI(source);
+    PassArgumentN(witness);
+    PassArgumentN(offender);
+    PassArgumentN(vict);
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/NinjaInit.d
+++ b/src/Ninja/G1CP/Content/NinjaInit.d
@@ -32,6 +32,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         Ninja_G1CP_029_BusterAcrobatics();                              // #29
         Ninja_G1CP_030_SilasTrade();                                    // #30
         Ninja_G1CP_031_WolfPlateDialog();                               // #31
+        Ninja_G1CP_032_GornAttackFreeMine();                            // #32
         Ninja_G1CP_033_ShrikeQuestDialog();                             // #33
         Ninja_G1CP_036_FiskFenceQuest();                                // #36
         Ninja_G1CP_038_SnafDialogNek();                                 // #38

--- a/src/Ninja/G1CP/Content/Tests/test032.d
+++ b/src/Ninja/G1CP/Content/Tests/test032.d
@@ -1,0 +1,43 @@
+/*
+ * #32 Gorn attacks the player in the Free Mine
+ *
+  * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+  *
+  * Expected behavior: Gorn no longer attacks the player or comments on a death during the raid of the Free Mine.
+  */
+func void Ninja_G1CP_Test_032() {
+     if (Ninja_G1CP_TestsuiteAllowManual) {
+        // Define possibly missing symbols locally
+        const int NPC_FLAG_IMMORTAL = 1 << 1;
+        const int ATR_STRENGTH      = 4;
+
+        // Toggle the attitude changes
+        var int symbPtr; symbPtr = MEM_GetSymbol("Kapitel");
+        if (!symbPtr) {
+            Ninja_G1CP_TestsuiteErrorDetail("Variable 'Kapitel' not found");
+            return;
+        };
+
+        // Setting the variable suffices to trigger the attitude change
+        MEM_WriteInt(symbPtr + zCParSymbol_content_offset, 4);
+
+        // Set PC to invincible to observe the action
+        hero.flags = hero.flags | NPC_FLAG_IMMORTAL;
+
+        // Give the PC enough strength to insta-kill
+        hero.attribute[ATR_STRENGTH] = 1000;
+
+        // But needs a weapon to finish them off
+        EquipWeapon(hero, MEM_FindParserSymbol("ItMw_1H_Sword_Old_01"));
+
+        // Teleport the player to the entrance of the Free Mine
+        if (!Hlp_StrCmp(MEM_World.worldFilename, "FREEMINE.ZEN")) {
+            const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
+            CALL_zStringPtrParam("FM_02");
+            CALL_zStringPtrParam("FREEMINE.ZEN");
+            CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
+        } else {
+            AI_Teleport(hero, "FM_02");
+        };
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -52,6 +52,7 @@ Content\Fixes\Session\fix028_MordragNoEscort.d
 Content\Fixes\Session\fix029_BusterAcrobatics.d
 Content\Fixes\Session\fix030_SilasTrade.d
 Content\Fixes\Session\fix031_WolfPlateDialog.d
+Content\Fixes\Session\fix032_GornAttackFreeMine.d
 Content\Fixes\Session\fix033_ShrikeQuestDialog.d
 Content\Fixes\Session\fix036_FiskFenceQuest.d
 Content\Fixes\Session\fix038_SnafDialogNek.d
@@ -106,6 +107,7 @@ Content\Tests\test028.d
 Content\Tests\test029.d
 Content\Tests\test030.d
 Content\Tests\test031.d
+Content\Tests\test032.d
 Content\Tests\test033.d
 Content\Tests\test036.d
 Content\Tests\test038.d


### PR DESCRIPTION
**Describe the bug**
Gorn sometimes attacks the player on the raid of the Free Mine.

**Expected behavior**
Gorn no longer attacks the player on the raid of the Free Mine.

**Test**
Run manual test with `test 32`.

- [x] Gorn no longer scolds the player for killing NPCs of the Old Camp when talking to him.
      *Triggered by killing a guard when out of sight of Gorn.*
- [x] Gorn no longer warns the player of attacking him again when talking to him.
      *Triggered by defeating guards of the Old Camp.*
- [x] Gorn no longer attacks the player.
      *Triggered by Gorn seeing a guard of the Old Camp attacking the PC first.*