### PR TITLE
Spelling - Improved Ore Armor (DE/EN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1.0 (TBA)
 ### General
-* Fix #149: Changed the name "Improved ore Armor" to "Improved Ore Armor".
+* Fix #149: The armor "Improved ore Armor" is now correctly labeled as "Improved Ore Armor".
 * Fix #192: Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 
 ### Story

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.1.0 (TBA)
 ### General
+* Fix #149: Changed the name "Improved ore Armor" to "Improved Ore Armor".
 * Fix #192: Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 
 ### Story

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1.0 (TBA)
 ### General
-* Fix #149: The armor "Improved ore Armor" is now correctly labeled as "Improved Ore Armor".
+* Fix #149: The armor "Improved ore Armor" is now correctly labelled as "Improved Ore Armor".
 * Fix #192: Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 
 ### Story

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -3,6 +3,7 @@
 ## v1.1.0 (TBA)
 ### General
 * Fix #144: Den Namen "Gomez'Rüstung" korrigiert zu "Gomez' Rüstung".
+* Fix #149: Den Namen "verbesserte Erzrüstung" korrigiert zu "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 
 ### Story

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -3,7 +3,7 @@
 ## v1.1.0 (TBA)
 ### General
 * Fix #144: Den Namen "Gomez'Rüstung" korrigiert zu "Gomez' Rüstung".
-* Fix #149: Den Namen "verbesserte Erzrüstung" korrigiert zu "Verbesserte Erzrüstung".
+* Fix #149: Der Name "verbesserte Erzrüstung" ist nun korrigiert zu "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 
 ### Story

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -3,7 +3,7 @@
 ## v1.1.0 (TBA)
 ### General
 * Fix #144: Den Namen "Gomez'Rüstung" korrigiert zu "Gomez' Rüstung".
-* Fix #149: Der Name "verbesserte Erzrüstung" ist nun korrigiert zu "Verbesserte Erzrüstung".
+* Fix #149: Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 
 ### Story

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix149_DE_EN_ImprovedOreArmorName.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix149_DE_EN_ImprovedOreArmorName.d
@@ -1,0 +1,16 @@
+/*
+ * #149 Spelling - Improved Ore Armor (DE/EN)
+ */
+func int G1CP_149_DE_EN_ImprovedOreArmorName() {
+    var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_H");
+    const string needle = "";
+    const string replace = "";
+    if (G1CP_Lang == G1CP_Lang_DE) {
+        needle  = "verbesserte Erzrüstung";
+        replace = "Verbesserte Erzrüstung";
+    } else if (G1CP_Lang == G1CP_Lang_EN) {
+        needle  = "Improved ore Armor";
+        replace = "Improved Ore Armor";
+    };
+    return (G1CP_ReplaceAssignStr(symbId, "C_Item.name", 0, needle, replace) > 0);
+};

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix149_DE_EN_ImprovedOreArmorName.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix149_DE_EN_ImprovedOreArmorName.d
@@ -3,8 +3,8 @@
  */
 func int G1CP_149_DE_EN_ImprovedOreArmorName() {
     var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_H");
-    const string needle = "";
-    const string replace = "";
+    const string needle = "G1CP invalid string";
+    const string replace = "G1CP invalid string";
     if (G1CP_Lang == G1CP_Lang_DE) {
         needle  = "verbesserte Erzrüstung";
         replace = "Verbesserte Erzrüstung";

--- a/src/Ninja/G1CP/Content/Tests/test149.d
+++ b/src/Ninja/G1CP/Content/Tests/test149.d
@@ -3,7 +3,7 @@
  *
  * The text of the item "ORE_ARMOR_H" is inspected programmatically.
  *
- * Expected behavior: The armor will have the correct description (checked for English and German localization only).
+ * Expected behavior: The armor will have the correct name (checked for English and German localization only).
  */
 func int G1CP_Test_149() {
     // Check language first

--- a/src/Ninja/G1CP/Content/Tests/test149.d
+++ b/src/Ninja/G1CP/Content/Tests/test149.d
@@ -22,7 +22,7 @@ func int G1CP_Test_149() {
     // Create the armor locally
     if (Itm_GetPtr(symbId)) {
         if (Hlp_StrCmp(item.name, "Improved Ore Armor")) // EN
-        || (Hlp_StrCmp(item.name, "Verbesserte ErzrÃ¼stung")) { // DE
+        || (Hlp_StrCmp(item.name, "Verbesserte Erzrüstung")) { // DE
             return TRUE;
         } else {
             var string msg; msg = "Text incorrect: name = '";

--- a/src/Ninja/G1CP/Content/Tests/test149.d
+++ b/src/Ninja/G1CP/Content/Tests/test149.d
@@ -1,0 +1,38 @@
+/*
+ * #149 Spelling - Improved Ore Armor (DE/EN)
+ *
+ * The text of the item "ORE_ARMOR_H" is inspected programmatically.
+ *
+ * Expected behavior: The armor will have the correct description (checked for English and German localization only).
+ */
+func int G1CP_Test_149() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_EN) && (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for English and German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_H");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'ORE_ARMOR_H' not found");
+        return FALSE;
+    };
+
+    // Create the armor locally
+    if (Itm_GetPtr(symbId)) {
+        if (Hlp_StrCmp(item.name, "Improved Ore Armor")) // EN
+        || (Hlp_StrCmp(item.name, "Verbesserte Erzrüstung")) { // DE
+            return TRUE;
+        } else {
+            var string msg; msg = "Text incorrect: name = '";
+            msg = ConcatStrings(msg, item.name);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'ORE_ARMOR_H' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -58,6 +58,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_126_SharkyTrade();                         // #126
         G1CP_136_FollowLadder();                        // #136
         G1CP_144_DE_GomezArmorName();                   // #144
+        G1CP_149_DE_EN_ImprovedOreArmorName();          // #149
         G1CP_157_SpeedPotion2Value();                   // #157
         G1CP_158_SpeedPotion3Value();                   // #158
         G1CP_163_CastleGate();                          // #163

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -78,6 +78,7 @@ Content\Fixes\Session\fix125_ButcherText.d
 Content\Fixes\Session\fix126_SharkyTrade.d
 Content\Fixes\Session\fix136_FollowLadder.d
 Content\Fixes\Session\fix144_DE_GomezArmorName.d
+Content\Fixes\Session\fix149_DE_EN_ImprovedOreArmorName.d
 Content\Fixes\Session\fix157_SpeedPotion2Value.d
 Content\Fixes\Session\fix158_SpeedPotion3Value.d
 Content\Fixes\Session\fix163_CastleGate.d
@@ -144,6 +145,7 @@ Content\Tests\test125.d
 Content\Tests\test126.d
 Content\Tests\test136.d
 Content\Tests\test144.d
+Content\Tests\test149.d
 Content\Tests\test157.d
 Content\Tests\test158.d
 Content\Tests\test163.d


### PR DESCRIPTION
**Describe the bug**
In the German and English localization there's a typo in the Improved Ore Armor's name.

**Changelog**
* Den Namen "verbesserte Erzrüstung" korrigiert zu "Verbesserte Erzrüstung".
* Changed the name "Improved ore Armor" to "Improved Ore Armor".