### PR TITLE
Snappers don't spawn outside the Monastery ruins 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### General
 * Fix [#4](https://g1cp.org/issues/4): NPCs no longer confront the player when he is standing in their way if he has defeated them before.
 * Fix [#14](https://g1cp.org/issues/14): The player can no longer cancel fights by entering and leaving a room. The behavior is unchanged, if trespassing into the room was the reason for the fight.
+* Fix [#45](https://g1cp.org/issues/45): Two snappers outside the Monastery ruins now correctly spawn.
 * Fix [#50](https://g1cp.org/issues/50): The inaccessible chest of the crypt below the stonehenge is now correctly positioned and accessible.
 * Fix [#52](https://g1cp.org/issues/52): The grindstone in the New Camp now correctly requires a sword blade to use.
 * Fix [#110](https://g1cp.org/issues/110): Mouse input is no longer locked when interacting with objects to allow adjusting the camera viewpoint.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -4,6 +4,7 @@
 ### General
 * Fix [#4](https://g1cp.org/issues/4): Zuvor besiegte NSCs fahren den Spieler nun nicht mehr an, wenn er ihnen im Weg steht.
 * Fix [#14](https://g1cp.org/issues/14): Der Spieler kann Kämpfe nicht mehr durch Betreten und Verlassen eines Raumes abbrechen. Falls das unerlaubte Betreten des Raumes der Angriffsgrund war, bleibt das Verhalten unverändert.
+* Fix [#45](https://g1cp.org/issues/45): Zwei Snapper außerhalb der Klosterruine spawnen nun korrekt.
 * Fix [#50](https://g1cp.org/issues/50): Die unerreichbare Truhe in der Gruft unter dem Stonehenge ist nun korrekt positioniert und zugänglich.
 * Fix [#52](https://g1cp.org/issues/52): Der Schleifstein im Neuen Lager setzt zur Benutzung nun korrekt eine Schwertklinge voraus.
 * Fix [#110](https://g1cp.org/issues/110): Die Maus ist während Interaktionen mit Objekten/Gegenständen nicht mehr blockiert und kann die Kameraperspektive beinflussen.

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix045_SpawnSnappersMonastery.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix045_SpawnSnappersMonastery.d
@@ -1,0 +1,202 @@
+/*
+ * #45 Snappers don't spawn outside the Monastery ruins
+ */
+
+/*
+ * Remember the snappers (until loading)
+ */
+instance G1CP_045_SpawnSnappersMonastery_Snapper1 (C_Npc);
+instance G1CP_045_SpawnSnappersMonastery_Snapper2 (C_Npc);
+
+
+/*
+ * One-time checks
+ */
+func int G1CP_045_SpawnSnappersMonastery_InitSession() {
+    // Get necessary symbols
+    var int funcId; funcId = G1CP_GetFuncID("Startup_Sub_Surface", "void|none");
+    var int instId; instId = G1CP_GetNpcInstId("Snapper");
+    if (funcId == -1) || (instId == -1) {
+        return FALSE;
+    };
+
+    // Find all pushed snapper instances in "Startup_Sub_Surface"
+    var int bytes[2];
+    MEMINT_OverrideFunc_Ptr = _@(bytes);
+    MEMINT_OFTokPar(zPAR_TOK_PUSHINT, instId);
+    MEMINT_OFTok(zPAR_TOK_PUSHVAR);
+    var int matches; matches = G1CP_FindInCode(funcId, 0, _@(bytes), 6, 0);
+
+    // Verify context: Wld_InsertNpc(Snapper, "OW_MONSTER_NAVIGATE02")
+    var int insertId; insertId = MEM_GetFuncID(Wld_InsertNpc);
+    var int i; i = 0;
+    var int wasFixed; wasFixed = FALSE;
+    while(i < MEM_ArraySize(matches));
+        var int pos; pos = MEM_ArrayRead(matches, i);
+        if (MEM_ReadByte(pos+10) == zPAR_TOK_CALLEXTERN) && (MEM_ReadInt(pos+11) == insertId) {
+            var string wp; wp = G1CP_GetStringI(MEM_ReadInt(pos+6), 0, "");
+            if (Hlp_StrCmp(wp, "OW_MONSTER_NAVIGATE02")) {
+                // Found a lost snapper
+                i += 1;
+                continue;
+            } else if (Hlp_StrCmp(wp, "OW_MONSTER_NAVIGATE_02")) {
+                // Someone adds a snapper at the correct way point
+                wasFixed = TRUE;
+                break;
+            };
+        };
+        MEM_ArrayRemoveIndex(matches, i);
+    end;
+
+    // Check if exactly two lost snapper-insertions were found
+    var int proceed; proceed = (!wasFixed) && (MEM_ArraySize(matches) == 2);
+
+    // Free the array
+    MEM_ArrayFree(matches);
+
+    // Success
+    return proceed;
+};
+
+
+/*
+ * Apply the changes
+ */
+func int G1CP_045_SpawnSnappersMonastery() {
+    // Do one-time checks
+    const int fixNecessary = -1;
+    if (fixNecessary == -1) {
+        fixNecessary = G1CP_045_SpawnSnappersMonastery_InitSession();
+    };
+
+    // No need to do anything, issue is mostly likely already fixed
+    if (!fixNecessary) {
+        return FALSE;
+    };
+
+    // The incorrect waypoint seems to have been created to fix the issue
+    if (G1CP_GetWaypoint("OW_MONSTER_NAVIGATE02")) {
+        return FALSE;
+    };
+
+    // Confirm the correct world by checking the waypoint
+    if (!G1CP_GetWaypoint("OW_MONSTER_NAVIGATE_02")) {
+        return FALSE;
+    };
+
+    // Proceed with the fix
+    var int snapper1; snapper1 = 0;
+    var int snapper2; snapper2 = 0;
+
+    // Iterate over all snappers in the world lists and get the lost ones
+    var int arrPtr; arrPtr = MEM_SearchAllVobsByName("SNAPPER");
+    repeat(i, MEM_ArraySize(arrPtr)); var int i;
+        var int npcPtr; npcPtr = MEM_ArrayRead(arrPtr, i);
+        if (Hlp_Is_oCNpc(npcPtr)) {
+            var oCNpc npc; npc = _^(npcPtr);
+
+            // Identify snappers by no spawn point information
+            if (npc.state_aiStatePosition[0] == 0) { // Separate blocks for performance
+            if (npc.state_aiStatePosition[1] == 0) {
+            if (npc.state_aiStatePosition[2] == 0) {
+            if (Hlp_StrCmp(npc.wpname, "")) {
+
+                // Double-check if in Spawn manager
+                var C_Npc slf; slf = MEM_CpyInst(npc);
+                if (G1CP_NpcIsInSpawnMan(slf)) {
+                    continue;
+                };
+
+                // Only accept two lost snappers, otherwise this fix becomes too complicated
+                if (snapper2) {
+                    snapper2 = 0; // Reset
+                    break;
+                } else if (snapper1) {
+                    snapper2 = npcPtr;
+                } else {
+                    snapper1 = npcPtr;
+                };
+            }; }; }; };
+        };
+    end;
+    MEM_ArrayFree(arrPtr);
+
+    // Only do something, if exactly two lost snappers were found
+    if (snapper1) && (snapper2) {
+
+        // Add both to the spawn manager. Equivalent to: Wld_InsertNpc, but with pre-existing NPCs
+        const int oCSpawnManager__SpawnNpc = 7144640; //0x6D04C0
+        const int spawnManPtr = 0;
+        const int strPtr = 0;
+        const int call = 0;
+        if (CALL_Begin(call)) {
+            spawnManPtr = MEM_Game.spawnman;
+            strPtr = _@s("OW_MONSTER_NAVIGATE_02");
+            CALL_PtrParam(_@(FLOATNULL));
+            CALL_PtrParam(_@(strPtr));
+            CALL_PtrParam(_@(snapper1));
+            CALL__thiscall(_@(spawnManPtr), oCSpawnManager__SpawnNpc);
+            CALL_PtrParam(_@(FLOATNULL));
+            CALL_PtrParam(_@(strPtr));
+            CALL_PtrParam(_@(snapper2));
+            CALL__thiscall(_@(spawnManPtr), oCSpawnManager__SpawnNpc);
+            call = CALL_End();
+        };
+
+        // Remember for reverting (will never be reset, see below)
+        G1CP_045_SpawnSnappersMonastery_Snapper1 = _^(snapper1);
+        G1CP_045_SpawnSnappersMonastery_Snapper2 = _^(snapper2);
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+
+/*
+ * Remove an NPC from the spawn manager
+ */
+func int G1CP_045_SpawnSnappersMonasteryRemoveSpawn(var C_Npc slf) {
+    // Check if in spawn list
+    var int nodePtr; nodePtr = G1CP_NpcGetSpawnNode(slf);
+    if (nodePtr) {
+
+        // Remove from spawn manager and disable NPC
+        const int oCSpawnManager__RemoveFromList = 7141232; //0x6CF770
+        const int spawnManPtr = 0;
+        const int call = 0;
+        if (CALL_Begin(call)) {
+            spawnManPtr = MEM_Game.spawnman;
+            CALL_PtrParam(_@(nodePtr));
+            CALL__thiscall(_@(spawnManPtr), oCSpawnManager__RemoveFromList);
+            call = CALL_End();
+        };
+
+        // Reset spawn position
+        var oCNpc npc; npc = Hlp_GetNpc(slf);
+        npc.state_aiStatePosition[0] = FLOATNULL;
+        npc.state_aiStatePosition[1] = FLOATNULL;
+        npc.state_aiStatePosition[2] = FLOATNULL;
+        npc.wpname = "";
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * Revert the changes
+ */
+func int G1CP_045_SpawnSnappersMonasteryRevert() {
+    // Remove snappers from the spawn manager
+    var int count; count = 0;
+    count += G1CP_045_SpawnSnappersMonasteryRemoveSpawn(G1CP_045_SpawnSnappersMonastery_Snapper1);
+    count += G1CP_045_SpawnSnappersMonasteryRemoveSpawn(G1CP_045_SpawnSnappersMonastery_Snapper2);
+
+    /* If reverting failed (because the snappers are currently spawned), keep the NPC instance variables intact. This
+    allows to try again on next revert. However, if the game is closed before saving again, the snappers will remain
+    in the savegame and are part of the game from that point on. */
+
+    // Return if removed both
+    return (count == 2);
+};

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -25,6 +25,7 @@ func int G1CP_HookGameSaveFixes() {
 func void G1CP_GamesaveFixes_Apply() {
     if (G1CP_InitStart()) {                             // Maximum fix function name length: 45 characters
         G1CP_037_LogEntryGravoMerchant();               // #37
+        G1CP_045_SpawnSnappersMonastery();              // #45
         G1CP_046_SmithDoor();                           // #46
         G1CP_050_Pillar();                              // #50
         G1CP_051_StonehengeCryptChest();                // #51
@@ -44,6 +45,7 @@ func void G1CP_GamesaveFixes_Apply() {
 func void G1CP_GamesaveFixes_Revert() {
     if (G1CP_InitStart()) {                             // Maximum fix function name length: 45 characters
         G1CP_037_LogEntryGravoMerchantRevert();         // #37
+        G1CP_045_SpawnSnappersMonasteryRevert();        // #45
         G1CP_046_SmithDoorRevert();                     // #46
         G1CP_050_PillarRevert();                        // #50
         G1CP_051_StonehengeCryptChestRevert();          // #51

--- a/src/Ninja/G1CP/Content/Misc/npc.d
+++ b/src/Ninja/G1CP/Content/Misc/npc.d
@@ -60,6 +60,62 @@ func int G1CP_NpcIsVisibleOnScreen(var C_Npc slf) {
 
 
 /*
+ * Get the oTSpawnNode of an NPC, if currently in the spawn manager
+ */
+func int G1CP_NpcGetSpawnNode(var C_Npc slf) {
+    // NPC must be valid
+    if (!Hlp_IsValidNpc(slf)) {
+        return 0;
+    };
+
+    // Iterate over spawn list (in machine code for performance)
+    const int ret = 0;
+    const int code = 0;
+    const int npcPtr = 0;
+    if (!code) {
+        MEM_InitGlobalInst();
+        ASM_Open(47+1);
+        ASM_1(96);                              // pusha
+        ASM_1(185);   ASM_4(MEM_Game.spawnman); // mov    ecx, spawnman
+        ASM_3(545163);                          // mov    edx, [ecx+0x8]
+        ASM_2(53893);                           // test   edx, edx
+        ASM_2(6260);                            // jz     notFound
+        ASM_2(2443);                            // mov    ecx, [ecx]
+        ASM_2(13707); ASM_4(_@(npcPtr));        // mov    esi, npcPtr
+        ASM_2(49201);                           // xor    eax, eax
+        // loopStart:
+        ASM_2(14731);                           // mov    edi, [ecx]
+        ASM_2(14137);                           // cmp    [edi], esi
+        ASM_2(2676);                            // jz     found
+        ASM_1(64);                              // inc    eax
+        ASM_3(311683);                          // add    ecx, 0x4
+        ASM_2(53305);                           // cmp    eax, edx
+        ASM_2(62076);                           // jl     loopStart
+        // notFound:
+        ASM_2(65329);                           // xor    edi, edi
+        // found:
+        ASM_2(15753);  ASM_4(_@(ret));          // mov    [ret], edi
+        ASM_1(97);                              // popa
+        ASM_1(195);                             // ret
+        code = ASM_Close();
+    };
+
+    // Execute the code
+    npcPtr = _@(slf);
+    ASM_Run(code);
+    return +ret;
+};
+
+
+/*
+ * Check if an NPC is in the spawn manager. That is not the case if they are currently spawned, dead or lost.
+ */
+func int G1CP_NpcIsInSpawnMan(var C_Npc slf) {
+    return (G1CP_NpcGetSpawnNode(slf) != 0);
+};
+
+
+/*
  * Instant teleport (for the testsuite functions)
  * Advantages:
  * - Destination may be anything from a waypoint to a VOB name/NPC instance name

--- a/src/Ninja/G1CP/Content/Tests/test045.d
+++ b/src/Ninja/G1CP/Content/Tests/test045.d
@@ -1,0 +1,33 @@
+/*
+ * #45 Snappers don't spawn outside the Monastery ruins
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ * Caution: This test will break the game. Save the game beforehand.
+ *
+ * Expected behavior: The snappers appear at the waypoint, identifiable by bounding boxes.
+ */
+func void G1CP_Test_045() {
+    if (!G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    // Define possibly missing symbols locally
+    const int NPC_FLAG_IMMORTAL = 1 << 1;
+
+    // Set PC to invincible to observe the action
+    hero.flags = hero.flags | NPC_FLAG_IMMORTAL;
+
+    // For this test: mark them
+    var zCVob vob;
+    if (Hlp_IsValidNpc(G1CP_045_SpawnSnappersMonastery_Snapper1)) {
+        vob = Hlp_GetNpc(G1CP_045_SpawnSnappersMonastery_Snapper1);
+        vob.bitfield[0] = vob.bitfield[0] | zCVob_bitfield0_drawBBox3D;
+    };
+    if (Hlp_IsValidNpc(G1CP_045_SpawnSnappersMonastery_Snapper2)) {
+        vob = Hlp_GetNpc(G1CP_045_SpawnSnappersMonastery_Snapper2);
+        vob.bitfield[0] = vob.bitfield[0] | zCVob_bitfield0_drawBBox3D;
+    };
+
+    // Teleport the player right to them
+    AI_Teleport(hero, "OW_MONSTER_NAVIGATE_02");
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -122,6 +122,7 @@ Content\Fixes\Session\fix217_MercenaryDailyRoutine.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix037_LogEntryGravoMerchant.d
+Content\Fixes\Gamesave\fix045_SpawnSnappersMonastery.d
 Content\Fixes\Gamesave\fix046_SmithDoor.d
 Content\Fixes\Gamesave\fix050_Pillar.d
 Content\Fixes\Gamesave\fix051_StonehengeCryptChest.d
@@ -171,6 +172,7 @@ Content\Tests\test040.d
 Content\Tests\test042.d
 Content\Tests\test043.d
 Content\Tests\test044.d
+Content\Tests\test045.d
 Content\Tests\test046.d
 Content\Tests\test049.d
 Content\Tests\test050.d


### PR DESCRIPTION
Snappers don't spawn outside the Monastery ruins.

This fix corrects the spawn of the two snappers such that they appear in the game. On saving, this fix is reverted to leave no changes in the savegame. That means, the spawn of the snappers is invalidated again. However, if the player is currently in spawn range of the snappers when saving, their spawn is not reverted and they will be written to the savegame. In that event, they remain in the game. This is necessary to avoid inconsistencies when saving the game while engaging with the snappers.