### PR TITLE
Spelling - Ancient Ore Armor (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -3,6 +3,7 @@
 ## v1.1.0 (TBA)
 ### General
 * Fix #144: Die Rüstung "Gomez'Rüstung" heißt nun korrekt "Gomez' Rüstung".
+* Fix #148: Die Rüstung "antike Erzrüstung" heißt nun korrekt "Antike Erzrüstung".
 * Fix #149: Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix148_DE_AncientOreArmorName.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix148_DE_AncientOreArmorName.d
@@ -1,0 +1,7 @@
+/*
+ * #148 Spelling - Ancient Ore Armor (DE)
+ */
+func int G1CP_148_DE_AncientOreArmorName() {
+    var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_M");
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.NAME", 0, "antike Erzrüstung", "Antike Erzrüstung") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test148.d
+++ b/src/Ninja/G1CP/Content/Tests/test148.d
@@ -8,7 +8,7 @@
 func int G1CP_Test_148() {
     // Check language first
     if (G1CP_Lang != G1CP_Lang_DE) {
-        G1CP_TestsuiteErrorDetail("Test applicable for English and German localization only");
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
         return TRUE; // True?
     };
 

--- a/src/Ninja/G1CP/Content/Tests/test148.d
+++ b/src/Ninja/G1CP/Content/Tests/test148.d
@@ -1,0 +1,37 @@
+/*
+ * #148 Spelling - Ancient Ore Armor (DE)
+ *
+ * The name of the item "ORE_ARMOR_M" is inspected programmatically.
+ *
+ * Expected behavior: The armor will have the correct name (checked for German localization only).
+ */
+func int G1CP_Test_148() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for English and German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("ORE_ARMOR_M");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'ORE_ARMOR_M' not found");
+        return FALSE;
+    };
+
+    // Create the armor locally
+    if (Itm_GetPtr(symbId)) {
+        if (Hlp_StrCmp(item.name, "Antike Erzrüstung")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Text incorrect: name = '";
+            msg = ConcatStrings(msg, item.name);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'ORE_ARMOR_M' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -59,6 +59,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_126_SharkyTrade();                         // #126
         G1CP_136_FollowLadder();                        // #136
         G1CP_144_DE_GomezArmorName();                   // #144
+        G1CP_148_DE_AncientOreArmorName();              // #148
         G1CP_149_DE_EN_ImprovedOreArmorName();          // #149
         G1CP_157_SpeedPotion2Value();                   // #157
         G1CP_158_SpeedPotion3Value();                   // #158

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -79,6 +79,7 @@ Content\Fixes\Session\fix125_ButcherText.d
 Content\Fixes\Session\fix126_SharkyTrade.d
 Content\Fixes\Session\fix136_FollowLadder.d
 Content\Fixes\Session\fix144_DE_GomezArmorName.d
+Content\Fixes\Session\fix148_DE_AncientOreArmorName.d
 Content\Fixes\Session\fix149_DE_EN_ImprovedOreArmorName.d
 Content\Fixes\Session\fix157_SpeedPotion2Value.d
 Content\Fixes\Session\fix158_SpeedPotion3Value.d
@@ -149,6 +150,7 @@ Content\Tests\test125.d
 Content\Tests\test126.d
 Content\Tests\test136.d
 Content\Tests\test144.d
+Content\Tests\test148.d
 Content\Tests\test149.d
 Content\Tests\test157.d
 Content\Tests\test158.d


### PR DESCRIPTION
**Describe the bug**
In the German localization there's a typo in the Ancient Ore Armor's name.

**Changelog**
Den Namen "antike Erzrüstung" korrigiert zu "Antike Erzrüstung".