### PR TITLE
Spelling - Ring of Fire Protection (EN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Fix [#50](https://g1cp.org/issues/50): The inaccessible chest of the crypt below the stonehenge is now correctly positioned and accessible.
 * Fix [#52](https://g1cp.org/issues/52): The grindstone in the New Camp now correctly requires a sword blade to use.
 * Fix [#149](https://g1cp.org/issues/149): The armor "Improved ore Armor" is now correctly labelled as "Improved Ore Armor".
-* Fix [#152](https://g1cp.org/issues/152): The ring "Protection of Fire" is now correctly labelled as "Ring of Fire Protection".
+* Fix [#152](https://g1cp.org/issues/152): The description of the ring "Protection of Fire" is corrected to "Ring of Fire Protection".
 * Fix [#192](https://g1cp.org/issues/192): Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 
 ### Story

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix [#50](https://g1cp.org/issues/50): The inaccessible chest of the crypt below the stonehenge is now correctly positioned and accessible.
 * Fix [#52](https://g1cp.org/issues/52): The grindstone in the New Camp now correctly requires a sword blade to use.
 * Fix [#149](https://g1cp.org/issues/149): The armor "Improved ore Armor" is now correctly labelled as "Improved Ore Armor".
+* Fix [#152](https://g1cp.org/issues/152): The ring "Protection of Fire" is now correctly labelled as "Ring of Fire Protection".
 * Fix [#192](https://g1cp.org/issues/192): Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 
 ### Story

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix152_EN_ProtectionOfFireDescription.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix152_EN_ProtectionOfFireDescription.d
@@ -3,5 +3,7 @@
  */
 func int G1CP_152_EN_ProtectionOfFireDescription() {
     var int symbId; symbId = MEM_GetSymbolIndex("Schutzring_Feuer2");
-    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.DESCRIPTION", 0, "Protection of Fire", "Ring of Fire Protection") > 0);
+    const string needle = "Protection of Fire";
+    const string replace = "Ring of Fire Protection";
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.DESCRIPTION", 0, needle, replace) > 0);
 };

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix152_EN_ProtectionOfFireDescription.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix152_EN_ProtectionOfFireDescription.d
@@ -1,0 +1,7 @@
+/*
+ * #152 Spelling - Ring of Fire Protection (EN)
+ */
+func int G1CP_152_EN_ProtectionOfFireDescription() {
+    var int symbId; symbId = MEM_GetSymbolIndex("Schutzring_Feuer2");
+    return (G1CP_ReplaceAssignStr(symbId, "C_ITEM.DESCRIPTION", 0, "Protection of Fire", "Ring of Fire Protection") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test152.d
+++ b/src/Ninja/G1CP/Content/Tests/test152.d
@@ -1,0 +1,37 @@
+/*
+ * #152 Spelling - Ring of Fire Protection (EN)
+ *
+ * The description of the item "Schutzring_Feuer2" is inspected programmatically.
+ *
+ * Expected behavior: The ring will have the correct description (checked for English localization only).
+ */
+func int G1CP_Test_152() {
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_EN) {
+        G1CP_TestsuiteErrorDetail("Test applicable for English localization only");
+        return TRUE; // True?
+    };
+
+    // Check if item exists
+    var int symbId; symbId = MEM_GetSymbolIndex("Schutzring_Feuer2");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'Schutzring_Feuer2' not found");
+        return FALSE;
+    };
+
+    // Create the ring locally
+    if (Itm_GetPtr(symbId)) {
+        if (Hlp_StrCmp(item.description, "Ring of Fire Protection")) {
+            return TRUE;
+        } else {
+            var string msg; msg = "description incorrect: description = '";
+            msg = ConcatStrings(msg, item.description);
+            msg = ConcatStrings(msg, "'");
+            G1CP_TestsuiteErrorDetail(msg);
+            return FALSE;
+        };
+    } else {
+        G1CP_TestsuiteErrorDetail("Item 'Schutzring_Feuer2' could not be created");
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/Tests/test152.d
+++ b/src/Ninja/G1CP/Content/Tests/test152.d
@@ -24,7 +24,7 @@ func int G1CP_Test_152() {
         if (Hlp_StrCmp(item.description, "Ring of Fire Protection")) {
             return TRUE;
         } else {
-            var string msg; msg = "description incorrect: description = '";
+            var string msg; msg = "Description incorrect: description = '";
             msg = ConcatStrings(msg, item.description);
             msg = ConcatStrings(msg, "'");
             G1CP_TestsuiteErrorDetail(msg);

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -67,6 +67,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_147_DE_CrawlerPlateArmorName();            // #147
         G1CP_148_DE_AncientOreArmorName();              // #148
         G1CP_149_DE_EN_ImprovedOreArmorName();          // #149
+        G1CP_152_EN_ProtectionOfFireDescription();      // #152
         G1CP_157_SpeedPotion2Value();                   // #157
         G1CP_158_SpeedPotion3Value();                   // #158
         G1CP_163_CastleGate();                          // #163

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -87,6 +87,7 @@ Content\Fixes\Session\fix146_DE_NovicesLoinclothName.d
 Content\Fixes\Session\fix147_DE_CrawlerPlateArmorName.d
 Content\Fixes\Session\fix148_DE_AncientOreArmorName.d
 Content\Fixes\Session\fix149_DE_EN_ImprovedOreArmorName.d
+Content\Fixes\Session\fix152_EN_ProtectionOfFireDescription.d
 Content\Fixes\Session\fix157_SpeedPotion2Value.d
 Content\Fixes\Session\fix158_SpeedPotion3Value.d
 Content\Fixes\Session\fix163_CastleGate.d
@@ -177,6 +178,7 @@ Content\Tests\test146.d
 Content\Tests\test147.d
 Content\Tests\test148.d
 Content\Tests\test149.d
+Content\Tests\test152.d
 Content\Tests\test157.d
 Content\Tests\test158.d
 Content\Tests\test163.d


### PR DESCRIPTION
**Describe the bug**
In the English localization the description of the ring *Protection of Fire* is inconsistent and grammatically incorrect.

**Changelog**
Changed description of ring "Protection of Fire" to "Ring of Fire Protection"