### PR TITLE
Spelling - Gomez' Key: "Gomez' Truhen" (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -8,6 +8,7 @@
 * Fix [#147](https://g1cp.org/issues/147): Die Rüstung "Crawler-Plattenrüstung" heißt nun korrekt "Crawlerplatten-Rüstung".
 * Fix [#148](https://g1cp.org/issues/148): Die Rüstung "antike Erzrüstung" heißt nun korrekt "Antike Erzrüstung".
 * Fix [#149](https://g1cp.org/issues/149): Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
+* Fix [#173](https://g1cp.org/issues/173): Im Text von "Gomez' Schlüssel" ist nun die Phrase "Öffnet Gomez Truhen" korrigiert zu "Öffnet Gomez' Truhen".
 * Fix [#192](https://g1cp.org/issues/192): Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 * Fix [#200](https://g1cp.org/issues/200): Die Beschreibung der "Verbesserten Erzrüstung" passt jetzt in die Textbox des Inventars.
 * Fix [#201](https://g1cp.org/issues/201): Die Beschreibung der "Antiken Erzrüstung" passt jetzt in die Textbox des Inventars und enthält keinen Rechtschreibfehler mehr.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix173_DE_GomezKeyText.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix173_DE_GomezKeyText.d
@@ -1,0 +1,7 @@
+/*
+ * #173 Spelling - Gomez' Key: "Gomez' Truhen" (DE)
+ */
+func int G1CP_173_DE_GomezKeyText() {
+    var int symbId; symbId = MEM_GetSymbolIndex("ItKe_Gomez_01");
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.TEXT", 0, "Öffnet Gomez Truhen", "Öffnet Gomez' Truhen") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test173.d
+++ b/src/Ninja/G1CP/Content/Tests/test173.d
@@ -1,0 +1,40 @@
+/*
+ * #173 Spelling - Gomez' Key: "Gomez' Truhen" (DE)
+ *
+ * The text of the item "ItKe_Gomez_01" is inspected programmatically.
+ *
+ * Expected behavior: The key will have the correct text (checked for German localization only).
+ */
+func int G1CP_Test_173() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("ItKe_Gomez_01");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'ItKe_Gomez_01' not found");
+        return FALSE;
+    };
+
+    // Create the key locally
+    if (Itm_GetPtr(symbId)) {
+        // Static string arrays cannot be read directly
+        var string item_text_0; item_text_0 = MEM_ReadStatStringArr(item.text, 0);
+
+        if (Hlp_StrCmp(item_text_0, "Öffnet Gomez' Truhen")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Text incorrect: text[0] = '";
+            msg = ConcatStrings(msg, item_text_0);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'ItKe_Gomez_01' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -67,6 +67,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_157_SpeedPotion2Value();                   // #157
         G1CP_158_SpeedPotion3Value();                   // #158
         G1CP_163_CastleGate();                          // #163
+        G1CP_173_DE_GomezKeyText();                     // #173
         G1CP_174_EN_GomezKeyName();                     // #174
         G1CP_175_EN_RiceLordKeyName();                  // #175
         G1CP_192_MagicUserAutoEquip();                  // #192

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -87,6 +87,7 @@ Content\Fixes\Session\fix149_DE_EN_ImprovedOreArmorName.d
 Content\Fixes\Session\fix157_SpeedPotion2Value.d
 Content\Fixes\Session\fix158_SpeedPotion3Value.d
 Content\Fixes\Session\fix163_CastleGate.d
+Content\Fixes\Session\fix173_DE_GomezKeyText.d
 Content\Fixes\Session\fix174_EN_GomezKeyName.d
 Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
@@ -163,6 +164,7 @@ Content\Tests\test149.d
 Content\Tests\test157.d
 Content\Tests\test158.d
 Content\Tests\test163.d
+Content\Tests\test173.d
 Content\Tests\test174.d
 Content\Tests\test175.d
 Content\Tests\test192.d


### PR DESCRIPTION
**Describe the bug**
In the German localization there's a typo in Gomez' Key's text.

**Changelog**
Im Text von Gomez' Schlüssel die Phrase "Öffnet Gomez Truhen" korrigiert zu "Öffnet Gomez' Truhen".
