### PR TITLE
Dummy Templars survive in orc graveyard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix [#23](https://g1cp.org/issues/23): The armor "Novice's Armor" is now available in chapter 2 to make it accessible before receiving the first templar armor.
 * Fix [#36](https://g1cp.org/issues/36) (updated): Fisk's quest "New Fence for Fisk" is now available when the player either knocked out or killed Mordrag.
 * Fix [#37](https://g1cp.org/issues/37): Gravo is now correctly listed as merchant in the Old Camp in the journal.
+* Fix [#115](https://g1cp.org/issues/115): The templars in the orc graveyard are now less likely to survive.
 * Fix [#174](https://g1cp.org/issues/174): The key "Gomez' Bowl" is now correctly labelled as "Gomez' Key".
 * Fix [#175](https://g1cp.org/issues/175): The key "Rice Lord's Bowl" is now correctly labelled as "Rice Lord's Key".
 * Fix [#181](https://g1cp.org/issues/181): Swiney no longer takes off his own Digger's Dress when he gives one to the player.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -23,6 +23,7 @@
 * Fix [#91](https://g1cp.org/issues/91): Die Dialogauswahl mit Horatio: "Ja. Ich will es mit Ricelord und seinen Schlägern aufnehmen können!" lautet nun korrekt "Ja. Ich will es mit dem Reislord und seinen Schlägern aufnehmen können!"
 * Fix [#93](https://g1cp.org/issues/93): Im Tagebucheintrag zu der Quest "Horatio der Bauer" lautet die Phrase "[...] stärker zuzuschalgen." nun korrekt "[...] stärker zuzuschlagen."
 * Fix [#94](https://g1cp.org/issues/94): Die Dialogoption mit Horatio "Ich hab' nochmal über die Sache nachgedacht..." lautet nun korrekt "Ich hab' noch einmal über die Sache nachgedacht...".
+* Fix [#115](https://g1cp.org/issues/115): Die Templar im Orkfriedhof sterben nun verlässlicher.
 * Fix [#121](https://g1cp.org/issues/121): Die Quest "Shrike's Hütte" heißt nun korrekt "Shrikes Hütte".
 * Fix [#142](https://g1cp.org/issues/142): Die Dialogzeile "Wer sind eure Gurus?" im Ambient-Dialog der Templer "Wer hat hier das Sagen?" ist nun korrekt dem Spieler Charakter zugewiesen.
 * Fix [#172](https://g1cp.org/issues/172): Das Schriftstück "Kalom's Rezept" heißt nun korrekt "Kaloms Rezept".

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix115_KillSittingDuck.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix115_KillSittingDuck.d
@@ -1,0 +1,92 @@
+/*
+ * #115 Dummy Templars survive in orc graveyard
+ */
+func int G1CP_115_KillSittingDuck() {
+    var int applied; applied = FALSE;
+
+    // Get necessary symbol indices
+    var int funcId; funcId = MEM_GetSymbolIndex("ZS_SittingDuck_Loop");
+    if (funcId == -1) {
+        return FALSE;
+    };
+
+    // Identify the content of the function to find if it is unmodified as found in the original
+    var int bytes[4];
+    MEMINT_OverrideFunc_Ptr = _@(bytes);
+    MEMINT_OFTokPar(zPAR_TOK_PUSHINST,   self);
+    MEMINT_OFTokPar(zPAR_TOK_PUSHINT,    FLOATONE);
+    MEMINT_OFTokPar(zPAR_TOK_CALLEXTERN, MEM_GetFuncID(AI_Wait));
+    MEMINT_OFTok(zPAR_TOK_RET);
+    var int matches; matches = G1CP_FindInFunc(funcId, _@(bytes), 16);
+
+    // There should be only one call to "AI_Wait(self, 1)" otherwise the function may have been modified
+    if (MEM_ArraySize(matches) == 1) {
+        // Check if there is more in the function
+        var int pos; pos = MEM_ArrayRead(matches, 0);
+        var int funcStart; funcStart = MEM_ReadInt(MEM_GetSymbolByIndex(funcId) + zCParSymbol_content_offset);
+        funcStart += currParserStackAddress;
+
+        // That check is not really satisfying yet, there is a lot that can happen in 15 bytes unaccounted for
+        if (pos - funcStart <= 15) {
+            // Replace the function call to "AI_Wait" with our own
+            MEMINT_OverrideFunc_Ptr = pos+10;
+            MEMINT_OFTokPar(zPAR_TOK_CALL, MEM_GetFuncOffset(G1CP_115_KillSittingDuck_Intercept));
+            applied = TRUE;
+        };
+    };
+
+    // Return success
+    return applied;
+};
+
+/*
+ * Intercept the loop of the NPC state
+ */
+func int G1CP_115_KillSittingDuck_Intercept(var C_Npc self, var float ms) {
+    G1CP_ReportFuncToSpy();
+
+    // Define possibly missing symbols locally
+    const int ATR_HITPOINTS = 0;
+    const int LOOP_CONTINUE = 0;
+    const int LOOP_END      = 1;
+
+    // Some additional safety
+    if (Npc_IsDead(self)) {
+        return LOOP_END;
+    };
+
+    // Send damage perception to all nearby enemies (exclude friendly NPCs, therefore not passive perception)
+    Npc_PerceiveAll(self);
+    var int slfPtr; slfPtr = _@(self);
+    var int count; count = 0;
+    while(Npc_GetNextTarget(self));
+        // This enemy is in range/sight, pretend to attack
+        if (Npc_GetDistToNpc(self, other) < 1200) // 12 m
+        || (Npc_CanSeeNpcFreeLOS(other, self)) {
+            Npc_SendSinglePerc(self, other, PERC_ASSESSDAMAGE); // You will think I hurt you, kill me now!
+            count += 1;
+        };
+
+        // Remove that enemy from the perception list to advance to the next one
+        var int vobPtr; vobPtr = _@(other);
+        const int oCNpc__RemoveFromVobList = 7041152; //0x6B7080
+        const int call = 0;
+        if (CALL_Begin(call)) {
+            CALL_PtrParam(_@(vobPtr));
+            CALL__thiscall(_@(slfPtr), oCNpc__RemoveFromVobList);
+            call = Call_End();
+        };
+
+        // Reset enemy/other for the next iteration
+        Npc_SetTarget(self, NULL);
+    end;
+
+    // No enemies around and player too close? Commit suicide
+    if (count < 1) && (Npc_GetDistToPlayer(self) < 2500) {
+        Npc_ChangeAttribute(self, ATR_HITPOINTS, -self.attribute[ATR_HITPOINTS]);
+        return LOOP_END;
+    };
+
+    // Continue otherwise
+    return LOOP_CONTINUE;
+};

--- a/src/Ninja/G1CP/Content/Tests/test115.d
+++ b/src/Ninja/G1CP/Content/Tests/test115.d
@@ -1,0 +1,26 @@
+/*
+ * #115 Dummy Templars survive in orc graveyard
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: The templars will be dead or reliably dying when walking through the orc graveyard.
+ */
+func void G1CP_Test_115() {
+    if (G1CP_TestsuiteAllowManual) {
+        // Define possibly missing symbols locally
+        const int NPC_FLAG_IMMORTAL = 1 << 1;
+
+        // Set PC to invincible to observe the action
+        hero.flags = hero.flags | NPC_FLAG_IMMORTAL;
+
+        // Teleport the player to the entrance of the orc graveyard
+        if (!Hlp_StrCmp(MEM_World.worldFilename, "ORCGRAVEYARD.ZEN")) {
+            const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
+            CALL_zStringPtrParam("GRYD_001");
+            CALL_zStringPtrParam("ORCGRAVEYARD.ZEN");
+            CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
+        } else {
+            AI_Teleport(hero, "GRYD_001");
+        };
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -56,6 +56,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_109_BloodwynProtectionMoneyPayLater();     // #109
         G1CP_111_JackalProtectionMoneyPay();            // #111
         G1CP_112_JackalProtectionMoneyPayLater();       // #112
+        G1CP_115_KillSittingDuck();                     // #115
         G1CP_122_CavalornDailyRoutine();                // #122
         G1CP_125_ButcherText();                         // #125
         G1CP_126_SharkyTrade();                         // #126

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -77,6 +77,7 @@ Content\Fixes\Session\fix102_JesseProtectionMoneyPay.d
 Content\Fixes\Session\fix109_BloodwynProtectionMoneyPayLater.d
 Content\Fixes\Session\fix111_JackalProtectionMoneyPay.d
 Content\Fixes\Session\fix112_JackalProtectionMoneyPayLater.d
+Content\Fixes\Session\fix115_KillSittingDuck.d
 Content\Fixes\Session\fix122_CavalornDailyRoutine.d
 Content\Fixes\Session\fix125_ButcherText.d
 Content\Fixes\Session\fix126_SharkyTrade.d

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -166,6 +166,7 @@ Content\Tests\test102.d
 Content\Tests\test109.d
 Content\Tests\test111.d
 Content\Tests\test112.d
+Content\Tests\test115.d
 Content\Tests\test121.d
 Content\Tests\test122.d
 Content\Tests\test124.d


### PR DESCRIPTION
**Describe the bug**
When the player is fast enough, he can kill the orcs near the dummy Templars before the orcs kill the Templars. Then the dummy Templars just stand there doing nothing.

**Expected behavior**
The dummy Templars in the orc graveyard are now already dead when the player enters the graveyard.

**Additional context**
My suggestion would be to kill the dummy Templars when the player first enters the orc graveyard.

**Screenshot**
![ScreenShot_2021_2_12_21_37_49](https://user-images.githubusercontent.com/2817152/107820946-f09a9680-6d7b-11eb-9bd6-db4253aebe5e.jpg)
