### PR TITLE
Spelling - Horatio: "Ricelord" (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -8,6 +8,7 @@
 
 ### Story
 * Fix #93: Im Tagebucheintrag zu der Quest "Horatio der Bauer" is nun die Phrase "[...] stärker zuzuschalgen." korrigiert zu "[...] stärker zuzuschlagen."
+* Fix #91: Die Dialogauswahl mit Horatio: "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!" is nun korrigiert zu "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!"
 * Fix #94: Die Dialogoption mit Horatio "Ich hab' nochmal über die Sache nachgedacht..." ist nun korrigiert zu "Ich hab' noch einmal über die Sache nachgedacht...".
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix091_DE_HoratioAddChoiceAvenge.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix091_DE_HoratioAddChoiceAvenge.d
@@ -1,0 +1,9 @@
+/*
+ * #91 Spelling - Horatio: "Ricelord" (DE)
+ */
+func int G1CP_091_DE_HoratioAddChoiceAvenge() {
+    var int symbId; symbId = MEM_GetSymbolIndex("DIA_Horatio_ThoughtSTR_Info");
+    const string needle  = "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!";
+    const string replace = "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!";
+    return(G1CP_ReplacePushStr(symbId, needle, replace) > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test091.d
+++ b/src/Ninja/G1CP/Content/Tests/test091.d
@@ -1,0 +1,72 @@
+/*
+ * #91 Spelling - Horatio: "Ricelord" (DE)
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ * Caution: This test will break the game. Be sure to save the game before.
+ *
+ * Expected behavior: The hero is merely teleported there, the dialog choice has the correct wording.
+ */
+func void G1CP_Test_091() {
+    if (!G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for the German localization only");
+        return;
+    };
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if dialog exists
+    if (MEM_GetSymbolIndex("DIA_Horatio_ThoughtSTR") == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog 'DIA_Horatio_ThoughtSTR' not found");
+        passed = FALSE;
+    };
+
+    // Check if required dialogs exist
+    if (MEM_GetSymbolIndex("DIA_Horatio_PleaseTeachSTR") == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog 'DIA_Horatio_PleaseTeachSTR' not found");
+        passed = FALSE;
+    };
+    if (MEM_GetSymbolIndex("DIA_Jeremiah_Horatio") == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog 'DIA_Jeremiah_Horatio' not found");
+        passed = FALSE;
+    };
+
+    // Check if variable exists
+    if (MEM_GetSymbolIndex("horatio_StrFree") == -1) {
+        G1CP_TestsuiteErrorDetail("Variable 'horatio_StrFree' not found");
+        passed = FALSE;
+    };
+
+    // Find the NPC
+    var int symbId; symbId = MEM_GetSymbolIndex("Bau_901_Horatio");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("NPC 'Bau_901_Horatio' not found");
+        return; // Immediately, because there is only one more check below which will fail now anyway
+    };
+
+    // Check if the NPC exists in the world
+    var C_Npc npc; npc = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(npc)) {
+        G1CP_TestsuiteErrorDetail("NPC 'Bau_901_Horatio' not valid");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return;
+    };
+
+    // Set unlock the dialog
+    G1CP_SetInfoTold("DIA_Horatio_Hello", TRUE); // Optional
+    G1CP_SetInfoTold("DIA_Horatio_PleaseTeachSTR", TRUE);
+    G1CP_SetInfoTold("DIA_Jeremiah_Horatio", TRUE);
+    G1CP_SetIntVar("horatio_StrFree", 0, FALSE);
+
+    // Teleport the hero
+    AI_Teleport(hero, npc.wp);
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -48,6 +48,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_060_JesseQuest();                          // #60
         G1CP_078_HumanAttackOrc();                      // #78
         G1CP_079_WolfDexDialog();                       // #79
+        G1CP_091_DE_HoratioAddChoiceAvenge();           // #91
         G1CP_094_DE_HoratioInfoDescThoughtStr();        // #94
         G1CP_102_JesseProtectionMoneyPay();             // #102
         G1CP_109_BloodwynProtectionMoneyPayLater();     // #109

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -68,6 +68,7 @@ Content\Fixes\Session\fix059_NpcEquipBestWeapons.d
 Content\Fixes\Session\fix060_JesseQuest.d
 Content\Fixes\Session\fix078_HumanAttackOrc.d
 Content\Fixes\Session\fix079_WolfDexDialog.d
+Content\Fixes\Session\fix091_DE_HoratioAddChoiceAvenge.d
 Content\Fixes\Session\fix094_DE_HoratioInfoDescThoughtStr.d
 Content\Fixes\Session\fix102_JesseProtectionMoneyPay.d
 Content\Fixes\Session\fix109_BloodwynProtectionMoneyPayLater.d
@@ -133,6 +134,7 @@ Content\Tests\test059.d
 Content\Tests\test060.d
 Content\Tests\test078.d
 Content\Tests\test079.d
+Content\Tests\test091.d
 Content\Tests\test093.d
 Content\Tests\test094.d
 Content\Tests\test102.d


### PR DESCRIPTION
**Describe the bug**
In the German localization, the "Reislord" is wrongly referenced to as "Ricelord". Also the written dialog line differs from the spoken dialog.

**Changelog**
Dialogzeile mit Horatio: "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!" korrigiert zu "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!"

**Additional context**
Reference:
https://github.com/AmProsius/gothic-1-community-patch/blob/f0c8d15ce2879c7913146364f5fdc9899a534639/scriptbase/_work/Data/Scripts/Content/Story/Missions/DIA_BAU_901_Horatio.d#L319-L322

Original:
```d
	if	Npc_KnowsInfo(hero,DIA_Jeremiah_Horatio)
	{
		Info_AddChoice	 (DIA_Horatio_ThoughtSTR, "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!",DIA_Horatio_ThoughtSTR_Ricelord);
	};
```

changed to

```d
	if	Npc_KnowsInfo(hero,DIA_Jeremiah_Horatio)
	{
		Info_AddChoice	 (DIA_Horatio_ThoughtSTR, "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!",DIA_Horatio_ThoughtSTR_Ricelord);
	};
```

See also:

```d
func void DIA_Horatio_ThoughtSTR_Ricelord()
{
	AI_Output (other, self,"DIA_Horatio_ThoughtSTR_Ricelord_15_00"); //Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!
	AI_Output (self, other,"DIA_Horatio_ThoughtSTR_Ricelord_09_01"); //Hmm ... Du bist nicht der Erste, der das versucht.
	horatio_StrFree = TRUE;
	
	Info_ClearChoices(DIA_Horatio_ThoughtSTR );
};
```