### PR TITLE
Gates triggered by switches are stuck after loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix [#52](https://g1cp.org/issues/52): The grindstone in the New Camp now correctly requires a sword blade to use.
 * Fix [#149](https://g1cp.org/issues/149): The armor "Improved ore Armor" is now correctly labelled as "Improved Ore Armor".
 * Fix [#192](https://g1cp.org/issues/192): Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
+* Fix [#193](https://g1cp.org/issues/193): Objects activated by switches/levers/winches are no longer stuck after loading a game.
 
 ### Story
 * Fix [#37](https://g1cp.org/issues/37): Gravo is now correctly listed as merchant in the Old Camp in the journal.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -11,6 +11,7 @@
 * Fix [#149](https://g1cp.org/issues/149): Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix [#173](https://g1cp.org/issues/173): Im Text von "Gomez' Schlüssel" ist nun die Phrase "Öffnet Gomez Truhen" korrigiert zu "Öffnet Gomez' Truhen".
 * Fix [#192](https://g1cp.org/issues/192): Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix #59 voraus.
+* Fix [#193](https://g1cp.org/issues/193): Objekte, die durch Hebel/Schalter/Winden aktiviert wurden, stecken nach dem Spielladen nicht mehr fest.
 * Fix [#200](https://g1cp.org/issues/200): Die Beschreibung der Rüstung "Verbesserte Erzrüstung" passt nun in die Textbox des Inventars.
 * Fix [#201](https://g1cp.org/issues/201): Die Beschreibung der Rüstung "Antike Erzrüstung" passt nun in die Textbox des Inventars und enthält keinen Rechtschreibfehler mehr.
 

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix193_GateSwitchesStuck.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix193_GateSwitchesStuck.d
@@ -1,0 +1,138 @@
+/*
+ * #193 Gates triggered by switches are stuck after loading
+ *
+ * Originally the idea was to fix the switch states on unarchiving. Unfortunately, the trigger-targets to infer the
+ * state from might not be unarchived at that time. Therefore, the switches are updated post-hoc after loading is
+ * complete. This is, of course, not so elegant or fast.
+ *
+ * The state of this fix is not informative, because it will only show as "applied" right after loading. When the fix
+ * is re-applied after saving, it will no longer be listed as "applied", because it was never reverted (only its state).
+ *
+ * This approach is based on (but much improved): https://forum.worldofplayers.de/forum/threads/?p=25954985
+ */
+
+/*
+ * Obtain the state of a VOB or its trigger-target VOB recursively
+ */
+func int G1CP_193_GateSwitchesStuck_InferState(var string targetVobName) {
+    const int zCTriggerList_vtbl                    = 8239436; //0x7DB94C
+    const int zCTriggerList__activeTargetIdx_offset = 476;     //0x1DC
+    const int zCTriggerList__triggerTargets_offset  = 328;     //0x148
+    const int MOVER_STATE_OPEN                      = 0;
+
+    // Filter out empty targets
+    if (Hlp_StrCmp(targetVobName, "")) {
+        return 0;
+    };
+
+    // Obtain trigger-target VOB
+    var int targetPtr; targetPtr = MEM_SearchVobByName(targetVobName);
+    if (!targetPtr) {
+        return 0;
+    };
+
+    // Check if mover
+    if (Hlp_Is_zCMover(targetPtr)) {
+        var zCMover mover; mover = _^(targetPtr);
+        return (mover.moverState == MOVER_STATE_OPEN);
+    };
+
+    // Check if trigger list
+    if (MEM_ReadInt(targetPtr) == zCTriggerList_vtbl) {
+        var int idx; idx = MEM_ReadInt(targetPtr+zCTriggerList__activeTargetIdx_offset);
+        var int arr; arr = targetPtr+zCTriggerList__triggerTargets_offset;
+        var string act; act = MEM_ReadStringArray(arr, idx);
+        return G1CP_193_GateSwitchesStuck_InferState(act); // Recursion with new trigger target
+    };
+
+    // No target or non-triggerable (== another oCMobInter)
+    return 0;
+};
+
+/*
+ * This function applies the changes
+ */
+func int G1CP_193_GateSwitchesStuck() {
+    var int vobTreePtr; vobTreePtr = _@(MEM_Vobtree);
+    var int worldPtr; worldPtr = _@(MEM_World);
+    var int arrPtr; arrPtr = MEM_ArrayCreate();
+
+    // Find all oCMobInter objects
+    const int zCWorld__SearchVobListByBaseClass = 6250016; //0x5F5E20
+    const int oCMobInter__classDef              = 9285728; //0x8DB060
+    const int call = 0;
+    if (CALL_Begin(call)) {
+        CALL_PtrParam(_@(vobTreePtr));
+        CALL_PtrParam(_@(arrPtr));
+        CALL_PtrParam(_@(oCMobInter__classDef));
+        CALL__thiscall(_@(worldPtr), zCWorld__SearchVobListByBaseClass);
+        call = CALL_End();
+    };
+
+    // Iterate over all found MOBs
+    var int count; count = 0;
+    repeat(i, MEM_ArraySize(arrPtr)); var int i;
+        var int vobPtr; vobPtr = MEM_ArrayRead(arrPtr, i);
+        var oCMobInter mob; mob = _^(vobPtr);
+
+        // Infer the state from potential trigger targets (if none, zero)
+        var int state; state = G1CP_193_GateSwitchesStuck_InferState(mob.triggerTarget);
+
+        // Update animation and state
+        if (state != mob.state) {
+
+            // Get MOB model
+            var int model; model = mob._zCVob_visual;
+            if (model) {
+                if (MEM_ReadInt(model+88)) { // Extra safety: Check for zCModelPrototype
+                    const string aniStr = "";
+                    aniStr = ConcatStrings("S_S", IntToString(state));
+
+                    // Check if the model has the corresponding animation
+                    const int zCModel__GetAniIDFromAniName = 4713552; //0x47EC50
+                    const int strPtr = 0;
+                    const int call2 = 0;
+                    if (CALL_Begin(call2)) {
+                        strPtr = _@s(aniStr);
+                        CALL_PtrParam(_@(strPtr));
+                        CALL_PutRetValTo(_@(aniId));
+                        CALL__thiscall(_@(model), zCModel__GetAniIDFromAniName);
+                        call2 = CALL_End();
+                    };
+
+                    // Only if it does, apply it
+                    var int aniId;
+                    if (aniId != -1) {
+                        const int zCModel__StartAni = 5640864; //0x5612A0
+                        const int call3 = 0;
+                        if (CALL_Begin(call3)) {
+                            CALL_IntParam(_@(FALSE));
+                            CALL_PtrParam(_@(aniId));
+                            CALL__thiscall(_@(model), zCModel__StartAni);
+                            call3 = CALL_End();
+                        };
+
+                        // Finally update the state
+                        mob.state = state;
+                        mob.state_target = state;
+
+                        count += 1;
+                    };
+                };
+            };
+        };
+    end;
+
+    // Free the array
+    MEM_ArrayFree(arrPtr);
+
+    // Return success
+    return (count > 0);
+};
+
+/*
+ * No need to revert anything. This function is just added for completeness
+ */
+func int G1CP_193_GateSwitchesStuckRevert() {
+    return TRUE;
+};

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -31,6 +31,7 @@ func void G1CP_GamesaveFixes_Apply() {
         G1CP_093_DE_LogEntryHoratio();                  // #93
         G1CP_121_DE_LogTopicShrikeHut();                // #121
         G1CP_124_GateGuardID();                         // #124
+        G1CP_193_GateSwitchesStuck();                   // #193
     };
 };
 
@@ -46,5 +47,6 @@ func void G1CP_GamesaveFixes_Revert() {
         G1CP_093_DE_LogEntryHoratioRevert();            // #93
         G1CP_121_DE_LogTopicShrikeHutRevert();          // #121
         G1CP_124_GateGuardIDRevert();                   // #124
+        G1CP_193_GateSwitchesStuckRevert();             // #193
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test193.d
+++ b/src/Ninja/G1CP/Content/Tests/test193.d
@@ -1,0 +1,47 @@
+/*
+ * #193 Gates triggered by switches are stuck after loading
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ * Caution: This test breaks the game. Save the game beforehand.
+ *
+ * Expected behavior: The gate (that the PC is teleported to) can be opened again after closing it, saving and loading.
+ */
+func void G1CP_Test_193() {
+    if (!G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Find the gate guard
+    var int symbId; symbId = MEM_GetSymbolIndex("GRD_230_Gardist");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("NPC 'GRD_230_Gardist' not found");
+        return;
+    };
+
+    // Check if gate guard exists in the world
+    var C_Npc npc; npc = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(npc)) {
+        G1CP_TestsuiteErrorDetail("NPC 'GRD_230_Gardist' not valid");
+        passed = FALSE;
+    };
+
+    // Find the daily routine
+    if (MEM_GetSymbolIndex("Rtn_OMFull_230") == -1) {
+        G1CP_TestsuiteErrorDetail("Daily routine function 'Rtn_OMFull_230' not found");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return;
+    };
+
+    // Change the routine of the NPC to leave the player alone
+    Npc_ExchangeRoutine(npc, "OMFull");
+
+    // Teleport the player to the gate
+    AI_Teleport(hero, "OCC_MAINGATE_VWHEEL");
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -104,6 +104,7 @@ Content\Fixes\Gamesave\fix052_UseWithItemNCGrindstone.d
 Content\Fixes\Gamesave\fix093_DE_LogEntryHoratio.d
 Content\Fixes\Gamesave\fix121_DE_LogTopicShrikeHut.d
 Content\Fixes\Gamesave\fix124_GateGuardID.d
+Content\Fixes\Gamesave\fix193_GateSwitchesStuck.d
 
 // Tests
 Content\Tests\test001.d
@@ -176,6 +177,7 @@ Content\Tests\test173.d
 Content\Tests\test174.d
 Content\Tests\test175.d
 Content\Tests\test192.d
+Content\Tests\test193.d
 Content\Tests\test200.d
 Content\Tests\test201.d
 


### PR DESCRIPTION
**Describe the bug**
After using a switch/lever/winch to close a gate, the switch does not work anymore after loading a game and the gate is stuck.

**Expected behavior**
Objects activated by switches/levers/winches are no longer stuck after loading a game.

**Steps to reproduce the issue**
1. Close a gate by using the respective switch.
2. Save the game.
3. Load the game.
4. The switch state returns to 0 while the gate remains in its triggered state: The gate will be stuck for good.

**Additional context**
[Attached](https://www.sendspace.com/file/49pe45) the fix done by szapp 2 years ago.  
See also the original post on WoG: https://forum.worldofplayers.de/forum/threads/?p=25954985