### PR TITLE
Text of Improved Ore Armor too long (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -5,7 +5,7 @@
 * Fix #144: Die Rüstung "Gomez'Rüstung" heißt nun korrekt "Gomez' Rüstung".
 * Fix #149: Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
-* Fix #200: Die Beschreibung der *Verbesserten Erzrüstung* passt jetzt in die Textbox.
+* Fix #200: Die Beschreibung der "Verbesserten Erzrüstung" passt jetzt in die Textbox des Inventars.
 
 ### Story
 * Fix #93: Im Tagebucheintrag zu der Quest "Horatio der Bauer" is nun die Phrase "[...] stärker zuzuschalgen." korrigiert zu "[...] stärker zuzuschlagen."

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -5,6 +5,7 @@
 * Fix #144: Die Rüstung "Gomez'Rüstung" heißt nun korrekt "Gomez' Rüstung".
 * Fix #149: Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
+* Fix #200: Die Beschreibung der *Verbesserten Erzrüstung* passt jetzt in die Textbox.
 
 ### Story
 * Fix #93: Im Tagebucheintrag zu der Quest "Horatio der Bauer" is nun die Phrase "[...] stärker zuzuschalgen." korrigiert zu "[...] stärker zuzuschlagen."

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix200_DE_ImprovedOreArmorDescription.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix200_DE_ImprovedOreArmorDescription.d
@@ -1,0 +1,9 @@
+/*
+ * #200 Description of Improved Ore Armor too long (DE)
+ */
+func int G1CP_200_DE_ImprovedOreArmorDescription() {
+    var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_H");
+    const string needle  = "Stone der Schmied hat diese antike Rüstung noch verbessern können!";
+    const string replace = "Stone der Schmied hat sie noch verbessern können!"; // Must be a constant
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.TEXT", 0, needle, replace) > 0);
+};

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix200_DE_ImprovedOreArmorText.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix200_DE_ImprovedOreArmorText.d
@@ -1,7 +1,7 @@
 /*
- * #200 Description of Improved Ore Armor too long (DE)
+ * #200 Text of Improved Ore Armor too long (DE)
  */
-func int G1CP_200_DE_ImprovedOreArmorDescription() {
+func int G1CP_200_DE_ImprovedOreArmorText() {
     var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_H");
     const string needle  = "Stone der Schmied hat diese antike Rüstung noch verbessern können!";
     const string replace = "Stone der Schmied hat sie noch verbessern können!"; // Must be a constant

--- a/src/Ninja/G1CP/Content/Tests/test200.d
+++ b/src/Ninja/G1CP/Content/Tests/test200.d
@@ -1,9 +1,9 @@
 /*
- * #200 Description of Improved Ore Armor too long (DE)
+ * #200 Text of Improved Ore Armor too long (DE)
  *
  * The text of the item "ORE_ARMOR_H" is inspected programmatically.
  *
- * Expected behavior: The armor will have the correct description (checked for German localization only).
+ * Expected behavior: The armor will have the correct text (checked for German localization only).
  */
 func int G1CP_Test_200() {
     // Check language first

--- a/src/Ninja/G1CP/Content/Tests/test200.d
+++ b/src/Ninja/G1CP/Content/Tests/test200.d
@@ -1,0 +1,40 @@
+/*
+ * #200 Description of Improved Ore Armor too long (DE)
+ *
+ * The text of the item "ORE_ARMOR_H" is inspected programmatically.
+ *
+ * Expected behavior: The armor will have the correct description (checked for German localization only).
+ */
+func int G1CP_Test_200() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_H");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'ORE_ARMOR_H' not found");
+        return FALSE;
+    };
+
+    // Create the armor locally
+    if (Itm_GetPtr(symbId)) {
+        // Static string arrays cannot be read directly
+        var string item_text_0; item_text_0 = MEM_ReadStatStringArr(item.text, 0);
+
+        if (Hlp_StrCmp(item_text_0, "Stone der Schmied hat sie noch verbessern können!")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Text incorrect: text[0] = '";
+            msg = ConcatStrings(msg, item_text_0);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'ORE_ARMOR_H' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -65,6 +65,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_174_EN_GomezKeyName();                     // #174
         G1CP_175_EN_RiceLordKeyName();                  // #175
         G1CP_192_MagicUserAutoEquip();                  // #192
+        G1CP_200_DE_ImprovedOreArmorDescription();      // #200
     };
 };
 

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -65,7 +65,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_174_EN_GomezKeyName();                     // #174
         G1CP_175_EN_RiceLordKeyName();                  // #175
         G1CP_192_MagicUserAutoEquip();                  // #192
-        G1CP_200_DE_ImprovedOreArmorDescription();      // #200
+        G1CP_200_DE_ImprovedOreArmorText();             // #200
     };
 };
 

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -85,7 +85,7 @@ Content\Fixes\Session\fix163_CastleGate.d
 Content\Fixes\Session\fix174_EN_GomezKeyName.d
 Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
-Content\Fixes\Session\fix200_DE_ImprovedOreArmorDescription.d
+Content\Fixes\Session\fix200_DE_ImprovedOreArmorText.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix046_SmithDoor.d

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -85,6 +85,7 @@ Content\Fixes\Session\fix163_CastleGate.d
 Content\Fixes\Session\fix174_EN_GomezKeyName.d
 Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
+Content\Fixes\Session\fix200_DE_ImprovedOreArmorDescription.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix046_SmithDoor.d
@@ -152,6 +153,7 @@ Content\Tests\test163.d
 Content\Tests\test174.d
 Content\Tests\test175.d
 Content\Tests\test192.d
+Content\Tests\test200.d
 
 // Initialization
 Content\initPre.d


### PR DESCRIPTION
**Describe the bug**
In the German localization the text of the Improved Ore Armor is too long and doesn't fit in the text box.

**Changelog**
Die Beschreibung der Verbesserten Erzrüstung passt jetzt in die Textbox.

**Additional context**

![ScreenShot_2021_3_21_14_44_41](https://user-images.githubusercontent.com/2817152/111910613-64f2e480-8a62-11eb-8e9b-508bc903ea92.jpg)

