### PR TITLE
Spelling - Light Mercenary's Armor (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -3,6 +3,7 @@
 ## v1.1.0 (TBA)
 ### General
 * Fix #144: Die Rüstung "Gomez'Rüstung" heißt nun korrekt "Gomez' Rüstung".
+* Fix [#145](https://g1cp.org/issues/145): Die Rüstung "leichte Söldnerrüstung" heißt nun korrekt "Leichte Söldnerrüstung".
 * Fix #147: Die Rüstung "Crawler-Plattenrüstung" heißt nun korrekt "Crawlerplatten-Rüstung".
 * Fix #149: Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix #192: Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix145_DE_LightMercenarysArmorName.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix145_DE_LightMercenarysArmorName.d
@@ -1,0 +1,7 @@
+/*
+ * #145 Spelling - Light Mercenary's Armor (DE)
+ */
+func int G1CP_145_DE_LightMercenarysArmorName() {
+    var int symbId; symbId = MEM_GetSymbolIndex("SLD_ARMOR_L");
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.NAME", 0, "leichte Söldnerrüstung", "Leichte Söldnerrüstung") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test145.d
+++ b/src/Ninja/G1CP/Content/Tests/test145.d
@@ -1,0 +1,37 @@
+/*
+ * #145 Spelling - Light Mercenary's Armor (DE)
+ *
+ * The name of the item "SLD_ARMOR_L" is inspected programmatically.
+ *
+ * Expected behavior: The armor will have the correct name (checked for German localization only).
+ */
+func int G1CP_Test_145() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("SLD_ARMOR_L");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'SLD_ARMOR_L' not found");
+        return FALSE;
+    };
+
+    // Create the armor locally
+    if (Itm_GetPtr(symbId)) {
+        if (Hlp_StrCmp(item.name, "Leichte Söldnerrüstung")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Name incorrect: name = '";
+            msg = ConcatStrings(msg, item.name);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'SLD_ARMOR_L' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -59,6 +59,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_126_SharkyTrade();                         // #126
         G1CP_136_FollowLadder();                        // #136
         G1CP_144_DE_GomezArmorName();                   // #144
+        G1CP_145_DE_LightMercenarysArmorName();         // #145
         G1CP_147_DE_CrawlerPlateArmorName();            // #147
         G1CP_149_DE_EN_ImprovedOreArmorName();          // #149
         G1CP_157_SpeedPotion2Value();                   // #157

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -79,6 +79,7 @@ Content\Fixes\Session\fix125_ButcherText.d
 Content\Fixes\Session\fix126_SharkyTrade.d
 Content\Fixes\Session\fix136_FollowLadder.d
 Content\Fixes\Session\fix144_DE_GomezArmorName.d
+Content\Fixes\Session\fix145_DE_LightMercenarysArmorName.d
 Content\Fixes\Session\fix147_DE_CrawlerPlateArmorName.d
 Content\Fixes\Session\fix149_DE_EN_ImprovedOreArmorName.d
 Content\Fixes\Session\fix157_SpeedPotion2Value.d
@@ -150,6 +151,7 @@ Content\Tests\test125.d
 Content\Tests\test126.d
 Content\Tests\test136.d
 Content\Tests\test144.d
+Content\Tests\test145.d
 Content\Tests\test147.d
 Content\Tests\test149.d
 Content\Tests\test157.d


### PR DESCRIPTION
**Describe the bug**
In the German localization there's a typo in the Light Mercenary Armor's name.

**Changelog**
Den Namen "leichte Söldnerrüstung" korrigiert zu "Leichte Söldnerrüstung".