### PR TITLE
Exploit: The gate guard can be bribed multiple times with Dusty as a follower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix [#37](https://g1cp.org/issues/37): Gravo is now correctly listed as merchant in the Old Camp in the journal.
 * Fix [#174](https://g1cp.org/issues/174): The key "Gomez' Bowl" is now correctly labelled as "Gomez' Key".
 * Fix [#175](https://g1cp.org/issues/175): The key "Rice Lord's Bowl" is now correctly labelled as "Rice Lord's Key".
+* Fix [#182](https://g1cp.org/issues/182): The gate guard can now only be bribed once when bringing Dusty to the Swamp Camp.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -22,6 +22,7 @@
 * Fix [#121](https://g1cp.org/issues/121): Die Quest "Shrike's Hütte" heißt nun korrekt "Shrikes Hütte".
 * Fix [#142](https://g1cp.org/issues/142): Die Dialogzeile "Wer sind eure Gurus?" im Ambient-Dialog der Templer "Wer hat hier das Sagen?" ist nun korrekt dem Spieler Charakter zugewiesen.
 * Fix [#172](https://g1cp.org/issues/172): Das Schriftstück "Kalom's Rezept" heißt nun korrekt "Kaloms Rezept".
+* Fix [#182](https://g1cp.org/issues/182): Die Torwache kann nun nur noch einmal bestochen werden, wenn Dusty zum Sumpflager gebracht wird.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix182_GuardDialogDusty.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix182_GuardDialogDusty.d
@@ -1,0 +1,71 @@
+/*
+ * #182 The gate guard can be bribed multiple times with Dusty as a follower
+ */
+
+/*
+ * Make the topic and entry available to the functions below
+ */
+const string G1CP_182_GuardDialogDusty_Topic = "G1CP invalid string";
+const string G1CP_182_GuardDialogDusty_Entry = "G1CP invalid string";
+
+/*
+ * Apply the fix
+ */
+func int G1CP_182_GuardDialogDusty() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int condId; condId = MEM_GetSymbolIndex("DIA_Grd_216_DustyZoll_Condition");
+    var int funcId; funcId = MEM_GetSymbolIndex("DIA_Grd_216_DustyZoll_LittleWalk");
+    var int entryFuncId; entryFuncId = MEM_GetSymbolIndex("B_LogEntry");
+    var int topicId; topicId = MEM_GetSymbolIndex("CH1_RecruitDusty");
+    if (funcId == -1) || (condId == -1) || (entryFuncId == -1) || (topicId == -1) {
+        return FALSE;
+    };
+
+    // Find "B_LogEntry" in the dialog info function
+    const int bytes[2] = {zPAR_TOK_CALL<<24, -1};
+    var zCPar_Symbol symb; symb = _^(MEM_GetSymbolByIndex(entryFuncId));
+    bytes[1] = symb.content;
+    var int matches; matches = G1CP_FindInFunc(funcId, _@(bytes)+3, 5);
+
+    // There should only be one occurrence, otherwise the function was somehow modified and we cannot identify the entry
+    if (MEM_ArraySize(matches) == 1) {
+        var int pos; pos = MEM_ArrayRead(matches, 0);
+
+        // B_LogEntry(arg1, arg2)
+        var int arg1; arg1 = MEM_ReadInt(pos-9); // Topic
+        var int arg2; arg2 = MEM_ReadInt(pos-4); // Entry
+        G1CP_182_GuardDialogDusty_Topic = G1CP_GetStringVarByIndex(arg1, 0, "G1CP invalid string");
+        G1CP_182_GuardDialogDusty_Entry = G1CP_GetStringVarByIndex(arg2, 0, "G1CP invalid string");
+
+        // Confirm the log topic and that an entry was found
+        if (Hlp_StrCmp(G1CP_182_GuardDialogDusty_Topic, G1CP_GetStringVarByIndex(topicId, 0, "G1CP invalid string 2")))
+        && (!Hlp_StrCmp(G1CP_182_GuardDialogDusty_Entry, "G1CP invalid string")) {
+            // Hook the condition function
+            HookDaedalusFuncS("DIA_Grd_216_DustyZoll_Condition", "G1CP_182_GuardDialogDusty_Hook");
+            applied = TRUE;
+        };
+    };
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    // Return success
+    return applied;
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int G1CP_182_GuardDialogDusty_Hook() {
+    G1CP_ReportFuncToSpy();
+
+    // Add the new condition (other conditions remain untouched)
+    if (G1CP_LogHasEntry(G1CP_182_GuardDialogDusty_Topic, G1CP_182_GuardDialogDusty_Entry)) {
+        return FALSE;
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/Tests/test182.d
+++ b/src/Ninja/G1CP/Content/Tests/test182.d
@@ -1,0 +1,131 @@
+/*
+ * #182 The gate guard can be bribed multiple times with Dusty as a follower
+ *
+ * The bribe function is executed and the dialog condition is called.
+ *
+ * Expected behavior: The dialog condition function returns false.
+ */
+func int G1CP_Test_182() {
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Define possibly missing symbols locally
+    const int LOG_MISSION = 0;
+
+    // Check if the dialog function exists
+    var int funcId; funcId = MEM_GetSymbolIndex("DIA_Grd_216_DustyZoll_LittleWalk");
+    if (funcId == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog function 'DIA_Grd_216_DustyZoll_LittleWalk' not found");
+        passed = FALSE;
+    };
+
+    // Check if the dialog condition function exists
+    var int condId; condId = MEM_GetSymbolIndex("DIA_Grd_216_DustyZoll_Condition");
+    if (condId == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog condition 'DIA_Grd_216_DustyZoll_Condition' not found");
+        passed = FALSE;
+    };
+
+    // Check if the log topic exists
+    var string topic; topic = G1CP_GetStringVar("CH1_RecruitDusty", 0, "G1CP invalid string");
+    if (Hlp_StrCmp(topic, "G1CP invalid string")) {
+        G1CP_TestsuiteErrorDetail("Log topic constant 'CH1_RecruitDusty' not found");
+        passed = FALSE;
+    };
+
+    // Check if the ore item exists
+    var int oreId; oreId = MEM_GetSymbolIndex("ItMiNugget");
+    if (oreId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'ItMiNugget' not found");
+        passed = FALSE;
+    };
+
+    // Find NPC
+    var int symbId; symbId = MEM_GetSymbolIndex("Vlk_524_Dusty");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("NPC 'Vlk_524_Dusty' not found");
+        return FALSE; // Return immediately, because the last condition below would fail anyway
+    };
+
+    // Check if NPC exists in the world
+    var C_Npc npc; npc = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(npc)) {
+        G1CP_TestsuiteErrorDetail("NPC 'Vlk_524_Dusty' not valid");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Backup values
+    var int amountBefore; amountBefore = Npc_HasItems(hero, oreId);
+    var int expBefore; expBefore = hero.exp;
+    var int expNxtBefore; expNxtBefore = hero.exp_next;
+    var int expLpBefore; expLpBefore = hero.lp;
+    var int lvlBefore; lvlBefore = hero.level;
+    var int aivBak; aivBak = G1CP_GetAIVar(npc, "AIV_PARTYMEMBER", 0);
+    var string npcWp; npcWp = Npc_GetNearestWP(npc);
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);
+    var C_Npc othBak; othBak = MEM_CpyInst(other);
+    G1CP_LogRenameTopic(topic, "G1CP invalid topic 182");
+
+    // Remove all ore
+    if (amountBefore > 0) {
+        Npc_RemoveInvItems(hero, oreId, amountBefore);
+    };
+    CreateInvItems(hero, oreId, 5000); // Should be enough
+
+    // Create log topic
+    Log_CreateTopic(topic, LOG_MISSION);
+
+    // Set self and other
+    self  = MEM_CpyInst(hero);
+    other = MEM_CpyInst(hero);
+
+    // Execute the bribe dialog function
+    MEM_CallByID(funcId);
+
+    // Satisfy dialog conditions
+    G1CP_SetAIVar(npc, "AIV_PARTYMEMBER", TRUE);
+    G1CP_NpcBeamTo(npc, Npc_GetNearestWP(hero));
+
+
+    // Call the condition function
+    MEM_CallByID(condId);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore self and other
+    self  = MEM_CpyInst(slfBak);
+    other = MEM_CpyInst(othBak);
+
+    // Stop the output units
+    Npc_ClearAIQueue(hero);
+    AI_StandUpQuick(hero);
+
+    // Restore values
+    hero.exp = expBefore;
+    hero.exp_next = expNxtBefore;
+    hero.lp = expLpBefore;
+    hero.level = lvlBefore;
+    var int amountAfter; amountAfter = Npc_HasItems(hero, oreId);
+    if (amountAfter > 0) {
+        Npc_RemoveInvItems(hero, oreId, amountAfter);
+    };
+    if (amountBefore > 0) {
+        CreateInvItems(hero, oreId, amountBefore);
+    };
+    G1CP_SetAIVar(npc, "AIV_PARTYMEMBER", aivBak);
+    G1CP_NpcBeamTo(npc, npcWp);
+    G1CP_LogRemoveTopic(topic);
+    G1CP_LogRenameTopic("G1CP invalid topic 182", topic);
+
+    // Check return value
+    if (ret) {
+        G1CP_TestsuiteErrorDetail("Dialog condition failed");
+        return FALSE;
+    } else {
+        return TRUE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -72,6 +72,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_173_DE_GomezKeyText();                     // #173
         G1CP_174_EN_GomezKeyName();                     // #174
         G1CP_175_EN_RiceLordKeyName();                  // #175
+        G1CP_182_GuardDialogDusty();                    // #182
         G1CP_192_MagicUserAutoEquip();                  // #192
         G1CP_200_DE_ImprovedOreArmorText();             // #200
         G1CP_201_DE_AncientOreArmorText();              // #201

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -92,6 +92,7 @@ Content\Fixes\Session\fix172_DE_KalomsRecipeName.d
 Content\Fixes\Session\fix173_DE_GomezKeyText.d
 Content\Fixes\Session\fix174_EN_GomezKeyName.d
 Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
+Content\Fixes\Session\fix182_GuardDialogDusty.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
 Content\Fixes\Session\fix200_DE_ImprovedOreArmorText.d
 Content\Fixes\Session\fix201_DE_AncientOreArmorText.d
@@ -175,6 +176,7 @@ Content\Tests\test172.d
 Content\Tests\test173.d
 Content\Tests\test174.d
 Content\Tests\test175.d
+Content\Tests\test182.d
 Content\Tests\test192.d
 Content\Tests\test200.d
 Content\Tests\test201.d


### PR DESCRIPTION
**Describe the bug**
When bringing Dusty to the Swamp Camp, the player can indefinitely bribe the gate guard to get EXP.

**Expected behavior**
The gate guard can only be bribed once when bringing Dusty to the Swamp Camp.

**Steps to reproduce the issue**
1. Bribe the gate guard with Dusty following you.
2. Save the game
3. Load the save.
4. Bribe the gate guard again (if you have enough ore).
