### PR TITLE
Improve fisk fence quest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix [#192](https://g1cp.org/issues/192): Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 
 ### Story
+* Fix [#36](https://g1cp.org/issues/36) (updated): Fisk's quest "New Fence for Fisk" is now available when the player either knocked out or killed Mordrag.
 * Fix [#37](https://g1cp.org/issues/37): Gravo is now correctly listed as merchant in the Old Camp in the journal.
 * Fix [#174](https://g1cp.org/issues/174): The key "Gomez' Bowl" is now correctly labelled as "Gomez' Key".
 * Fix [#175](https://g1cp.org/issues/175): The key "Rice Lord's Bowl" is now correctly labelled as "Rice Lord's Key".
@@ -49,7 +50,7 @@
 * Fix [#31](https://g1cp.org/issues/31): Wolf can't be offered Minecrawler's Armor Plates any longer if the player already gave him the requested amount.
 * Fix [#32](https://g1cp.org/issues/32): Gorn no longer attacks the player on the raid of the Free Mine.
 * Fix [#33](https://g1cp.org/issues/33): The quest "Shrike's Hut" can be closed no matter in which order the player gets to know about the quest and defeats Shrike.
-* Fix [#36](https://g1cp.org/issues/36): Fisk's quest "New Fence for Fisk" is now available regardless of how the quest "Thorus' Quest" is (successfully) completed.
+* Fix [#36](https://g1cp.org/issues/36): Fisk's quest "New Fence for Fisk" is now available regardless of how the quest "Thorus' Quest" is (successfully) completed. (revisited in v1.1.0)
 * Fix [#38](https://g1cp.org/issues/38): Snaf now offers the dialog about Nek even when the quest "Snaf's Recipe" is completed.
 * Fix [#39](https://g1cp.org/issues/39): Fingers no longer offers to teach level two of pickpocketing and lock picking before level one has been learned.
 * Fix [#40](https://g1cp.org/issues/40): Aleph doesn't offer to sell the key anymore when the player already obtained it.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -15,6 +15,7 @@
 * Fix [#201](https://g1cp.org/issues/201): Die Beschreibung der Rüstung "Antike Erzrüstung" passt nun in die Textbox des Inventars und enthält keinen Rechtschreibfehler mehr.
 
 ### Story
+* Fix [#36](https://g1cp.org/issues/36) (aktualisiert): Fisks Quest "Neuer Hehler für Fisk" is nun verfügbar, wenn der Spieler Mordrag entweder KO geschlagen oder getötet hat.
 * Fix [#37](https://g1cp.org/issues/37): Gravo ist nun korrekt als Händler im Alten Lager im Tagebuch aufgelistet.
 * Fix [#93](https://g1cp.org/issues/93): Im Tagebucheintrag zu der Quest "Horatio der Bauer" lautet die Phrase "[...] stärker zuzuschalgen." nun korrekt "[...] stärker zuzuschlagen."
 * Fix [#91](https://g1cp.org/issues/91): Die Dialogauswahl mit Horatio: "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!" lautet nun korrekt "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!"
@@ -60,7 +61,7 @@
 * Fix [#31](https://g1cp.org/issues/31): Wolf können keine Minecrawlerpanzerplatten mehr angeboten werden, wenn der Spieler ihm schon die erforderliche Anzahl gebracht hat.
 * Fix [#32](https://g1cp.org/issues/32): Gorn greift den Spieler nicht mehr beim Überfall auf die Freie Mine an.
 * Fix [#33](https://g1cp.org/issues/33): Die Quest "Shrike's Hütte" kann nun abgeschlossen werden, unabhängig davon, ob der Spieler zuerst von der Quest erfährt oder Shrike besiegt.
-* Fix [#36](https://g1cp.org/issues/36): Fisks Quest "Neuer Hehler für Fisk" is nun immer erhältlich, egal, wie Thorus' Quest "Auftrag von Thorus" (erfolgreich) beendet wurde.  
+* Fix [#36](https://g1cp.org/issues/36): Fisks Quest "Neuer Hehler für Fisk" is nun immer erhältlich, egal, wie Thorus' Quest "Auftrag von Thorus" (erfolgreich) beendet wurde. (überarbeitet in v1.1.0)
 * Fix [#38](https://g1cp.org/issues/38): Snaf spricht nun auch über Nek, wenn die Quest "Snafs Rezept" abgeschlossen wurde. 
 * Fix [#39](https://g1cp.org/issues/39): Fingers lehrt nicht mehr Taschendiebstahl und Schlösserknacken auf Stufe zwei, wenn Stufe eins jeweils noch nicht gelernt wurde.
 * Fix [#40](https://g1cp.org/issues/40): Aleph bietet den Schlüssel nun nicht noch einmal an, wenn der Spieler ihn schon erhalten hat.

--- a/src/Ninja/G1CP/Content/Tests/test036.d
+++ b/src/Ninja/G1CP/Content/Tests/test036.d
@@ -21,20 +21,6 @@ func int G1CP_Test_036() {
         passed = FALSE;
     };
 
-    // Find Mordrag
-    var int symbId; symbId = MEM_GetSymbolIndex("Org_826_Mordrag");
-    if (symbId == -1) {
-        G1CP_TestsuiteErrorDetail("NPC 'Org_826_Mordrag' not found");
-        passed = FALSE;
-    };
-
-    // Check if Mordrag exists in the world
-    var C_Npc mordrag; mordrag = Hlp_GetNpc(symbId);
-    if (!Hlp_IsValidNpc(mordrag)) {
-        G1CP_TestsuiteErrorDetail("NPC 'Org_826_Mordrag' not valid");
-        passed = FALSE;
-    };
-
     // Check if variable exists
     var int hauAbPtr; hauAbPtr = MEM_GetSymbol("MordragKO_HauAb");
     if (!hauAbPtr) {
@@ -50,6 +36,20 @@ func int G1CP_Test_036() {
         passed = FALSE;
     };
     stayAtNcPtr += zCParSymbol_content_offset;
+
+    // Find Mordrag
+    var int symbId; symbId = MEM_GetSymbolIndex("Org_826_Mordrag");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("NPC 'Org_826_Mordrag' not found");
+        return FALSE; // Fail immediately, because the following (last) check will fail now anyway
+    };
+
+    // Check if Mordrag exists in the world
+    var C_Npc mordrag; mordrag = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(mordrag)) {
+        G1CP_TestsuiteErrorDetail("NPC 'Org_826_Mordrag' not valid");
+        passed = FALSE;
+    };
 
     // At the latest now, we need to stop if there are fails already
     if (!passed) {
@@ -71,7 +71,7 @@ func int G1CP_Test_036() {
     other = MEM_CpyInst(hero);                                   // Other
 
     // Now do two passes for each OR-condition
-    var int ret; ret = 0;
+    var int pass1; var int pass2;
 
     // First pass: Mordrag is dead but MordragKO_StayAtNC if false
     mordrag.attribute[ATR_HITPOINTS] = 0;
@@ -79,8 +79,8 @@ func int G1CP_Test_036() {
 
     // Call dialog condition function
     MEM_CallByID(funcId);
-    ret += MEM_PopIntResult();
-    if (!ret) {
+    pass1 = MEM_PopIntResult();
+    if (!pass1) {
         G1CP_TestsuiteErrorDetail("Condition 'Mordrag is dead' failed");
     };
 
@@ -90,9 +90,9 @@ func int G1CP_Test_036() {
 
     // Call dialog condition function
     MEM_CallByID(funcId);
-    ret += MEM_PopIntResult();
-    if (!ret) {
-        G1CP_TestsuiteErrorDetail("Condition 'stay at NC' failed");
+    pass2 = MEM_PopIntResult();
+    if (pass2) {
+        G1CP_TestsuiteErrorDetail("Condition 'stay at NC' did not fail");
     };
 
     // Restore values
@@ -104,5 +104,5 @@ func int G1CP_Test_036() {
     MEM_WriteInt(hauAbPtr, hauAbBak);                            // Variable
 
     // Check return value
-    return (ret == 2);
+    return (pass1) && (!pass2);
 };


### PR DESCRIPTION
This PR constraints the conditions introduced in v1.1.0 in #36. Now the fence quest is only available if Mordrag was knocked down (default) or if he is dead. The additional option of him being in the New Camp was removed here.

Additionally, the fix was reimplemented to fix a major bug of overwriting the global variable `MordragKO_HauAb`, which would cause inwanted side-effects in other dialogs/story.

### Description
Fixes #36.

### Test
Run automatic test with `test 36`.
