### PR TITLE
Spelling - Kalom's Recipe (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -8,6 +8,7 @@
 * Fix [#147](https://g1cp.org/issues/147): Die Rüstung "Crawler-Plattenrüstung" heißt nun korrekt "Crawlerplatten-Rüstung".
 * Fix [#148](https://g1cp.org/issues/148): Die Rüstung "antike Erzrüstung" heißt nun korrekt "Antike Erzrüstung".
 * Fix [#149](https://g1cp.org/issues/149): Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
+* Fix [#172](https://g1cp.org/issues/172): Die Schriftrolle "Kalom's Rezept" heißt nun korrekt "Kaloms Rezept".
 * Fix [#192](https://g1cp.org/issues/192): Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 * Fix [#200](https://g1cp.org/issues/200): Die Beschreibung der "Verbesserten Erzrüstung" passt jetzt in die Textbox des Inventars.
 * Fix [#201](https://g1cp.org/issues/201): Die Beschreibung der "Antiken Erzrüstung" passt jetzt in die Textbox des Inventars und enthält keinen Rechtschreibfehler mehr.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -8,7 +8,6 @@
 * Fix [#147](https://g1cp.org/issues/147): Die Rüstung "Crawler-Plattenrüstung" heißt nun korrekt "Crawlerplatten-Rüstung".
 * Fix [#148](https://g1cp.org/issues/148): Die Rüstung "antike Erzrüstung" heißt nun korrekt "Antike Erzrüstung".
 * Fix [#149](https://g1cp.org/issues/149): Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
-* Fix [#172](https://g1cp.org/issues/172): Die Schriftrolle "Kalom's Rezept" heißt nun korrekt "Kaloms Rezept".
 * Fix [#192](https://g1cp.org/issues/192): Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
 * Fix [#200](https://g1cp.org/issues/200): Die Beschreibung der "Verbesserten Erzrüstung" passt jetzt in die Textbox des Inventars.
 * Fix [#201](https://g1cp.org/issues/201): Die Beschreibung der "Antiken Erzrüstung" passt jetzt in die Textbox des Inventars und enthält keinen Rechtschreibfehler mehr.
@@ -18,6 +17,7 @@
 * Fix [#91](https://g1cp.org/issues/91): Die Dialogauswahl mit Horatio: "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!" is nun korrigiert zu "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!"
 * Fix [#94](https://g1cp.org/issues/94): Die Dialogoption mit Horatio "Ich hab' nochmal über die Sache nachgedacht..." ist nun korrigiert zu "Ich hab' noch einmal über die Sache nachgedacht...".
 * Fix [#121](https://g1cp.org/issues/121): Der Name der Quest "Shrike's Hütte" ist nun korrigiert zu "Shrikes Hütte".
+* Fix [#172](https://g1cp.org/issues/172): Das Schriftstück "Kalom's Rezept" heißt nun korrekt "Kaloms Rezept".
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix172_DE_KalomsRecipeName.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix172_DE_KalomsRecipeName.d
@@ -1,0 +1,8 @@
+/*
+ * #172 Spelling - Kalom's Recipe (DE)
+ */
+func int G1CP_172_DE_KalomsRecipeName() {
+    var int symbId; symbId = MEM_GetSymbolIndex("KalomsRecipe");
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.NAME", 0, "Kalom's Rezept", "Kaloms Rezept") > 0);
+};
+

--- a/src/Ninja/G1CP/Content/Tests/test172.d
+++ b/src/Ninja/G1CP/Content/Tests/test172.d
@@ -1,0 +1,37 @@
+/*
+ * #172 Spelling - Kalom's Recipe (DE)
+ *
+ * The name of the item "KalomsRecipe" is inspected programmatically.
+ *
+ * Expected behavior: The scroll will have the correct name (checked for German localization only).
+ */
+func int G1CP_Test_172() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("KalomsRecipe");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'KalomsRecipe' not found");
+        return FALSE;
+    };
+
+    // Create the scroll locally
+    if (Itm_GetPtr(symbId)) {
+        if (Hlp_StrCmp(item.name, "Kaloms Rezept")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "Name incorrect: name = '";
+            msg = ConcatStrings(msg, item.name);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'KalomsRecipe' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -67,6 +67,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_157_SpeedPotion2Value();                   // #157
         G1CP_158_SpeedPotion3Value();                   // #158
         G1CP_163_CastleGate();                          // #163
+        G1CP_172_DE_KalomsRecipeName();                 // #172
         G1CP_174_EN_GomezKeyName();                     // #174
         G1CP_175_EN_RiceLordKeyName();                  // #175
         G1CP_192_MagicUserAutoEquip();                  // #192

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -87,6 +87,7 @@ Content\Fixes\Session\fix149_DE_EN_ImprovedOreArmorName.d
 Content\Fixes\Session\fix157_SpeedPotion2Value.d
 Content\Fixes\Session\fix158_SpeedPotion3Value.d
 Content\Fixes\Session\fix163_CastleGate.d
+Content\Fixes\Session\fix172_DE_KalomsRecipeName.d
 Content\Fixes\Session\fix174_EN_GomezKeyName.d
 Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
@@ -163,6 +164,7 @@ Content\Tests\test149.d
 Content\Tests\test157.d
 Content\Tests\test158.d
 Content\Tests\test163.d
+Content\Tests\test172.d
 Content\Tests\test174.d
 Content\Tests\test175.d
 Content\Tests\test192.d


### PR DESCRIPTION
**Describe the bug**
In the German localization there's a typo in Kalom's Recipe's name.

**Changelog**
Den Namen "Kalom's Rezept" korrigiert zu "Kaloms Rezept".