### PR TITLE
Spelling - Horatio: "den Reislord" (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -22,6 +22,7 @@
 * Fix [#37](https://g1cp.org/issues/37): Gravo ist nun korrekt als Händler im Alten Lager im Tagebuch aufgelistet.
 * Fix [#93](https://g1cp.org/issues/93): Im Tagebucheintrag zu der Quest "Horatio der Bauer" lautet die Phrase "[...] stärker zuzuschalgen." nun korrekt "[...] stärker zuzuschlagen."
 * Fix [#91](https://g1cp.org/issues/91): Die Dialogauswahl mit Horatio: "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!" lautet nun korrekt "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!"
+* Fix [#92](https://g1cp.org/issues/92): Die Dialogauswahl mit Horatio: "Damit ich Reislord und seine Schläger fertigmachen kann!" lautet nun korrekt "Damit ich den Reislord und seine Schläger fertigmachen kann!"
 * Fix [#94](https://g1cp.org/issues/94): Die Dialogoption mit Horatio "Ich hab' nochmal über die Sache nachgedacht..." lautet nun korrekt "Ich hab' noch einmal über die Sache nachgedacht...".
 * Fix [#121](https://g1cp.org/issues/121): Die Quest "Shrike's Hütte" heißt nun korrekt "Shrikes Hütte".
 * Fix [#142](https://g1cp.org/issues/142): Die Dialogzeile "Wer sind eure Gurus?" im Ambient-Dialog der Templer "Wer hat hier das Sagen?" ist nun korrekt dem Spieler Charakter zugewiesen.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix092_DE_HoratioAddChoiceWipeOut.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix092_DE_HoratioAddChoiceWipeOut.d
@@ -1,0 +1,9 @@
+/*
+ * #92 Spelling - Horatio: "den Reislord" (DE)
+ */
+func int G1CP_092_DE_HoratioAddChoiceWipeOut() {
+    var int symbId; symbId = MEM_GetSymbolIndex("DIA_Horatio_PleaseTeachSTR_Info");
+    const string needle  = "Damit ich Reislord und seine Schläger fertigmachen kann!";
+    const string replace = "Damit ich den Reislord und seine Schläger fertigmachen kann!";
+    return(G1CP_ReplacePushStr(symbId, needle, replace) > 0);
+};

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix092_DE_HoratioAddChoiceWipeOut.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix092_DE_HoratioAddChoiceWipeOut.d
@@ -5,5 +5,5 @@ func int G1CP_092_DE_HoratioAddChoiceWipeOut() {
     var int symbId; symbId = MEM_GetSymbolIndex("DIA_Horatio_PleaseTeachSTR_Info");
     const string needle  = "Damit ich Reislord und seine Schläger fertigmachen kann!";
     const string replace = "Damit ich den Reislord und seine Schläger fertigmachen kann!";
-    return(G1CP_ReplacePushStr(symbId, needle, replace) > 0);
+    return (G1CP_ReplacePushStr(symbId, needle, replace) > 0);
 };

--- a/src/Ninja/G1CP/Content/Tests/test092.d
+++ b/src/Ninja/G1CP/Content/Tests/test092.d
@@ -1,0 +1,65 @@
+/*
+ * #92 Spelling - Horatio: "den Reislord" (DE)
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ * Caution: This test will break the game. Be sure to save the game before.
+ *
+ * Expected behavior: The hero is merely teleported there, the dialog choice has the correct wording.
+ */
+func void G1CP_Test_092() {
+    if (!G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Check language first
+    if (G1CP_Lang != G1CP_Lang_DE) {
+        G1CP_TestsuiteErrorDetail("Test applicable for German localization only");
+        return;
+    };
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Check if dialog exists
+    if (MEM_GetSymbolIndex("DIA_Horatio_PleaseTeachSTR") == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog 'DIA_Horatio_PleaseTeachSTR' not found");
+        passed = FALSE;
+    };
+
+    // Check if required dialogs exist
+    if (MEM_GetSymbolIndex("DIA_Horatio_Story") == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog 'DIA_Horatio_Story' not found");
+        passed = FALSE;
+    };
+    if (MEM_GetSymbolIndex("DIA_Jeremiah_Horatio") == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog 'DIA_Jeremiah_Horatio' not found");
+        passed = FALSE;
+    };
+
+    // Find the NPC
+    var int symbId; symbId = MEM_GetSymbolIndex("Bau_901_Horatio");
+    if (symbId == -1) {
+        G1CP_TestsuiteErrorDetail("NPC 'Bau_901_Horatio' not found");
+        return; // Immediately, because there is only one more check below which will fail now anyway
+    };
+
+    // Check if the NPC exists in the world
+    var C_Npc npc; npc = Hlp_GetNpc(symbId);
+    if (!Hlp_IsValidNpc(npc)) {
+        G1CP_TestsuiteErrorDetail("NPC 'Bau_901_Horatio' not valid");
+        passed = FALSE;
+    };
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return;
+    };
+
+    // Set unlock the dialog
+    G1CP_SetInfoTold("DIA_Horatio_Hello", TRUE); // Optional
+    G1CP_SetInfoTold("DIA_Horatio_Story", TRUE);
+    G1CP_SetInfoTold("DIA_Jeremiah_Horatio", TRUE);
+
+    // Teleport the hero
+    AI_Teleport(hero, npc.wp);
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -51,6 +51,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_078_HumanAttackOrc();                      // #78
         G1CP_079_WolfDexDialog();                       // #79
         G1CP_091_DE_HoratioAddChoiceAvenge();           // #91
+        G1CP_092_DE_HoratioAddChoiceWipeOut();          // #92
         G1CP_094_DE_HoratioInfoDescThoughtStr();        // #94
         G1CP_102_JesseProtectionMoneyPay();             // #102
         G1CP_109_BloodwynProtectionMoneyPayLater();     // #109

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -71,6 +71,7 @@ Content\Fixes\Session\fix060_JesseQuest.d
 Content\Fixes\Session\fix078_HumanAttackOrc.d
 Content\Fixes\Session\fix079_WolfDexDialog.d
 Content\Fixes\Session\fix091_DE_HoratioAddChoiceAvenge.d
+Content\Fixes\Session\fix092_DE_HoratioAddChoiceWipeOut.d
 Content\Fixes\Session\fix094_DE_HoratioInfoDescThoughtStr.d
 Content\Fixes\Session\fix102_JesseProtectionMoneyPay.d
 Content\Fixes\Session\fix109_BloodwynProtectionMoneyPayLater.d
@@ -158,6 +159,7 @@ Content\Tests\test060.d
 Content\Tests\test078.d
 Content\Tests\test079.d
 Content\Tests\test091.d
+Content\Tests\test092.d
 Content\Tests\test093.d
 Content\Tests\test094.d
 Content\Tests\test102.d


### PR DESCRIPTION
**Describe the bug**
In the German localization there is a noun marker missing. Also the written dialog line differs from the spoken dialog.

**Changelog**
Dialogoption mit Horatio: "Damit ich Reislord und seine Schläger fertigmachen kann!" korrigiert zu "Damit ich den Reislord und seine Schläger fertig machen kann!"

**Additional context**
```d
func void DIA_Horatio_PleaseTeachSTR_Ricelord()
{
	AI_Output (other, self,"DIA_Horatio_PleaseTeachSTR_Ricelord_15_00"); //Damit ich den Reislord und seine Schläger fertig machen kann!
	AI_Output (self, other,"DIA_Horatio_PleaseTeachSTR_Ricelord_09_01"); //Hmm ... Du bist nicht der Erste, der das versucht.
	horatio_StrFree = TRUE;
	Info_ClearChoices(DIA_Horatio_PleaseTeachSTR );
};
```