### PR TITLE
Dialog lines with ambient templar interchanged pt. 1

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -18,6 +18,7 @@
 * Fix [#91](https://g1cp.org/issues/91): Die Dialogauswahl mit Horatio: "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!" lautet nun korrekt "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!"
 * Fix [#94](https://g1cp.org/issues/94): Die Dialogoption mit Horatio "Ich hab' nochmal über die Sache nachgedacht..." lautet nun korrekt "Ich hab' noch einmal über die Sache nachgedacht...".
 * Fix [#121](https://g1cp.org/issues/121): Die Quest "Shrike's Hütte" heißt nun korrekt "Shrikes Hütte".
+* Fix [#142](https://g1cp.org/issues/142): Die Dialogzeile "Wer sind eure Gurus?" im Ambient-Dialog der Templer "Wer hat hier das Sagen?" ist nun korrekt dem Spieler Charakter zugewiesen.
 * Fix [#172](https://g1cp.org/issues/172): Das Schriftstück "Kalom's Rezept" heißt nun korrekt "Kaloms Rezept".
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix142_TemplarVIPDialog.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix142_TemplarVIPDialog.d
@@ -1,0 +1,43 @@
+/*
+ * #142 Dialog lines with ambient templar interchanged pt. 1
+ */
+func int G1CP_142_TemplarVIPDialog() {
+    var int applied; applied = FALSE;
+
+    // Specifics
+    var int funcId; funcId = MEM_GetSymbolIndex("Info_Tpl_8_WichtigePersonen_Info");
+    const string ou = "Info_Tpl_8_WichtigePersonen_15_02";
+
+    // Find all output units
+    const int bytes[2] = {zPAR_TOK_CALLEXTERN<<24, -1};
+    bytes[1] = MEM_GetFuncID(AI_Output);
+    var int matches; matches = G1CP_FindInFunc(funcId, _@(bytes)+3, 5);
+
+    // Iterate over all output units and check the function arguments
+    repeat(i, MEM_ArraySize(matches)); var int i;
+        var int pos; pos = MEM_ArrayRead(matches, i);
+
+        // Read the arguments
+        var int arg1; arg1 = MEM_ReadInt(pos-14); // zPAR_TOK_PUSHINST instance
+        var int arg2; arg2 = MEM_ReadInt(pos-9);  // zPAR_TOK_PUSHINST instance
+        var int arg3; arg3 = MEM_ReadInt(pos-4);  // zPAR_TOK_PUSHVAR  string
+
+        // Confirm: AI_Output(self, other, "Info_Tpl_8_WichtigePersonen_15_02");
+        if (arg1 == self) && (arg2 == other)
+        && (Hlp_StrCmp(G1CP_GetStringVarByIndex(arg3, 0, ""), ou)) {
+
+            // Switch self and other
+            MEMINT_OverrideFunc_Ptr = pos-15;
+            MEMINT_OFTokPar(zPAR_TOK_PUSHINST, other);
+            MEMINT_OFTokPar(zPAR_TOK_PUSHINST, self);
+
+            applied += 1;
+        };
+    end;
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    // Return success
+    return (applied > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test142.d
+++ b/src/Ninja/G1CP/Content/Tests/test142.d
@@ -1,0 +1,12 @@
+/*
+ * #142 Dialog lines with ambient templar interchanged pt. 1
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: The ambient templar NPC that the player is teleported to has the correct subtitles.
+ */
+func void G1CP_Test_142() {
+    if (G1CP_TestsuiteAllowManual) {
+        AI_Teleport(hero, "PSI_GUARD2");
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -58,6 +58,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_125_ButcherText();                         // #125
         G1CP_126_SharkyTrade();                         // #126
         G1CP_136_FollowLadder();                        // #136
+        G1CP_142_TemplarVIPDialog();                    // #142
         G1CP_144_DE_GomezArmorName();                   // #144
         G1CP_145_DE_LightMercenarysArmorName();         // #145
         G1CP_146_DE_NovicesLoinclothName();             // #146

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -78,6 +78,7 @@ Content\Fixes\Session\fix122_CavalornDailyRoutine.d
 Content\Fixes\Session\fix125_ButcherText.d
 Content\Fixes\Session\fix126_SharkyTrade.d
 Content\Fixes\Session\fix136_FollowLadder.d
+Content\Fixes\Session\fix142_TemplarVIPDialog.d
 Content\Fixes\Session\fix144_DE_GomezArmorName.d
 Content\Fixes\Session\fix145_DE_LightMercenarysArmorName.d
 Content\Fixes\Session\fix146_DE_NovicesLoinclothName.d
@@ -156,6 +157,7 @@ Content\Tests\test124.d
 Content\Tests\test125.d
 Content\Tests\test126.d
 Content\Tests\test136.d
+Content\Tests\test142.d
 Content\Tests\test144.d
 Content\Tests\test145.d
 Content\Tests\test146.d


### PR DESCRIPTION
**Describe the bug**
In the German localization a dialog line with an ambient templar is interchanged.

**Changelog**
Vertauschte Dialogzeilen mit einem Ambient-Templer korrigiert.

**Additional context**
See #197 for pt. 2.