### PR TITLE
Spelling - Novice's Loincloth (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -3,6 +3,7 @@
 ## v1.1.0 (TBA)
 ### General
 * Fix #144: Die Rüstung "Gomez'Rüstung" heißt nun korrekt "Gomez' Rüstung".
+* Fix [#146](https://github.com/AmProsius/gothic-1-community-patch/pull/146): Die Rüstung "Novizen Rock" heißt nun korrekt "Novizenrock".
 * Fix #147: Die Rüstung "Crawler-Plattenrüstung" heißt nun korrekt "Crawlerplatten-Rüstung".
 * Fix #149: Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -3,7 +3,7 @@
 ## v1.1.0 (TBA)
 ### General
 * Fix #144: Die Rüstung "Gomez'Rüstung" heißt nun korrekt "Gomez' Rüstung".
-* Fix [#146](https://github.com/AmProsius/gothic-1-community-patch/pull/146): Die Rüstung "Novizen Rock" heißt nun korrekt "Novizenrock".
+* Fix [#146](https://g1cp.org/issue/146): Die Rüstung "Novizen Rock" heißt nun korrekt "Novizenrock".
 * Fix #147: Die Rüstung "Crawler-Plattenrüstung" heißt nun korrekt "Crawlerplatten-Rüstung".
 * Fix #149: Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix146_DE_NovicesLoinclothName.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix146_DE_NovicesLoinclothName.d
@@ -1,0 +1,7 @@
+/*
+ * #146 Spelling - Novice's Loincloth (DE)
+ */
+func int G1CP_146_DE_NovicesLoinclothName() {
+    var int symbId; symbId = MEM_GetSymbolIndex("NOV_ARMOR_L");
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.NAME", 0, "Novizen Rock", "Novizenrock") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test146.d
+++ b/src/Ninja/G1CP/Content/Tests/test146.d
@@ -1,0 +1,37 @@
+/*
+ * #146 Spelling - Novice's Loincloth (DE)
+ *
+ * The name of the item "NOV_ARMOR_L" is inspected programmatically.
+ *
+ * Expected behavior: The armor will have the correct name (checked for German localization only).
+ */
+func int G1CP_Test_146() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("NOV_ARMOR_L");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'NOV_ARMOR_L' not found");
+        return FALSE;
+    };
+
+    // Create the armor locally
+    if (Itm_GetPtr(symbId)) {
+        if (Hlp_StrCmp(item.name, "Novizenrock")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Name incorrect: name = '";
+            msg = ConcatStrings(msg, item.name);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'NOV_ARMOR_L' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -59,6 +59,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_126_SharkyTrade();                         // #126
         G1CP_136_FollowLadder();                        // #136
         G1CP_144_DE_GomezArmorName();                   // #144
+        G1CP_146_DE_NovicesLoinclothName();             // #146
         G1CP_147_DE_CrawlerPlateArmorName();            // #147
         G1CP_149_DE_EN_ImprovedOreArmorName();          // #149
         G1CP_157_SpeedPotion2Value();                   // #157

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -79,6 +79,7 @@ Content\Fixes\Session\fix125_ButcherText.d
 Content\Fixes\Session\fix126_SharkyTrade.d
 Content\Fixes\Session\fix136_FollowLadder.d
 Content\Fixes\Session\fix144_DE_GomezArmorName.d
+Content\Fixes\Session\fix146_DE_NovicesLoinclothName.d
 Content\Fixes\Session\fix147_DE_CrawlerPlateArmorName.d
 Content\Fixes\Session\fix149_DE_EN_ImprovedOreArmorName.d
 Content\Fixes\Session\fix157_SpeedPotion2Value.d
@@ -150,6 +151,7 @@ Content\Tests\test125.d
 Content\Tests\test126.d
 Content\Tests\test136.d
 Content\Tests\test144.d
+Content\Tests\test146.d
 Content\Tests\test147.d
 Content\Tests\test149.d
 Content\Tests\test157.d


### PR DESCRIPTION
**Describe the bug**
In the German localization there's a typo in the Novice's Loincloth's name.

**Changelog**
Den Namen "Novizen Rock" korrigiert zu "Novizenrock".