### PR TITLE
Baal Namib sells Novice's Armor too late

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix [#192](https://g1cp.org/issues/192): Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 
 ### Story
+* Fix [#23](https://g1cp.org/issues/23): The armor "Novice's Armor" is now available in chapter 2 to make it accessible before receiving the first templar armor.
 * Fix [#37](https://g1cp.org/issues/37): Gravo is now correctly listed as merchant in the Old Camp in the journal.
 * Fix [#174](https://g1cp.org/issues/174): The key "Gomez' Bowl" is now correctly labelled as "Gomez' Key".
 * Fix [#175](https://g1cp.org/issues/175): The key "Rice Lord's Bowl" is now correctly labelled as "Rice Lord's Key".

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -15,6 +15,7 @@
 * Fix [#201](https://g1cp.org/issues/201): Die Beschreibung der Rüstung "Antike Erzrüstung" passt nun in die Textbox des Inventars und enthält keinen Rechtschreibfehler mehr.
 
 ### Story
+* Fix [#23](https://g1cp.org/issues/23): Die Rüstung "Novizenrüstung" ist nun im zweiten Kapitel erhältlich damit sie vor der ersten Templarrüstung erlangt werden kann.
 * Fix [#37](https://g1cp.org/issues/37): Gravo ist nun korrekt als Händler im Alten Lager im Tagebuch aufgelistet.
 * Fix [#93](https://g1cp.org/issues/93): Im Tagebucheintrag zu der Quest "Horatio der Bauer" lautet die Phrase "[...] stärker zuzuschalgen." nun korrekt "[...] stärker zuzuschlagen."
 * Fix [#91](https://g1cp.org/issues/91): Die Dialogauswahl mit Horatio: "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!" lautet nun korrekt "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!"

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix023_BaalNamibSellArmor.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix023_BaalNamibSellArmor.d
@@ -1,0 +1,35 @@
+/*
+ * #23 Baal Namib sells Novice's Armor too late
+ */
+func int G1CP_023_BaalNamibSellArmor() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int funcId;  funcId = MEM_GetSymbolIndex("GUR_1204_BaalNamib_ARMOR_Info");
+    var int chptrId; chptrId = MEM_GetSymbolIndex("Kapitel");
+    if (funcId == -1) || (chptrId == -1) {
+        return FALSE;
+    };
+
+    // Find byte code in dialog function corresponding to: if (Kapitel < 3)
+    const int bytes[3] = {0, 0, 0}; // 12 bytes used
+    MEMINT_OverrideFunc_Ptr = _@(bytes);
+    MEMINT_OFTokPar(zPAR_TOK_PUSHINT, 3);
+    MEMINT_OFTokPar(zPAR_TOK_PUSHVAR, chptrId);
+    MEMINT_OFTok(zPAR_OP_LOWER);
+    MEMINT_OFTok(zPAR_TOK_JUMPF);
+    var int matches; matches = G1CP_FindInFunc(funcId, _@(bytes), 12);
+
+    // There should only be one occurrence, otherwise no chance to identify the correct position in the function
+    if (MEM_ArraySize(matches) == 1) {
+        var int pos; pos = MEM_ArrayRead(matches, 0)+1; // Just before "3"
+        MEM_WriteInt(pos, 2);
+        applied = TRUE;
+    };
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    // Return success
+    return applied;
+};

--- a/src/Ninja/G1CP/Content/Tests/test023.d
+++ b/src/Ninja/G1CP/Content/Tests/test023.d
@@ -1,0 +1,111 @@
+/*
+ * #23 Baal Namib sells Novice's Armor too late
+ *
+ * The dialog function is called with the necessary requirements.
+ *
+ * Expected behavior: The armor is sold at chapter 2.
+ */
+func int G1CP_Test_023() {
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if the dialog function exists
+    var int funcId; funcId = MEM_GetSymbolIndex("GUR_1204_BaalNamib_ARMOR_Info");
+    if (funcId == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog function 'GUR_1204_BaalNamib_ARMOR_Info' not found");
+        passed = FALSE;
+    };
+
+    // Check if the variable exists
+    var int chapterPtr; chapterPtr = MEM_GetSymbol("Kapitel");
+    if (!chapterPtr) {
+        G1CP_TestsuiteErrorDetail("Variable 'Kapitel' not found");
+        passed = FALSE;
+    };
+    chapterPtr += zCParSymbol_content_offset;
+
+    // Check if the armor item exists
+    var int armorId; armorId = MEM_GetSymbolIndex("NOV_ARMOR_H");
+    if (armorId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'NOV_ARMOR_H' not found");
+        passed = FALSE;
+    };
+
+    // Check if the ore item exists
+    var int oreId; oreId = MEM_GetSymbolIndex("ItMinugget");
+    if (oreId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'ItMinugget' not found");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Backup values
+    var int chapterBak; chapterBak = MEM_ReadInt(chapterPtr);
+    var int armorBefore; armorBefore = Npc_HasItems(hero, armorId);
+    var int oreBefore; oreBefore = Npc_HasItems(hero, oreId);
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);
+    var C_Npc othBak; othBak = MEM_CpyInst(other);
+
+    // Remove all armor (ignores equipped armor, give me a break)
+    if (armorBefore > 0) {
+        Npc_RemoveInvItems(hero, armorId, armorBefore);
+    };
+    if (oreBefore > 0) {
+        Npc_RemoveInvItems(hero, oreId, oreBefore);
+    };
+
+    // Set variable
+    MEM_WriteInt(chapterPtr, 2);
+
+    // Give enough ore (don't care about the details)
+    CreateInvItems(hero, oreId, 5000);
+
+    // Set self and other
+    GetItemHelper();
+    self  = MEM_CpyInst(Item_Helper);
+    other = MEM_CpyInst(hero);
+
+    // Just run the dialog and see what happens
+    MEM_CallByID(funcId);
+
+    // Restore self and other
+    self  = MEM_CpyInst(slfBak);
+    other = MEM_CpyInst(othBak);
+
+    // Stop the output units
+    Npc_ClearAIQueue(hero);
+    AI_StandUpQuick(hero);
+
+    // Restore the amount of ore
+    var int oreAfter; oreAfter = Npc_HasItems(hero, oreId);
+    if (oreAfter > 0) {
+        Npc_RemoveInvItems(hero, oreId, oreAfter);
+    };
+    if (oreBefore > 0) {
+        CreateInvItems(hero, oreId, oreBefore);
+    };
+
+    // Restore the armor
+    var int armorAfter; armorAfter = Npc_HasItems(hero, armorId);
+    if (armorAfter > 0) {
+        Npc_RemoveInvItems(hero, armorId, armorAfter);
+    };
+    if (armorBefore > 0) {
+        CreateInvItems(hero, armorId, armorBefore);
+    };
+
+    // Revert variable
+    MEM_WriteInt(chapterPtr, chapterBak);
+
+    // Check the amount
+    if (armorAfter > 0) {
+        return TRUE;
+    } else {
+        G1CP_TestsuiteErrorDetail("The hero did not receive the armor");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -26,6 +26,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_020_KirgoGivesBeer();                      // #20
         G1CP_021_FletcherClosedQuest();                 // #21
         G1CP_022_YBerionAttacks();                      // #22
+        G1CP_023_BaalNamibSellArmor();                  // #23
         G1CP_024_CorKalomWrongQuest();                  // #24
         G1CP_025_SaturasSellsRobe();                    // #25
         G1CP_026_LaresGuardAttacks();                   // #26

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -46,6 +46,7 @@ Content\Fixes\Session\fix019_ScorpioFightDialog.d
 Content\Fixes\Session\fix020_KirgoGivesBeer.d
 Content\Fixes\Session\fix021_FletcherClosedQuest.d
 Content\Fixes\Session\fix022_YBerionAttacks.d
+Content\Fixes\Session\fix023_BaalNamibSellArmor.d
 Content\Fixes\Session\fix024_CorKalomWrongQuest.d
 Content\Fixes\Session\fix025_SaturasSellsRobe.d
 Content\Fixes\Session\fix026_LaresGuardAttacks.d
@@ -122,6 +123,7 @@ Content\Tests\test019.d
 Content\Tests\test020.d
 Content\Tests\test021.d
 Content\Tests\test022.d
+Content\Tests\test023.d
 Content\Tests\test024.d
 Content\Tests\test025.d
 Content\Tests\test026.d


### PR DESCRIPTION
**Describe the bug**
Baal Namib doesn't sell the Novice's Armor until chapter 3, but the player can already become a Templar in chapter 2.

**Expected behavior**
Baal Namib now sells the Novice's Armor in chapter 2 already, if the Minecrawler Queen quest is running or completed.