### PR TITLE
Mercenary doesn't guard the palisade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix [#181](https://g1cp.org/issues/181): Swiney no longer takes off his own Digger's Dress when he gives one to the player.
 * Fix [#182](https://g1cp.org/issues/182): The gate guard can now only be bribed once when bringing Dusty to the Swamp Camp.
 * Fix [#214](https://g1cp.org/issues/214): Graham now correctly sits at the campfire in the evening.
+* Fix [#217](https://g1cp.org/issues/217): A mercenary now correctly guards the palisade at the Free Mine in the afternoon.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Fix [#214](https://g1cp.org/issues/214): Graham now correctly sits at the campfire in the evening.
 * Fix [#215](https://g1cp.org/issues/215): Guy now correctly sits at the arena in the evening.
 * Fix [#216](https://g1cp.org/issues/216): A digger now correctly repairs his hut during daytime.
-* Fix [#217](https://g1cp.org/issues/217): A mercenary now correctly guards the palisade at the Free Mine in the afternoon.
+* Fix [#217](https://g1cp.org/issues/217): One of the mercenaries now correctly guards the palisade at the Free Mine in the afternoon.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -33,7 +33,7 @@
 * Fix [#214](https://g1cp.org/issues/214): Graham sitzt nun korrekt abends am Lagerfeuer.
 * Fix [#215](https://g1cp.org/issues/215): Guy sitzt nun korrekt abends bei der Arena.
 * Fix [#216](https://g1cp.org/issues/216): Ein Buddler repariert jetzt korrekt tagsüber seine Hütte.
-* Fix [#217](https://g1cp.org/issues/217): Ein Söldner passt nun korrekt nachmittags am Talkessel der Freien Mine auf.
+* Fix [#217](https://g1cp.org/issues/217): Einer der Söldner passt nun korrekt nachmittags am Talkessel der Freien Mine auf.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -29,6 +29,7 @@
 * Fix [#181](https://g1cp.org/issues/181): Swiney zieht nicht mehr seine eigenen Schürferklamotten aus, wenn er dem Spieler welche gibt.
 * Fix [#182](https://g1cp.org/issues/182): Die Torwache kann nun nur noch einmal bestochen werden, wenn Dusty zum Sumpflager gebracht wird.
 * Fix [#214](https://g1cp.org/issues/214): Graham sitzt nun korrekt abends am Lagerfeuer.
+* Fix [#217](https://g1cp.org/issues/217): Ein Söldner passt nun korrekt nachmittags am Talkessel der Freien Mine auf.
 
 ## [v1.0.0](https://github.com/AmProsius/gothic-1-community-patch/releases/tag/v1.0.0) (2021-03-15)
 ### General

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix217_MercenaryDailyRoutine.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix217_MercenaryDailyRoutine.d
@@ -1,0 +1,7 @@
+/*
+ * #217 Mercenary doesn't guard the palisade
+ */
+func int G1CP_217_MercenaryDailyRoutine() {
+    var int funcId; funcId = MEM_GetSymbolIndex("Rtn_FMCstart_750");
+    return (G1CP_ReplacePushStr(funcId, "FMC_Path19", "FMC_PATH19") > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test217.d
+++ b/src/Ninja/G1CP/Content/Tests/test217.d
@@ -1,0 +1,14 @@
+/*
+ * #217 Mercenary doesn't guard the palisade
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: The mercenary will guard the palisade shortly after triggering this test.
+ */
+func void G1CP_Test_217() {
+    if (G1CP_TestsuiteAllowManual) {
+        // Set time and place
+        Wld_SetTime(13, 0);
+        AI_Teleport(hero, "FMC_PATH19");
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -80,6 +80,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_200_DE_ImprovedOreArmorText();             // #200
         G1CP_201_DE_AncientOreArmorText();              // #201
         G1CP_214_GrahamDailyRoutine();                  // #214
+        G1CP_217_MercenaryDailyRoutine();               // #217
     };
 };
 

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -100,6 +100,7 @@ Content\Fixes\Session\fix192_MagicUserAutoEquip.d
 Content\Fixes\Session\fix200_DE_ImprovedOreArmorText.d
 Content\Fixes\Session\fix201_DE_AncientOreArmorText.d
 Content\Fixes\Session\fix214_GrahamDailyRoutine.d
+Content\Fixes\Session\fix217_MercenaryDailyRoutine.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix037_LogEntryGravoMerchant.d
@@ -190,6 +191,7 @@ Content\Tests\test192.d
 Content\Tests\test200.d
 Content\Tests\test201.d
 Content\Tests\test214.d
+Content\Tests\test217.d
 
 // Initialization
 Content\initPre.d


### PR DESCRIPTION
**Describe the bug**
A Mercenary is supposed to guard the palisade during the afternoon, but a typo in the waypoint name prevents him from doing so.

**Expected behavior**
A Mercenary now correctly guards the palisade during the afternoon.

**Additional context**
Bug and fix provided by [NikX94](https://github.com/AmProsius/gothic-1-community-patch/issues/211#issuecomment-808929770).
