### PR TITLE
Spelling - Rice Lord's Key (EN)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 * Fix #192: Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 #### Story
 * Fix #174: Changed the name "Gomez' Bowl" to "Gomez' Key".
+* Fix #175: Changed the name "Rice Lord's Bowl" to "Rice Lord's Key".
 
 ### v1.0.0 (2021-03-15)
 #### General

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix175_EN_RiceLordKeyName.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix175_EN_RiceLordKeyName.d
@@ -1,0 +1,7 @@
+/*
+ * #175 Spelling - Rice Lord's Key (EN)
+ */
+func int G1CP_175_EN_RiceLordKeyName() {
+    var int symbId; symbId = MEM_GetSymbolIndex("ItKey_RB_01");
+    return (G1CP_ReplaceAssignStr(symbId, "C_Item.name", 0, "Rice Lord's Bowl", "Rice Lord's Key") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test175.d
+++ b/src/Ninja/G1CP/Content/Tests/test175.d
@@ -1,0 +1,37 @@
+/*
+ * #175 Spelling - Rice Lord's Key (EN)
+ *
+ * The name of the item "ItKey_RB_01" is inspected programmatically
+ *
+ * Expected behavior: The key will have the correct name (checked for English localization only)
+ */
+func int G1CP_Test_175() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_EN) {
+        G1CP_TestsuiteErrorDetail("Test applicable for English localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("ItKey_RB_01");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'ItKey_RB_01' not found");
+        return FALSE;
+    };
+
+    // Create the key locally
+    if (Itm_GetPtr(symbId)) {
+        if (Hlp_StrCmp(item.name, "Rice Lord's Key")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Name incorrect: name = '";
+            msg = ConcatStrings(msg, item.name);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'ItKey_RB_01' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -61,6 +61,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_158_SpeedPotion3Value();                   // #158
         G1CP_163_CastleGate();                          // #163
         G1CP_174_EN_GomezKeyName();                     // #174
+        G1CP_175_EN_RiceLordKeyName();                  // #175
         G1CP_192_MagicUserAutoEquip();                  // #192
     };
 };

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -81,6 +81,7 @@ Content\Fixes\Session\fix157_SpeedPotion2Value.d
 Content\Fixes\Session\fix158_SpeedPotion3Value.d
 Content\Fixes\Session\fix163_CastleGate.d
 Content\Fixes\Session\fix174_EN_GomezKeyName.d
+Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
 
 // Game save fixes
@@ -143,6 +144,7 @@ Content\Tests\test157.d
 Content\Tests\test158.d
 Content\Tests\test163.d
 Content\Tests\test174.d
+Content\Tests\test175.d
 Content\Tests\test192.d
 
 // Initialization


### PR DESCRIPTION
**Describe the bug**
In the English localization there's a typo in the Rice Lord's Key's name.

**Changelog**
Changed the name "Rice Lord's Bowl" to "Rice Lord's Key".

**Additional context**
Looks like the translator made a mistake by translating *Schüssel* (Bowl) instead of *Schlüssel* (Key).