### PR TITLE
The text of items with no value is incomplete in the inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## v1.2.0 (TBA)
 ### General
-* Fix [#176](https://g1cp.org/issues/176): Items with no value no longer show an empty "Value:" in the inventory text.
 ### Story
 
 ## v1.1.0 (TBA)
@@ -15,6 +14,7 @@
 * Fix [#110](https://g1cp.org/issues/110): Mouse input is no longer locked when interacting with objects to allow adjusting the camera viewpoint.
 * Fix [#149](https://g1cp.org/issues/149): The armor "Improved ore Armor" is now correctly labelled as "Improved Ore Armor".
 * Fix [#152](https://g1cp.org/issues/152): The description of the ring "Protection of Fire" is corrected to "Ring of Fire Protection".
+* Fix [#176](https://g1cp.org/issues/176): Items with no value no longer show an empty "Value:" in the inventory text.
 * Fix [#192](https://g1cp.org/issues/192): Mages (NPCs fighting only with spells) no longer auto-equip weapons (e.g. after trading). This requires fix #59 to be active.
 * Fix [#193](https://g1cp.org/issues/193): Objects activated by switches/levers/winches are no longer stuck after loading a game.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.2.0 (TBA)
 ### General
+* Fix [#176](https://g1cp.org/issues/176): Items with no value no longer show an empty "Value:" in the inventory text.
 ### Story
 
 ## v1.1.0 (TBA)

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -2,7 +2,6 @@
 
 ## v1.2.0 (TBA)
 ### General
-* Fix [#176](https://g1cp.org/issues/176): Gegenstände ohne Wert zeigen nicht mehr ein leeres "Wert:" im Inventartext an.
 ### Story
 
 ## v1.1.0 (TBA)
@@ -20,6 +19,7 @@
 * Fix [#148](https://g1cp.org/issues/148): Die Rüstung "antike Erzrüstung" heißt nun korrekt "Antike Erzrüstung".
 * Fix [#149](https://g1cp.org/issues/149): Die Rüstung "verbesserte Erzrüstung" heißt nun korrekt "Verbesserte Erzrüstung".
 * Fix [#173](https://g1cp.org/issues/173): Im Text von "Gomez' Schlüssel" ist nun die Phrase "Öffnet Gomez Truhen" korrigiert zu "Öffnet Gomez' Truhen".
+* Fix [#176](https://g1cp.org/issues/176): Gegenstände ohne Wert zeigen nicht mehr ein leeres "Wert:" im Inventartext an.
 * Fix [#192](https://g1cp.org/issues/192): Magier (NSCs, die nur mit Magie kämpfen) rüsten nicht länger automatisch Nah- und Fernkampfwaffen aus (z.B. nach dem Handeln). Dieser Fix setzt den Fix [#59](https://g1cp.org/issues/59) voraus.
 * Fix [#193](https://g1cp.org/issues/193): Objekte, die durch Hebel/Schalter/Winden aktiviert wurden, stecken nach dem Spielladen nicht mehr fest.
 * Fix [#200](https://g1cp.org/issues/200): Die Beschreibung der Rüstung "Verbesserte Erzrüstung" passt nun in die Textbox des Inventars.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -2,6 +2,7 @@
 
 ## v1.2.0 (TBA)
 ### General
+* Fix [#176](https://g1cp.org/issues/176): Gegenstände ohne Wert zeigen nicht mehr ein leeres "Wert:" im Inventartext an.
 ### Story
 
 ## v1.1.0 (TBA)

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix176_InvItemTextValue.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix176_InvItemTextValue.d
@@ -1,0 +1,35 @@
+/*
+ * #176 The text of items with no value is incomplete in the inventory
+ */
+func int G1CP_176_InvItemTextValue() {
+    const int oCItemContainer__DrawItemInfo_showText = 6714596; //0x6674E4
+
+    if (G1CP_CheckBytes(oCItemContainer__DrawItemInfo_showText, "50 53 68 FA 00 00 00") == 1) // Must not be hooked
+    && (G1CP_IsStringConst("NAME_Value", 0)) {
+        HookEngineF(oCItemContainer__DrawItemInfo_showText, 7, G1CP_176_InvItemTextValue_Hook);
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * Engine hook to intercept printing of the left hand text
+ * This function is called five times per frame when the inventory is open. It should be replaced by machine code!
+ */
+func void G1CP_176_InvItemTextValue_Hook() {
+    // Get the content of the string once
+    const string NAME_Value = "";
+    const int once = 0;
+    if (!once) {
+        once = 1;
+        NAME_Value = G1CP_GetStringConst("NAME_Value", 0, NAME_Value);
+    };
+
+    if (!EDI) { // The value number
+        var string left; left = MEM_ReadString(EAX); // The text on the left side
+        if (STR_Compare(left, NAME_Value) == STR_EQUAL) {
+            EAX = _@s(""); // New text on the left side
+        };
+    };
+};

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix176_InvItemTextValue.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix176_InvItemTextValue.d
@@ -2,34 +2,46 @@
  * #176 The text of items with no value is incomplete in the inventory
  */
 func int G1CP_176_InvItemTextValue() {
-    const int oCItemContainer__DrawItemInfo_showText = 6714596; //0x6674E4
+    const int oCItemContainer__DrawItemInfo_showText = 6714592; //0x6674E0
 
-    if (G1CP_CheckBytes(oCItemContainer__DrawItemInfo_showText, "50 53 68 FA 00 00 00") == 1) // Must not be hooked
+    if (G1CP_CheckBytes(oCItemContainer__DrawItemInfo_showText, "8D 44 24 34 50") == 1) // Must not be hooked
     && (G1CP_IsStringConst("NAME_Value", 0)) {
-        HookEngineF(oCItemContainer__DrawItemInfo_showText, 7, G1CP_176_InvItemTextValue_Hook);
+
+        // Write new instructions to skip display if count is zero and text corresponds to "NAME_Value"
+        const string str = ""; str = G1CP_GetStringConst("NAME_Value", 0, str);
+        const int ds_lstrcmpiA = 8192708; //0x7D02C4
+        const int backAddr = oCItemContainer__DrawItemInfo_showText + 5;
+        const int addr = 0;
+        ASM_Open(52+1);
+        ASM_4(874792077);                    // lea    eax, [esp+0x34]
+        ASM_1(80);                           // push   eax
+        ASM_1(81);                           // push   ecx
+        ASM_1(82);                           // push   edx
+        ASM_2(65413);                        // test   edi, edi
+        ASM_2(8565);                         // jnz    back
+        ASM_3(542859);                       // mov    ecx, [eax+0x8]
+        ASM_2(51589);                        // test   ecx, ecx
+        ASM_2(6772);                         // jz     back
+        ASM_3(553215);                       // push   [eax+0x8]
+        ASM_1(104); ASM_4(STR_toChar(str));  // push   STR_toChar(value)
+        ASM_2(5631); ASM_4(ds_lstrcmpiA);    // call   [ds:lstrcmpiA]
+        ASM_2(49285);                        // test   eax, eax
+        ASM_2(2165);                         // jnz    back
+        ASM_4(136594631); ASM_4(_@s(""));    // mov    [esp+0x8], _@s("")
+        // back:
+        ASM_1(90);                           // pop    edx
+        ASM_1(89);                           // pop    ecx
+        ASM_1(104); ASM_4(backAddr);         // push   oCItemContainer__DrawItemInfo_showText+5
+        ASM_1(195);                          // ret
+        addr = ASM_Close();
+
+        // Hook just before drawing the left hand side text
+        MemoryProtectionOverride(oCItemContainer__DrawItemInfo_showText, 5);
+        MEM_WriteByte(oCItemContainer__DrawItemInfo_showText, ASMINT_OP_jmp);
+        MEM_WriteInt(oCItemContainer__DrawItemInfo_showText+1, addr - oCItemContainer__DrawItemInfo_showText - 5);
+
         return TRUE;
     } else {
         return FALSE;
-    };
-};
-
-/*
- * Engine hook to intercept printing of the left hand text
- * This function is called five times per frame when the inventory is open. It should be replaced by machine code!
- */
-func void G1CP_176_InvItemTextValue_Hook() {
-    // Get the content of the string once
-    const string NAME_Value = "";
-    const int once = 0;
-    if (!once) {
-        once = 1;
-        NAME_Value = G1CP_GetStringConst("NAME_Value", 0, NAME_Value);
-    };
-
-    if (!EDI) { // The value number
-        var string left; left = MEM_ReadString(EAX); // The text on the left side
-        if (STR_Compare(left, NAME_Value) == STR_EQUAL) {
-            EAX = _@s(""); // New text on the left side
-        };
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test176.d
+++ b/src/Ninja/G1CP/Content/Tests/test176.d
@@ -1,0 +1,33 @@
+/*
+ * #176 The text of items with no value is incomplete in the inventory
+ */
+func void G1CP_Test_176() {
+    if (!G1CP_TestsuiteAllowManual) {
+        return;
+    };
+
+    var int passed; passed = TRUE;
+
+    var int item1Id; item1Id = G1CP_GetItemInstId("ItKe_Gomez_01");
+    if (item1Id == -1) {
+        G1CP_TestsuiteErrorDetail("Item instance 'ItKe_Gomez_01' not found");
+        passed = FALSE;
+    };
+
+    var int item2Id; item2Id = G1CP_GetItemInstId("ItMw_1H_Sword_01");
+    if (item2Id == -1) {
+        G1CP_TestsuiteErrorDetail("Item instance 'ItMw_1H_Sword_01' not found");
+        passed = FALSE;
+    };
+
+    if (!passed) {
+        return;
+    };
+
+    // Give two items in the inventory
+    CreateInvItem(hero, item1Id);
+    CreateInvItem(hero, item2Id);
+
+    // Give some info
+    Print("Two items have been placed in the inventory. Please check their text display.");
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -79,6 +79,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_173_DE_GomezKeyText();                     // #173
         G1CP_174_EN_GomezKeyName();                     // #174
         G1CP_175_EN_RiceLordKeyName();                  // #175
+        G1CP_176_InvItemTextValue();                    // #176
         G1CP_181_SwineyGiveArmor();                     // #181
         G1CP_182_GuardDialogDusty();                    // #182
         G1CP_183_CorristoSellsRobe();                   // #183

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -109,6 +109,7 @@ Content\Fixes\Session\fix172_DE_KalomsRecipeName.d
 Content\Fixes\Session\fix173_DE_GomezKeyText.d
 Content\Fixes\Session\fix174_EN_GomezKeyName.d
 Content\Fixes\Session\fix175_EN_RiceLordKeyName.d
+Content\Fixes\Session\fix176_InvItemTextValue.d
 Content\Fixes\Session\fix181_SwineyGiveArmor.d
 Content\Fixes\Session\fix182_GuardDialogDusty.d
 Content\Fixes\Session\fix183_CorristoSellsRobe.d
@@ -222,6 +223,7 @@ Content\Tests\test172.d
 Content\Tests\test173.d
 Content\Tests\test174.d
 Content\Tests\test175.d
+Content\Tests\test176.d
 Content\Tests\test181.d
 Content\Tests\test182.d
 Content\Tests\test183.d


### PR DESCRIPTION
**Describe the bug**
There are items that have no value. In the inventory it shows "Value:" but not number.

**Expected behavior**
Items with no value no longer show an empty "Value:" in the inventory text.

**Additional context**
The items have a value of 0 and therefor the value isn't displayed.

The bug has been reported in #177 #178 #179 #180.