### PR TITLE
Exploit: Grindstone in the New Camp can be used without sword blade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.1.0 (TBA)
 ### General
+* Fix [#52](https://g1cp.org/issues/52): The grindstone in the New Camp now correctly requires a sword blade to use.
 * Fix [#149](https://g1cp.org/issues/149): The armor "Improved ore Armor" is now correctly labelled as "Improved Ore Armor".
 * Fix [#192](https://g1cp.org/issues/192): Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -2,6 +2,7 @@
 
 ## v1.1.0 (TBA)
 ### General
+* Fix [#52](https://g1cp.org/issues/52): Der Schleifstein im Neuen Lager setzt zur Benutzung nun korrekt eine Schwertklinge voraus.
 * Fix [#144](https://g1cp.org/issues/144): Die Rüstung "Gomez'Rüstung" heißt nun korrekt "Gomez' Rüstung".
 * Fix [#145](https://g1cp.org/issues/145): Die Rüstung "leichte Söldnerrüstung" heißt nun korrekt "Leichte Söldnerrüstung".
 * Fix [#146](https://g1cp.org/issues/146): Die Rüstung "Novizen Rock" heißt nun korrekt "Novizenrock".

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix052_UseWithItemNCGrindstone.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix052_UseWithItemNCGrindstone.d
@@ -1,0 +1,47 @@
+/*
+ * #52 MOBs in New Camp can be used without corresponding items
+ */
+func int G1CP_052_UseWithItemNCGrindstone() {
+    // Make sure the usage item actually exists
+    const int symbId = -2;
+    if (symbId == -2) {
+        symbId = MEM_GetSymbolIndex("ItMiSwordBlade");
+    };
+    if (symbId == -1) {
+        return FALSE;
+    };
+
+    // Search the VOB
+    var int vobPtr; vobPtr = G1CP_FindVobByPosF(-58212.9141, 3233.08716, 7490.75928);
+    if (Hlp_Is_oCMobInter(vobPtr)) {
+        var oCMobInter mob; mob  = _^(vobPtr);
+        if (Hlp_StrCmp(mob.sceme, "BSSHARP"))
+        && (Hlp_StrCmp(mob.useWithItem, "")) {
+            mob.useWithItem = "ITMISWORDBLADE";
+            return TRUE;
+        };
+    };
+    return FALSE;
+};
+
+/*
+ * This function reverts the changes
+ */
+func int G1CP_052_UseWithItemNCGrindstoneRevert() {
+    // Only revert if it was applied by the G1CP
+    if (!G1CP_IsFixApplied(52)) {
+        return FALSE;
+    };
+
+    // Search the VOB again
+    var int vobPtr; vobPtr = G1CP_FindVobByPosF(-58212.9141, 3233.08716, 7490.75928);
+    if (Hlp_Is_oCMobInter(vobPtr)) {
+        var oCMobInter mob; mob  = _^(vobPtr);
+        if (Hlp_StrCmp(mob.sceme, "BSSHARP"))
+        && (Hlp_StrCmp(mob.useWithItem, "ITMISWORDBLADE")) {
+            mob.useWithItem = "";
+            return TRUE;
+        };
+    };
+    return FALSE;
+};

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -26,6 +26,7 @@ func void G1CP_GamesaveFixes_Apply() {
     if (G1CP_InitStart()) {                             // Maximum fix function name length: 45 characters
         G1CP_046_SmithDoor();                           // #46
         G1CP_050_Pillar();                              // #50
+        G1CP_052_UseWithItemNCGrindstone();             // #52
         G1CP_093_DE_LogEntryHoratio();                  // #93
         G1CP_121_DE_LogTopicShrikeHut();                // #121
         G1CP_124_GateGuardID();                         // #124
@@ -39,6 +40,7 @@ func void G1CP_GamesaveFixes_Revert() {
     if (G1CP_InitStart()) {                             // Maximum fix function name length: 45 characters
         G1CP_046_SmithDoorRevert();                     // #46
         G1CP_050_PillarRevert();                        // #50
+        G1CP_052_UseWithItemNCGrindstoneRevert();       // #52
         G1CP_093_DE_LogEntryHoratioRevert();            // #93
         G1CP_121_DE_LogTopicShrikeHutRevert();          // #121
         G1CP_124_GateGuardIDRevert();                   // #124

--- a/src/Ninja/G1CP/Content/Tests/test052.d
+++ b/src/Ninja/G1CP/Content/Tests/test052.d
@@ -1,0 +1,13 @@
+/*
+ * #52 MOBs in New Camp can be used without corresponding items
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: The grindstone is not usable anymore (without a sword blade).
+ */
+func void G1CP_Test_052() {
+    if (G1CP_TestsuiteAllowManual) {
+        Wld_SetTime(3, 0); // Get that mercenary out of the way
+        AI_Teleport(hero, "NC_HUT03_OUT_MOVEMENT");
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -98,6 +98,7 @@ Content\Fixes\Session\fix201_DE_AncientOreArmorText.d
 // Game save fixes
 Content\Fixes\Gamesave\fix046_SmithDoor.d
 Content\Fixes\Gamesave\fix050_Pillar.d
+Content\Fixes\Gamesave\fix052_UseWithItemNCGrindstone.d
 Content\Fixes\Gamesave\fix093_DE_LogEntryHoratio.d
 Content\Fixes\Gamesave\fix121_DE_LogTopicShrikeHut.d
 Content\Fixes\Gamesave\fix124_GateGuardID.d
@@ -139,6 +140,7 @@ Content\Tests\test044.d
 Content\Tests\test046.d
 Content\Tests\test049.d
 Content\Tests\test050.d
+Content\Tests\test052.d
 Content\Tests\test059.d
 Content\Tests\test060.d
 Content\Tests\test078.d


### PR DESCRIPTION
**Describe the bug**
The grindstone in the New Camp can be used without having a sword blade in the inventory.

**Expected behavior**
The grindstone in the New Camp now correctly requires a sword blade to use.

**Additional context**
It's currently possible to produce *Grobe Schwerter* without having Swordblades in the inventory.  
This issue was split into two further issues #212 #213.  
Add `useWithItem` with `ItMiSwordblade` to grindstone at `NC_HUT03_OUT_MOVEMENT`.

**Screenhots**
![ScreenShot_2021_2_4_23_1_41](https://user-images.githubusercontent.com/2817152/106961677-3b922980-673e-11eb-8f3b-4011b6ae63d9.jpg)