### PR TITLE
Digger doesn't repair hut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix [#181](https://g1cp.org/issues/181): Swiney no longer takes off his own Digger's Dress when he gives one to the player.
 * Fix [#182](https://g1cp.org/issues/182): The gate guard can now only be bribed once when bringing Dusty to the Swamp Camp.
 * Fix [#214](https://g1cp.org/issues/214): Graham now correctly sits at the campfire in the evening.
+* Fix [#216](https://g1cp.org/issues/216): A digger now correctly repairs his hut during daytime.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -29,6 +29,7 @@
 * Fix [#181](https://g1cp.org/issues/181): Swiney zieht nicht mehr seine eigenen Schürferklamotten aus, wenn er dem Spieler welche gibt.
 * Fix [#182](https://g1cp.org/issues/182): Die Torwache kann nun nur noch einmal bestochen werden, wenn Dusty zum Sumpflager gebracht wird.
 * Fix [#214](https://g1cp.org/issues/214): Graham sitzt nun korrekt abends am Lagerfeuer.
+* Fix [#216](https://g1cp.org/issues/216): Ein Buddler repariert jetzt korrekt tagsüber seine Hütte.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix216_DiggerDailyRoutine.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix216_DiggerDailyRoutine.d
@@ -1,0 +1,7 @@
+/*
+ * #216 Digger doesn't repair hut
+ */
+func int G1CP_216_DiggerDailyRoutine() {
+    var int funcId; funcId = MEM_GetSymbolIndex("Rtn_start_506");
+    return (G1CP_ReplacePushStr(funcId, "OCR_Hut_15", "OCR_HUT_15") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test216.d
+++ b/src/Ninja/G1CP/Content/Tests/test216.d
@@ -1,0 +1,14 @@
+/*
+ * #216 Digger doesn't repair hut
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: The Digger will repair his hut shortly after triggering this test.
+ */
+func void G1CP_Test_216() {
+    if (G1CP_TestsuiteAllowManual) {
+        // Set time and place
+        Wld_SetTime(11, 0);
+        AI_Teleport(hero, "OCR_HUT_15");
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -80,6 +80,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_200_DE_ImprovedOreArmorText();             // #200
         G1CP_201_DE_AncientOreArmorText();              // #201
         G1CP_214_GrahamDailyRoutine();                  // #214
+        G1CP_216_DiggerDailyRoutine();                  // #216
     };
 };
 

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -100,6 +100,7 @@ Content\Fixes\Session\fix192_MagicUserAutoEquip.d
 Content\Fixes\Session\fix200_DE_ImprovedOreArmorText.d
 Content\Fixes\Session\fix201_DE_AncientOreArmorText.d
 Content\Fixes\Session\fix214_GrahamDailyRoutine.d
+Content\Fixes\Session\fix216_DiggerDailyRoutine.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix037_LogEntryGravoMerchant.d
@@ -190,6 +191,7 @@ Content\Tests\test192.d
 Content\Tests\test200.d
 Content\Tests\test201.d
 Content\Tests\test214.d
+Content\Tests\test216.d
 
 // Initialization
 Content\initPre.d


### PR DESCRIPTION
**Describe the bug**
A Digger is supposed to repair his hut during daytime, but a typo in the waypoint name prevents him from doing so.

**Expected behavior**
A Digger now correctly repairs his hut during daytime.

**Additional context**
Bug and fix provided by [NikX94](https://github.com/AmProsius/gothic-1-community-patch/issues/211#issuecomment-808926648).
