### PR TITLE
Spelling - Crawler Plate Armor (DE)

### DIFF
--- a/src/Ninja/G1CP/Content/Fixes/Session/fix147_DE_CrawlerPlateArmorName.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix147_DE_CrawlerPlateArmorName.d
@@ -1,0 +1,7 @@
+/*
+ * #147 Spelling - Crawler Plate Armor (DE)
+ */
+func int G1CP_147_DE_CrawlerPlateArmorName() {
+    var int symbId; symbId = MEM_GetSymbolIndex("CRW_ARMOR_H");
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.NAME", 0, "Crawler-Plattenrüstung", "Crawlerplatten-Rüstung") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test147.d
+++ b/src/Ninja/G1CP/Content/Tests/test147.d
@@ -1,0 +1,37 @@
+/*
+ * #147 Spelling - Crawler Plate Armor (DE)
+ *
+ * The name of the item "CRW_ARMOR_H" is inspected programmatically.
+ *
+ * Expected behavior: The armor will have the correct name (checked for German localization only).
+ */
+func int G1CP_Test_147() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("CRW_ARMOR_H");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'CRW_ARMOR_H' not found");
+        return FALSE;
+    };
+
+    // Create the armor locally
+    if (Itm_GetPtr(symbId)) {
+        if (Hlp_StrCmp(item.name, "Crawlerplatten-Rüstung")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Name incorrect: name = '";
+            msg = ConcatStrings(msg, item.name);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'CRW_ARMOR_H' could not be created");
+        return FALSE;
+    };
+};


### PR DESCRIPTION
**Describe the bug**
In the German localization there's a typo in the Crawler Plate Armor's name.

**Changelog**
Den Namen "Crawler-Plattenrüstung" korrigiert zu "Crawlerplatten-Rüstung".

**Additional context**
https://github.com/AmProsius/gothic-1-community-patch/blob/703d7554a7623acd2abbf79318c53dd3ed744690/scriptbase/_work/Data/Scripts/Content/Items/Armor.d#L1057
