### PR TITLE
Spelling - Gomez' Armor (DE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 
 ### v1.1.0 (TBA)
 #### General
+* Fix #144: Den Namen "Gomez'Rüstung" korrigiert zu "Gomez' Rüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 #### Story
 * Fix #94: Die Dialogoption mit Horatio "Ich hab' nochmal über die Sache nachgedacht..." ist nun korrigiert zu "Ich hab' noch einmal über die Sache nachgedacht...".

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix144_DE_GomezArmorName.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix144_DE_GomezArmorName.d
@@ -1,0 +1,7 @@
+/*
+ * #144 Spelling - Gomez' Armor (DE)
+ */
+func int G1CP_144_DE_GomezArmorName() {
+    var int symbId; symbId = MEM_GetSymbolIndex("EBR_ARMOR_H");
+    return (G1CP_ReplaceAssignStr(symbId, "C_Item.name", 0, "Gomez'Rüstung", "Gomez' Rüstung") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test144.d
+++ b/src/Ninja/G1CP/Content/Tests/test144.d
@@ -1,0 +1,37 @@
+/*
+ * #174 Spelling - Gomez' Armor (DE)
+ *
+ * The name of the item "EBR_ARMOR_H" is inspected programmatically.
+ *
+ * Expected behavior: The armor will have the correct name (checked for German localization only).
+ */
+func int G1CP_Test_144() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("EBR_ARMOR_H");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'EBR_ARMOR_H' not found");
+        return FALSE;
+    };
+
+    // Create the armor locally
+    if (Itm_GetPtr(symbId)) {
+        if (Hlp_StrCmp(item.name, "Gomez' Rüstung")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Name incorrect: name = '";
+            msg = ConcatStrings(msg, item.name);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'EBR_ARMOR_H' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -57,6 +57,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_125_ButcherText();                         // #125
         G1CP_126_SharkyTrade();                         // #126
         G1CP_136_FollowLadder();                        // #136
+        G1CP_144_DE_GomezArmorName();                   // #144
         G1CP_157_SpeedPotion2Value();                   // #157
         G1CP_158_SpeedPotion3Value();                   // #158
         G1CP_163_CastleGate();                          // #163

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -77,6 +77,7 @@ Content\Fixes\Session\fix122_CavalornDailyRoutine.d
 Content\Fixes\Session\fix125_ButcherText.d
 Content\Fixes\Session\fix126_SharkyTrade.d
 Content\Fixes\Session\fix136_FollowLadder.d
+Content\Fixes\Session\fix144_DE_GomezArmorName.d
 Content\Fixes\Session\fix157_SpeedPotion2Value.d
 Content\Fixes\Session\fix158_SpeedPotion3Value.d
 Content\Fixes\Session\fix163_CastleGate.d
@@ -140,6 +141,7 @@ Content\Tests\test124.d
 Content\Tests\test125.d
 Content\Tests\test126.d
 Content\Tests\test136.d
+Content\Tests\test144.d
 Content\Tests\test157.d
 Content\Tests\test158.d
 Content\Tests\test163.d


### PR DESCRIPTION
**Describe the bug**
In the German localization there's a typo in Gomez' Armor's name.

**Changelog**
Den Namen "Gomez'Rüstung" korrigiert zu "Gomez' Rüstung".