### PR TITLE
Graham doesn't sit at campfire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix [#37](https://g1cp.org/issues/37): Gravo is now correctly listed as merchant in the Old Camp in the journal.
 * Fix [#174](https://g1cp.org/issues/174): The key "Gomez' Bowl" is now correctly labelled as "Gomez' Key".
 * Fix [#175](https://g1cp.org/issues/175): The key "Rice Lord's Bowl" is now correctly labelled as "Rice Lord's Key".
+* Fix [#214](https://g1cp.org/issues/214): Graham now correctly sits at the campfire in the evening.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -22,6 +22,7 @@
 * Fix [#121](https://g1cp.org/issues/121): Die Quest "Shrike's Hütte" heißt nun korrekt "Shrikes Hütte".
 * Fix [#142](https://g1cp.org/issues/142): Die Dialogzeile "Wer sind eure Gurus?" im Ambient-Dialog der Templer "Wer hat hier das Sagen?" ist nun korrekt dem Spieler Charakter zugewiesen.
 * Fix [#172](https://g1cp.org/issues/172): Das Schriftstück "Kalom's Rezept" heißt nun korrekt "Kaloms Rezept".
+* Fix [#214](https://g1cp.org/issues/214): Graham sitzt nun abends korrekt am Lagerfeuer.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix214_GrahamDailyRoutine.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix214_GrahamDailyRoutine.d
@@ -1,0 +1,7 @@
+/*
+ * #214 Graham doesn't sit at campfire
+ */
+func int G1CP_214_GrahamDailyRoutine() {
+    var int funcId; funcId = MEM_GetSymbolIndex("Rtn_start_573");
+    return (G1CP_ReplacePushStr(funcId, "OCR_OUSIDE_HUT_77_INSERT", "OCR_OUTSIDE_HUT_77_INSERT") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test214.d
+++ b/src/Ninja/G1CP/Content/Tests/test214.d
@@ -1,0 +1,19 @@
+/*
+ * #214 Graham doesn't sit at campfire
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ * Caution: This test breaks the game. Save the game beforehand.
+ *
+ * Expected behavior: Graham will sit down by the campfire shortly (one game minute) after triggering this test.
+ */
+func void G1CP_Test_214() {
+    if (G1CP_TestsuiteAllowManual) {
+        // Shut up Bloodwyn
+        G1CP_SetIntVar("Bloodwyn_PayDay", 0, Wld_GetDay()+1);
+        G1CP_SetInfoTold("Info_Bloodwyn_Hello", TRUE);
+
+        // Set time and place
+        Wld_SetTime(18, 0);
+        AI_Teleport(hero, "OCR_OUTSIDE_HUT_77_MOVEMENT");
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -75,6 +75,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_192_MagicUserAutoEquip();                  // #192
         G1CP_200_DE_ImprovedOreArmorText();             // #200
         G1CP_201_DE_AncientOreArmorText();              // #201
+        G1CP_214_GrahamDailyRoutine();                  // #214
     };
 };
 

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -95,6 +95,7 @@ Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
 Content\Fixes\Session\fix200_DE_ImprovedOreArmorText.d
 Content\Fixes\Session\fix201_DE_AncientOreArmorText.d
+Content\Fixes\Session\fix214_GrahamDailyRoutine.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix037_LogEntryGravoMerchant.d
@@ -178,6 +179,7 @@ Content\Tests\test175.d
 Content\Tests\test192.d
 Content\Tests\test200.d
 Content\Tests\test201.d
+Content\Tests\test214.d
 
 // Initialization
 Content\initPre.d


### PR DESCRIPTION
**Describe the bug**
Graham is supposed to sit at the campfire in the evening, but a typo in the waypoint name prevents him from doing so.

**Expected behavior**
Graham now correctly sits at the campfire in the evening.

**Additional context**
Bug and fix provided by [NikX94](https://github.com/AmProsius/gothic-1-community-patch/issues/211#issuecomment-808914450).