### PR TITLE
Corristo sells High Robe multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix [#175](https://g1cp.org/issues/175): The key "Rice Lord's Bowl" is now correctly labelled as "Rice Lord's Key".
 * Fix [#181](https://g1cp.org/issues/181): Swiney no longer takes off his own Digger's Dress when he gives one to the player.
 * Fix [#182](https://g1cp.org/issues/182): The gate guard can now only be bribed once when bringing Dusty to the Swamp Camp.
+* Fix [#183](https://g1cp.org/issues/183): Corristo no longer offers to sell a High Robe of Fire if the player already obtained one.
 * Fix [#214](https://g1cp.org/issues/214): Graham now correctly sits at the campfire in the evening.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -28,6 +28,7 @@
 * Fix [#172](https://g1cp.org/issues/172): Das Schriftstück "Kalom's Rezept" heißt nun korrekt "Kaloms Rezept".
 * Fix [#181](https://g1cp.org/issues/181): Swiney zieht nicht mehr seine eigenen Schürferklamotten aus, wenn er dem Spieler welche gibt.
 * Fix [#182](https://g1cp.org/issues/182): Die Torwache kann nun nur noch einmal bestochen werden, wenn Dusty zum Sumpflager gebracht wird.
+* Fix [#183](https://g1cp.org/issues/183): Corristo bietet nun keine Große Feuerrobe mehr an, wenn der Spieler bereits eine erworben hat.
 * Fix [#214](https://g1cp.org/issues/214): Graham sitzt nun korrekt abends am Lagerfeuer.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix183_CorristoSellsRobe.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix183_CorristoSellsRobe.d
@@ -1,0 +1,30 @@
+/*
+ * #183 Corristo sells High Robe multiple times
+ */
+func int G1CP_183_CorristoSellsRobe() {
+    if (MEM_GetSymbolIndex("KDF_402_Corristo_HEAVYARMOR_Condition") != -1)
+    && (MEM_GetSymbolIndex("KDF_ARMOR_H") != -1) {
+        HookDaedalusFuncS("KDF_402_Corristo_HEAVYARMOR_Condition", "G1CP_183_CorristoSellsRobe_Hook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int G1CP_183_CorristoSellsRobe_Hook() {
+    G1CP_ReportFuncToSpy();
+
+    // Obtain symbol
+    var int symbId; symbId = MEM_GetSymbolIndex("KDF_ARMOR_H");
+    if (symbId != -1) {
+        if (Npc_HasItems(hero, symbId)) {
+            return FALSE;
+        };
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/Tests/test183.d
+++ b/src/Ninja/G1CP/Content/Tests/test183.d
@@ -1,0 +1,82 @@
+/*
+ * #183 Corristo sells High Robe multiple times
+ *
+ * The hero is given the heavy robe and the KDF guild and the condition function of the dialog is called.
+ *
+ * Expected behavior: The condition function will return FALSE.
+ */
+func int G1CP_Test_183() {
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // Find the dialog condition function
+    var int funcId; funcId = MEM_GetSymbolIndex("KDF_402_Corristo_HEAVYARMOR_Condition");
+    if (funcId == -1) {
+        G1CP_TestsuiteErrorDetail("Dialog condition 'KDF_402_Corristo_HEAVYARMOR_Condition' not found");
+        passed = FALSE;
+    };
+
+    // Find the symbol
+    var int robeId; robeId = MEM_GetSymbolIndex("KDF_ARMOR_H");
+    if (robeId == -1) {
+        G1CP_TestsuiteErrorDetail("Item 'KDF_ARMOR_H' not found");
+        passed = FALSE;
+    };
+
+    // Find the guild
+    var int symbPtr; symbPtr = MEM_GetSymbol("GIL_KDF");
+    if (!symbPtr) {
+        G1CP_TestsuiteErrorDetail("Variable 'GIL_KDF' not found");
+        passed = FALSE;
+    };
+
+    // Obtain guild value
+    var int GIL_KDF; GIL_KDF = MEM_ReadInt(symbPtr + zCParSymbol_content_offset);
+
+    // Backup hero guild
+    var int guildBak; guildBak = hero.guild;
+    var int guildTrueBak; guildTrueBak = Npc_GetTrueGuild(hero);
+
+    // At the latest now, we need to stop if there are fails already
+    if (!passed) {
+        return FALSE;
+    };
+
+    // Set guild
+    Npc_SetTrueGuild(hero, GIL_KDF);
+    hero.guild = GIL_KDF;
+
+    // Give the robe to the hero
+    CreateInvItem(hero, robeId);
+
+    // Backup self and other
+    var C_Npc slfBak; slfBak = MEM_CpyInst(self);
+    var C_Npc othBak; othBak = MEM_CpyInst(other);
+
+    // Set self and other
+    self  = MEM_CpyInst(hero);
+    other = MEM_CpyInst(hero);
+
+    // Call dialog condition function
+    MEM_CallByID(funcId);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore self and other
+    self  = MEM_CpyInst(slfBak);
+    other = MEM_CpyInst(othBak);
+
+    // Remove the robe again
+    Npc_RemoveInvItems(hero, robeId, 1);
+
+    // Restore guild
+    Npc_SetTrueGuild(hero, guildTrueBak);
+    hero.guild = guildBak;
+
+    // Check return value
+    if (ret) {
+        G1CP_TestsuiteErrorDetail("Dialog condition failed");
+        return FALSE;
+    } else {
+        return TRUE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -76,6 +76,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_175_EN_RiceLordKeyName();                  // #175
         G1CP_181_SwineyGiveArmor();                     // #181
         G1CP_182_GuardDialogDusty();                    // #182
+        G1CP_183_CorristoSellsRobe();                   // #183
         G1CP_192_MagicUserAutoEquip();                  // #192
         G1CP_200_DE_ImprovedOreArmorText();             // #200
         G1CP_201_DE_AncientOreArmorText();              // #201

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -96,6 +96,7 @@ Content\Fixes\Session\fix174_EN_GomezKeyName.d
 Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
 Content\Fixes\Session\fix181_SwineyGiveArmor.d
 Content\Fixes\Session\fix182_GuardDialogDusty.d
+Content\Fixes\Session\fix183_CorristoSellsRobe.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
 Content\Fixes\Session\fix200_DE_ImprovedOreArmorText.d
 Content\Fixes\Session\fix201_DE_AncientOreArmorText.d
@@ -186,6 +187,7 @@ Content\Tests\test174.d
 Content\Tests\test175.d
 Content\Tests\test181.d
 Content\Tests\test182.d
+Content\Tests\test183.d
 Content\Tests\test192.d
 Content\Tests\test200.d
 Content\Tests\test201.d


### PR DESCRIPTION
**Describe the bug**
The player can obtain more than one High Robe of Fire from Corristo.

**Expected behavior**
Corristo now sells only one High Robe of Fire to the player.

**Steps to reproduce the issue**
1. Buy High Robe of Fire from Corristo.
2. Save the game.
3. Load the save.
4. Buy another High Robe of Fire from Corristo.
