### PR TITLE
Spelling - Quest: "Shrikes Hütte" (DE)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -71,6 +71,7 @@
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 #### Story
 * Fix #94: Die Dialogoption mit Horatio "Ich hab' nochmal über die Sache nachgedacht..." ist nun korrigiert zu "Ich hab' noch einmal über die Sache nachgedacht...".
+* Fix #121: Der Name der Quest "Shrike's Hütte" ist nun korrigiert zu "Shrikes Hütte".
 
 ### v1.0.0 (2021-03-15)
 #### General

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix121_DE_LogTopicShrikeHut.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix121_DE_LogTopicShrikeHut.d
@@ -1,0 +1,36 @@
+/*
+ * #121 Spelling - Quest: "Shrikes Hütte" (DE)
+ */
+func int G1CP_121_DE_LogTopicShrikeHut() {
+    const string newName = "Shrikes Hütte";
+    var string curName; curName = G1CP_GetStringVar("CH1_ShrikesHut", 0, "");
+
+    if (Hlp_StrCmp(curName, "Shrike's Hütte")) {
+        G1CP_SetStringVar("CH1_ShrikesHut", 0, newName);
+        G1CP_RenameTopic(curName, newName);
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function reverts the changes of #50
+ */
+func int G1CP_121_DE_LogTopicShrikeHutRevert() {
+    // Only revert if it was applied by the G1CP
+    if (!G1CP_IsFixApplied(121)) {
+        return FALSE;
+    };
+
+    const string oldName = "Shrike's Hütte";
+    var string curName; curName = G1CP_GetStringVar("CH1_ShrikesHut", 0, "");
+
+    if (Hlp_StrCmp(curName, "Shrikes Hütte")) {
+        G1CP_SetStringVar("CH1_ShrikesHut", 0, oldName); // Necessary for re-applying
+        G1CP_RenameTopic(curName, oldName);
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix121_DE_LogTopicShrikeHut.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix121_DE_LogTopicShrikeHut.d
@@ -15,7 +15,7 @@ func int G1CP_121_DE_LogTopicShrikeHut() {
 };
 
 /*
- * This function reverts the changes of #50
+ * This function reverts the changes of #121
  */
 func int G1CP_121_DE_LogTopicShrikeHutRevert() {
     // Only revert if it was applied by the G1CP

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -26,6 +26,7 @@ func void G1CP_GamesaveFixes_Apply() {
     if (G1CP_InitStart()) {                             // Maximum fix function name length: 45 characters
         G1CP_046_SmithDoor();                           // #46
         G1CP_050_Pillar();                              // #50
+        G1CP_121_DE_LogTopicShrikeHut();                // #121
         G1CP_124_GateGuardID();                         // #124
     };
 };
@@ -37,6 +38,7 @@ func void G1CP_GamesaveFixes_Revert() {
     if (G1CP_InitStart()) {                             // Maximum fix function name length: 45 characters
         G1CP_046_SmithDoorRevert();                     // #46
         G1CP_050_PillarRevert();                        // #50
+        G1CP_121_DE_LogTopicShrikeHutRevert();          // #121
         G1CP_124_GateGuardIDRevert();                   // #124
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test121.d
+++ b/src/Ninja/G1CP/Content/Tests/test121.d
@@ -1,0 +1,51 @@
+/*
+ * #121 Spelling - Quest: "Shrikes Hütte" (DE)
+ */
+func int G1CP_Test_121() {
+    // Define possibly missing symbols locally
+    const int LOG_MISSION = 0;
+
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test only applicable for the German localization");
+        return TRUE; // True?
+    };
+
+    // Check if the constant exists
+    if (MEM_GetSymbolIndex("G1CP_GetStringVar") == -1) {
+        G1CP_TestsuiteErrorDetail("Variable 'G1CP_GetStringVar' not found");
+        return FALSE;
+    };
+
+    // Retrieve the content of the log topic string constant
+    var string CH1_ShrikesHut; CH1_ShrikesHut = G1CP_GetStringVar("CH1_ShrikesHut", 0, "G1CP invalid string");
+
+    // Backup the status of the log topic if it exists already
+    var int sectionBak; sectionBak = G1CP_GetTopicSection(CH1_ShrikesHut);
+
+    // Create the topic if it does not exist yet
+    Log_CreateTopic(CH1_ShrikesHut, LOG_MISSION);
+
+    // Check if the log topic exists as expected
+    var int passed; passed = TRUE;
+    const string wrong = "Shrike's Hütte";
+    const string right = "Shrikes Hütte";
+    if (G1CP_GetTopic(wrong)) {
+        G1CP_TestsuiteErrorDetail("Log topic 'Shrike's Hütte' wrongfully exists");
+        passed = FALSE;
+    };
+    if (!G1CP_GetTopic(right)) {
+        G1CP_TestsuiteErrorDetail("Log topic 'Shrikes Hütte' wrongfully does not exist");
+        passed = FALSE;
+    };
+
+    // Restore the topic to how it was before
+    if (sectionBak == -1) {
+        G1CP_RemoveTopic(CH1_ShrikesHut);
+    } else {
+        G1CP_SetTopicSection(CH1_ShrikesHut, sectionBak);
+    };
+
+    // Return success
+    return passed;
+};

--- a/src/Ninja/G1CP/Content/Tests/test121.d
+++ b/src/Ninja/G1CP/Content/Tests/test121.d
@@ -1,7 +1,15 @@
 /*
  * #121 Spelling - Quest: "Shrikes Hütte" (DE)
+ *
+ * The content of the string constant will be checked and a log topic will be temporarily created with the original
+ * topic name. After applying the fix, its name should be updated correctly.
+ *
+ * Expected behavior: The wording of the constant and the log topic name will be correct.
  */
 func int G1CP_Test_121() {
+    var int passed; passed = TRUE;
+    const string right = "Shrikes Hütte";
+
     // Define possibly missing symbols locally
     const int LOG_MISSION = 0;
 
@@ -12,38 +20,55 @@ func int G1CP_Test_121() {
     };
 
     // Check if the constant exists
-    if (MEM_GetSymbolIndex("G1CP_GetStringVar") == -1) {
-        G1CP_TestsuiteErrorDetail("Variable 'G1CP_GetStringVar' not found");
+    if (MEM_GetSymbolIndex("CH1_ShrikesHut") == -1) {
+        G1CP_TestsuiteErrorDetail("Variable 'CH1_ShrikesHut' not found");
         return FALSE;
     };
 
     // Retrieve the content of the log topic string constant
-    var string CH1_ShrikesHut; CH1_ShrikesHut = G1CP_GetStringVar("CH1_ShrikesHut", 0, "G1CP invalid string");
+    var string topic; topic = G1CP_GetStringVar("CH1_ShrikesHut", 0, "G1CP invalid string");
 
-    // Backup the status of the log topic if it exists already
-    var int sectionBak; sectionBak = G1CP_GetTopicSection(CH1_ShrikesHut);
+    // First test: Check if the name is correct in the string constant
 
-    // Create the topic if it does not exist yet
-    Log_CreateTopic(CH1_ShrikesHut, LOG_MISSION);
-
-    // Check if the log topic exists as expected
-    var int passed; passed = TRUE;
-    const string wrong = "Shrike's Hütte";
-    const string right = "Shrikes Hütte";
-    if (G1CP_GetTopic(wrong)) {
-        G1CP_TestsuiteErrorDetail("Log topic 'Shrike's Hütte' wrongfully exists");
-        passed = FALSE;
-    };
-    if (!G1CP_GetTopic(right)) {
-        G1CP_TestsuiteErrorDetail("Log topic 'Shrikes Hütte' wrongfully does not exist");
+    if (!Hlp_StrCmp(topic, right)) {
+        G1CP_TestsuiteErrorDetail(ConcatStrings("Variable 'CH1_ShrikesHut' has incorrect content: ", topic));
         passed = FALSE;
     };
 
-    // Restore the topic to how it was before
-    if (sectionBak == -1) {
-        G1CP_RemoveTopic(CH1_ShrikesHut);
-    } else {
-        G1CP_SetTopicSection(CH1_ShrikesHut, sectionBak);
+    // Second test: Check if an existing topic is updated in the log
+    // For that, we first revert the fix, then create the log topic (with potentially incorrect name), then apply
+    // the fix and finally confirm that the name was correctly updated
+
+    // Remember for later if the log topic already exists
+    var int topicBakPtr; topicBakPtr = G1CP_GetTopic(topic);
+
+    // Revert the fix (careful now, don't overwrite the fix status!)
+    var int r; r = G1CP_121_DE_LogTopicShrikeHutRevert();
+    topic = G1CP_GetStringVar("CH1_ShrikesHut", 0, "G1CP invalid string"); // Original topic name
+
+    // Create the topic with original name temporarily (if it does not exist already)
+    Log_CreateTopic(topic, LOG_MISSION);
+    var int topicTempPtr; topicTempPtr = G1CP_GetTopic(topic);
+
+    // Apply the fix again (careful now, don't overwrite the fix status!)
+    r = G1CP_121_DE_LogTopicShrikeHut();
+
+    // Check if - for some reason - the log topic was not created
+    if (!topicTempPtr) {
+        G1CP_TestsuiteErrorDetail("Log topic could not be created");
+        return FALSE;
+    };
+
+    // Check if its name was updated
+    var oCLogTopic topicTemp; topicTemp = _^(topicTempPtr);
+    if (!Hlp_StrCmp(topicTemp.m_strDescription, right)) {
+        G1CP_TestsuiteErrorDetail(ConcatStrings("Log topic name was not updated: ", topicTemp.m_strDescription));
+        passed = FALSE;
+    };
+
+    // Remove the temporary log topic
+    if (topicTempPtr != topicBakPtr) {
+        G1CP_RemoveTopic(topicTemp.m_strDescription);
     };
 
     // Return success

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -86,6 +86,7 @@ Content\Fixes\Session\fix192_MagicUserAutoEquip.d
 // Game save fixes
 Content\Fixes\Gamesave\fix046_SmithDoor.d
 Content\Fixes\Gamesave\fix050_Pillar.d
+Content\Fixes\Gamesave\fix121_DE_LogTopicShrikeHut.d
 Content\Fixes\Gamesave\fix124_GateGuardID.d
 
 // Tests
@@ -134,6 +135,7 @@ Content\Tests\test102.d
 Content\Tests\test109.d
 Content\Tests\test111.d
 Content\Tests\test112.d
+Content\Tests\test121.d
 Content\Tests\test122.d
 Content\Tests\test124.d
 Content\Tests\test125.d


### PR DESCRIPTION
**Describe the bug**
In the German localization of the game, there's a typo in the quest name of "Shrike's Hut".

**Expected behavior**
No typo in the quest name.

**Changelog**
Die Quest "Shrike's Hütte" korrigiert zu "Shrikes Hütte".

**Additional context**
In Germany this is called a *[Deppenapostroph](https://de.wikipedia.org/wiki/Apostroph#Diskussion_%C3%BCber_fehlerhafte_Verwendung)*.