### PR TITLE
Text of Ancient Ore Armor too long (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -5,6 +5,7 @@
 * Fix #144: Die Rüstung "Gomez'Rüstung" heißt nun korrekt "Gomez' Rüstung".
 * Fix #149: Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
+* Fix #201: Die Beschreibung der Antiken Erzrüstung passt jetzt in die Textbox und enthält keinen Rechtschreibfehler mehr.
 
 ### Story
 * Fix #93: Im Tagebucheintrag zu der Quest "Horatio der Bauer" is nun die Phrase "[...] stärker zuzuschalgen." korrigiert zu "[...] stärker zuzuschlagen."

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -5,7 +5,7 @@
 * Fix #144: Die Rüstung "Gomez'Rüstung" heißt nun korrekt "Gomez' Rüstung".
 * Fix #149: Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
-* Fix #201: Die Beschreibung der Antiken Erzrüstung passt jetzt in die Textbox und enthält keinen Rechtschreibfehler mehr.
+* Fix #201: Die Beschreibung der "Antiken Erzrüstung" passt jetzt in die Textbox des Inventars und enthält keinen Rechtschreibfehler mehr.
 
 ### Story
 * Fix #93: Im Tagebucheintrag zu der Quest "Horatio der Bauer" is nun die Phrase "[...] stärker zuzuschalgen." korrigiert zu "[...] stärker zuzuschlagen."

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix201_DE_AncientOreArmorDescription.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix201_DE_AncientOreArmorDescription.d
@@ -1,0 +1,9 @@
+/*
+ * #201 Description of Ancient Ore Armor too long (DE)
+ */
+func int G1CP_201_DE_AncientOreArmorDescription() {
+    var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_M");
+    const string needle  = "Diese uralte Rüstung wurde vollständig aus magischen Erz geschmiedet.";
+    const string replace = "Diese alte Rüstung wurde aus magischem Erz gefertigt."; // Must be a constant
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.TEXT", 0, needle, replace) > 0);
+};

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix201_DE_AncientOreArmorText.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix201_DE_AncientOreArmorText.d
@@ -1,7 +1,7 @@
 /*
- * #201 Description of Ancient Ore Armor too long (DE)
+ * #201 Text of Ancient Ore Armor too long (DE)
  */
-func int G1CP_201_DE_AncientOreArmorDescription() {
+func int G1CP_201_DE_AncientOreArmorText() {
     var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_M");
     const string needle  = "Diese uralte Rüstung wurde vollständig aus magischen Erz geschmiedet.";
     const string replace = "Diese alte Rüstung wurde aus magischem Erz gefertigt."; // Must be a constant

--- a/src/Ninja/G1CP/Content/Tests/test201.d
+++ b/src/Ninja/G1CP/Content/Tests/test201.d
@@ -1,9 +1,9 @@
 /*
- * #201 Description of Ancient Ore Armor too long (DE)
+ * #201 Text of Ancient Ore Armor too long (DE)
  *
  * The text of the item "ORE_ARMOR_M" is inspected programmatically.
  *
- * Expected behavior: The armor will have the correct description (checked for German localization only).
+ * Expected behavior: The armor will have the correct text (checked for German localization only).
  */
 func int G1CP_Test_201() {
     // Check language first

--- a/src/Ninja/G1CP/Content/Tests/test201.d
+++ b/src/Ninja/G1CP/Content/Tests/test201.d
@@ -1,0 +1,40 @@
+/*
+ * #201 Description of Ancient Ore Armor too long (DE)
+ *
+ * The text of the item "ORE_ARMOR_M" is inspected programmatically.
+ *
+ * Expected behavior: The armor will have the correct description (checked for German localization only).
+ */
+func int G1CP_Test_200() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_M");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'ORE_ARMOR_M' not found");
+        return FALSE;
+    };
+
+    // Create the armor locally
+    if (Itm_GetPtr(symbId)) {
+        // Static string arrays cannot be read directly
+        var string item_text_0; item_text_0 = MEM_ReadStatStringArr(item.text, 0);
+
+        if (Hlp_StrCmp(item_text_0, "Diese alte Rüstung wurde aus magischem Erz gefertigt.")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Text incorrect: text[0] = '";
+            msg = ConcatStrings(msg, item_text_0);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'ORE_ARMOR_M' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/Tests/test201.d
+++ b/src/Ninja/G1CP/Content/Tests/test201.d
@@ -5,7 +5,7 @@
  *
  * Expected behavior: The armor will have the correct description (checked for German localization only).
  */
-func int G1CP_Test_200() {
+func int G1CP_Test_201() {
     // Check language first
     if (G1CP_Lang != G1CP_Lang_DE) {
         G1CP_TestsuiteErrorDetail("Test applicable for German localization only");

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -66,6 +66,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_174_EN_GomezKeyName();                     // #174
         G1CP_175_EN_RiceLordKeyName();                  // #175
         G1CP_192_MagicUserAutoEquip();                  // #192
+        G1CP_201_DE_AncientOreArmorDescription();       // #201
     };
 };
 

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -66,7 +66,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_174_EN_GomezKeyName();                     // #174
         G1CP_175_EN_RiceLordKeyName();                  // #175
         G1CP_192_MagicUserAutoEquip();                  // #192
-        G1CP_201_DE_AncientOreArmorDescription();       // #201
+        G1CP_201_DE_AncientOreArmorText();              // #201
     };
 };
 

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -86,6 +86,7 @@ Content\Fixes\Session\fix163_CastleGate.d
 Content\Fixes\Session\fix174_EN_GomezKeyName.d
 Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
+Content\Fixes\Session\fix201_DE_AncientOreArmorDescription.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix046_SmithDoor.d
@@ -156,6 +157,7 @@ Content\Tests\test163.d
 Content\Tests\test174.d
 Content\Tests\test175.d
 Content\Tests\test192.d
+Content\Tests\test201.d
 
 // Initialization
 Content\initPre.d

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -86,7 +86,7 @@ Content\Fixes\Session\fix163_CastleGate.d
 Content\Fixes\Session\fix174_EN_GomezKeyName.d
 Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
-Content\Fixes\Session\fix201_DE_AncientOreArmorDescription.d
+Content\Fixes\Session\fix201_DE_AncientOreArmorText.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix046_SmithDoor.d


### PR DESCRIPTION
**Describe the bug**
In the German localization the text of the Ancient Ore Armor is too long and doesn't fit in the text box.

**Expected behavior**
Die Beschreibung der Antiken Erzrüstung passt jetzt in die Textbox und enthält keinen Rechtschreibfehler mehr.