### PR TITLE
Spelling - Horatio: "zuzuschlagen" (DE)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -70,6 +70,7 @@
 #### General
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 #### Story
+* Fix #93: Im Tagebucheintrag zu der Quest "Horatio der Bauer" is nun die Phrase "[...] stärker zuzuschalgen." korrigiert zu "[...] stärker zuzuschlagen."
 * Fix #94: Die Dialogoption mit Horatio "Ich hab' nochmal über die Sache nachgedacht..." ist nun korrigiert zu "Ich hab' noch einmal über die Sache nachgedacht...".
 
 ### v1.0.0 (2021-03-15)

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix093_DE_HoratioLogEntry.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix093_DE_HoratioLogEntry.d
@@ -1,0 +1,60 @@
+/*
+ * #93 Spelling - Horatio: "zuzuschlagen" (DE)
+ */
+func int G1CP_093_DE_HoratioLogEntry() {
+    // I'm sorry for not breaking the line at 120 characters
+    const string curString = "Horatio, ein Bauer auf den Reisfeldern des Neuen Lagers will mir beibringen, stärker zuzuschalgen. Doch irgendwie habe ich noch nicht die richtige Antwort auf seine Frage WOZU gefunden.";
+    const string newString = "Horatio, ein Bauer auf den Reisfeldern des Neuen Lagers will mir beibringen, stärker zuzuschlagen. Doch irgendwie habe ich noch nicht die richtige Antwort auf seine Frage WOZU gefunden.";
+    const string topicName = "";
+
+    // Do only once per session for performance on consecutive calls
+    const int topicId = -2; // -1 is reserved for invalid symbols
+    const int count   = -1;
+    if (topicId == -2) {
+        // Find and retrieve the topic
+        topicId = MEM_GetSymbolIndex("CH1_HoratiosTeachings");
+        topicName = G1CP_GetStringVarByIndex(topicId, 0, "");
+
+        // Replace the push of the old string with the new string (this is never reverted, i.e. session fix)
+        count = G1CP_ReplacePushStr(MEM_GetSymbolIndex("DIA_Horatio_PleaseTeachSTR_Info"), curString, newString);
+    };
+
+    // Check if the log topic constant exists and if the adding of the log entry was successfully replaced
+    if (topicId == -1) || (count < 1) {
+        return FALSE;
+    };
+
+    // Replace the log entry
+    G1CP_TopicReplaceEntry(topicName, curString, newString);
+
+    // Return success
+    return TRUE;
+};
+
+/*
+ * This function reverts the changes of #93
+ */
+func int G1CP_093_DE_HoratioLogEntryRevert() {
+    // I'm sorry for not breaking the line at 120 characters
+    const string oldString = "Horatio, ein Bauer auf den Reisfeldern des Neuen Lagers will mir beibringen, stärker zuzuschalgen. Doch irgendwie habe ich noch nicht die richtige Antwort auf seine Frage WOZU gefunden.";
+    const string curString = "Horatio, ein Bauer auf den Reisfeldern des Neuen Lagers will mir beibringen, stärker zuzuschlagen. Doch irgendwie habe ich noch nicht die richtige Antwort auf seine Frage WOZU gefunden.";
+    const string topicName = "";
+
+    // Only revert if it was applied by the G1CP
+    if (!G1CP_IsFixApplied(93)) {
+        return FALSE;
+    };
+
+    // Retrieve the topic name only once per session for performance on consecutive calls
+    const int once = 0;
+    if (!once) {
+        topicName = G1CP_GetStringVar("CH1_HoratiosTeachings", 0, "");
+        once = 1;
+    };
+
+    // Revert the log entry
+    G1CP_TopicReplaceEntry(topicName, curString, oldString);
+
+    // Return success
+    return TRUE;
+};

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -26,6 +26,7 @@ func void G1CP_GamesaveFixes_Apply() {
     if (G1CP_InitStart()) {                             // Maximum fix function name length: 45 characters
         G1CP_046_SmithDoor();                           // #46
         G1CP_050_Pillar();                              // #50
+        G1CP_093_DE_HoratioLogEntry();                  // #93
         G1CP_124_GateGuardID();                         // #124
     };
 };
@@ -37,6 +38,7 @@ func void G1CP_GamesaveFixes_Revert() {
     if (G1CP_InitStart()) {                             // Maximum fix function name length: 45 characters
         G1CP_046_SmithDoorRevert();                     // #46
         G1CP_050_PillarRevert();                        // #50
+        G1CP_093_DE_HoratioLogEntryRevert();            // #93
         G1CP_124_GateGuardIDRevert();                   // #124
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test093.d
+++ b/src/Ninja/G1CP/Content/Tests/test093.d
@@ -1,0 +1,107 @@
+/*
+ * #93 Spelling - Horatio: "zuzuschlagen" (DE)
+ *
+ * The faulty log topic entry will be temporarily created and the fix is called, then the dialog function will be
+ * called to check if the entry was correctly created there, too.
+ *
+ * Expected behavior: The wording of the log topic entry will be correct in both cases.
+ */
+func int G1CP_Test_093() {
+    var int passed; passed = TRUE;
+
+    // Define possibly missing symbols locally
+    const int LOG_MISSION = 0;
+    const int LOG_RUNNING = 1;
+
+    // I'm sorry for not breaking the line at 120 characters
+    const string wrong = "Horatio, ein Bauer auf den Reisfeldern des Neuen Lagers will mir beibringen, stärker zuzuschalgen. Doch irgendwie habe ich noch nicht die richtige Antwort auf seine Frage WOZU gefunden.";
+    const string right = "Horatio, ein Bauer auf den Reisfeldern des Neuen Lagers will mir beibringen, stärker zuzuschlagen. Doch irgendwie habe ich noch nicht die richtige Antwort auf seine Frage WOZU gefunden.";
+
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test only applicable for the German localization");
+        return TRUE; // True?
+    };
+
+    // Check if the constant exists
+    if (MEM_GetSymbolIndex("CH1_HoratiosTeachings") == -1) {
+        G1CP_TestsuiteErrorDetail("Variable 'CH1_HoratiosTeachings' not found");
+        passed = FALSE;
+    };
+
+    // Check if the dialog function exists
+    var int funcId; funcId = MEM_GetSymbolIndex("DIA_Horatio_PleaseTeachSTR_Info");
+    if (funcId == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog function 'DIA_Horatio_PleaseTeachSTR_Info' not found");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Retrieve the content of the log topic string constant
+    var string topic; topic = G1CP_GetStringVar("CH1_HoratiosTeachings", 0, "G1CP invalid string");
+
+    // Backup the status of the log topic if it exists already
+    G1CP_RenameTopic(topic, "G1CP test 93 temporary");
+
+    // First pass: Create the log topic with the faulty entry and see if the fix will update it
+
+    // Create the topic
+    Log_CreateTopic(topic, LOG_MISSION);
+    Log_SetTopicStatus(topic, LOG_RUNNING);
+    Log_AddEntry(topic, wrong);
+
+    // Trigger the fix (careful now, don't overwrite the fix status!)
+    var int r; r = G1CP_093_DE_HoratioLogEntry();
+
+    // Check if it was updated
+    if (G1CP_TopicHasEntry(topic, wrong)) {
+        G1CP_TestsuiteErrorDetail("Log topic entry (incorrect) remained unchanged");
+        passed = FALSE;
+    };
+    if (!G1CP_TopicHasEntry(topic, right)) {
+        G1CP_TestsuiteErrorDetail("Log topic entry (correct) does not exist");
+        passed = FALSE;
+    };
+    G1CP_RemoveTopic(topic);
+
+    // Second pass: Call the dialog function and observe if it creates the corrected entry
+
+    // Backup self and other
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);
+    var C_Npc othBak; othBak = MEM_CpyInst(other);
+
+    // Set self and other
+    self  = MEM_CpyInst(hero);
+    other = MEM_CpyInst(hero);
+
+    MEM_CallByID(funcId);
+
+    // Restore self and other
+    self  = MEM_CpyInst(slfBak);
+    other = MEM_CpyInst(othBak);
+
+    // Stop the output units
+    Npc_ClearAIQueue(hero);
+    AI_StandUpQuick(hero);
+
+    // Check if it was updated
+    if (G1CP_TopicHasEntry(topic, wrong)) {
+        G1CP_TestsuiteErrorDetail("Log topic entry was created with incorrect wording");
+        passed = FALSE;
+    };
+    if (!G1CP_TopicHasEntry(topic, right)) {
+        G1CP_TestsuiteErrorDetail("Log topic entry was not added by the dialog function");
+        passed = FALSE;
+    };
+    G1CP_RemoveTopic(topic);
+
+    // Restore the topic to how it was before
+    G1CP_RenameTopic("G1CP test 93 temporary", topic);
+
+    // Return success
+    return passed;
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -86,6 +86,7 @@ Content\Fixes\Session\fix192_MagicUserAutoEquip.d
 // Game save fixes
 Content\Fixes\Gamesave\fix046_SmithDoor.d
 Content\Fixes\Gamesave\fix050_Pillar.d
+Content\Fixes\Gamesave\fix093_DE_HoratioLogEntry.d
 Content\Fixes\Gamesave\fix124_GateGuardID.d
 
 // Tests
@@ -129,6 +130,7 @@ Content\Tests\test059.d
 Content\Tests\test060.d
 Content\Tests\test078.d
 Content\Tests\test079.d
+Content\Tests\test093.d
 Content\Tests\test094.d
 Content\Tests\test102.d
 Content\Tests\test109.d


### PR DESCRIPTION
**Describe the bug**
In the German localization there is a typo for a log entry concerning Horatio's offer.

**Changelog**
Im Tagebucheintrag zu der Quest "Horatio der Bauer" die Phrase "[...] stärker zuzuschalgen." korrigiert zu "[...] stärker zuzuschlagen."