### PR TITLE
Missing mana potion in stonehenge crypt chest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.2.0 (TBA)
 ### General
+* Fix [#226](https://g1cp.org/issues/226): A misplaced mana potion is now correctly inserted in one of the chests in the crypt under the stonehenge.
 ### Story
 
 ## v1.1.0 (TBA)

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -2,6 +2,7 @@
 
 ## v1.2.0 (TBA)
 ### General
+* Fix [#226](https://g1cp.org/issues/226): Ein falsch platzierter Manatrank ist nun korrekt in einer der Truhen in der Gruft unter dem Stonehenge aufzufinden.
 ### Story
 
 ## v1.1.0 (TBA)

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix226_PotionStonehengeChest.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix226_PotionStonehengeChest.d
@@ -1,0 +1,129 @@
+/*
+ * #226 Missing mana potion in stonehenge crypt chest
+ */
+
+
+/*
+ * Identify the chest
+ */
+func int G1CP_226_PotionStonehengeChestFind() {
+    // Find the chest by its position
+    var int vobPtr; vobPtr = G1CP_FindVobByPosF(-35412.4219, 2280.677, -15320.7129);
+    if (!Hlp_Is_oCMobContainer(vobPtr)) {
+        return 0;
+    };
+    var oCMobContainer mob; mob = _^(vobPtr);
+
+    // Confirm its "contains" string
+    const string expected = "FOCUS_5,ITKELOCKPICK:2,ITFOBEER:2,ITAMARROW:45,ITMINUGGET:521,,ITFO_POTION_MANA_03";
+    if (!Hlp_StrCmp(mob.contains, expected)) {
+        return 0;
+    };
+
+    // Check if it's still locked. A chest cannot be locked again after it was opened once
+    if (!(mob._oCMobLockable_bitfield & oCMobLockable_bitfield_locked)) {
+        return 0;
+    };
+
+    return vobPtr;
+};
+
+
+/*
+ * Apply the changes
+ */
+func int G1CP_226_PotionStonehengeChest() {
+    var int applied; applied = FALSE;
+
+    // Check if the potion item even exists
+    const int itemId = -2;
+    if (itemId == -2) {
+        itemId = G1CP_GetItemInstId("ItFo_Potion_Mana_03");
+    };
+    if (itemId == -1) {
+        return FALSE;
+    };
+
+    // Find the chest
+    var int vobPtr; vobPtr = G1CP_226_PotionStonehengeChestFind();
+    if (!vobPtr) {
+        return FALSE;
+    };
+
+    // Check if the potion is already in the inventory
+    var int isIn;
+    const int oCMobContainer__IsIn = 6833040; //0x684390
+    const int call = 0;
+    if (CALL_Begin(call)) {
+        CALL_IntParam(_@(itemId));
+        CALL_PutRetValTo(_@(isIn));
+        CALL__thiscall(_@(vobPtr), oCMobContainer__IsIn);
+        call = CALL_End();
+    };
+    if (isIn) {
+        return FALSE;
+    };
+
+    // Finally: Add the missing potion
+    var oCMobContainer mob; mob = _^(vobPtr);
+    var string bak; bak = mob._zCObject_objectname;
+    mob._zCObject_objectname = "G1CP 226 TEMPORARY MOB";
+    Mob_CreateItems(mob._zCObject_objectname, itemId, 1);
+    mob._zCObject_objectname = bak;
+    return TRUE;
+};
+
+
+/*
+ * Revert the changes
+ */
+func int G1CP_226_PotionStonehengeChestRevert() {
+    // Only revert if it was applied by the G1CP
+    if (!G1CP_IsFixApplied(226)) {
+        return FALSE;
+    };
+
+    // The item does exist (checked by the function above), but we only need to retrieve the symbol index once
+    const int itemId = -2;
+    if (itemId == -2) {
+        itemId = G1CP_GetItemInstId("ItFo_Potion_Mana_03");
+    };
+
+    // Find the chest by its position
+    var int vobPtr; vobPtr = G1CP_226_PotionStonehengeChestFind();
+    if (!vobPtr) {
+        return FALSE;
+    };
+
+    // Remove the item from the chest. There is no convenient way to do this...
+    var int removed; removed = FALSE;
+    var oCMobContainer mob; mob = _^(vobPtr);
+    var int list; list = mob.containList_next;
+    while(list);
+        var zCListSort l; l = _^(list);
+        list = l.next;
+        if (Hlp_Is_oCItem(l.data)) {
+            var oCItem itm; itm = _^(l.data);
+            if (itm.instanz == itemId) {
+                if (itm.amount > 1) {
+                    itm.amount -= 1;
+                    removed = TRUE;
+                } else {
+                    var int itmPtr; itmPtr = l.data;
+                    const int call = 0;
+                    const int oCMobContainer__Remove = 6831936; //0x683F40
+                    if (CALL_Begin(call)) {
+                        CALL_IntParam(_@(TRUE));
+                        CALL_PtrParam(_@(itmPtr));
+                        CALL_PutRetValTo(_@(itmPtr));
+                        CALL__thiscall(_@(vobPtr), oCMobContainer__Remove);
+                        call = CALL_End();
+                    };
+                    removed = (itmPtr == 0);
+                };
+                break;
+            };
+        };
+    end;
+    return removed;
+};

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -41,6 +41,7 @@ func void G1CP_GamesaveFixes_Apply() {
         G1CP_205_LogEntryWolfMerchant();                // #205
         G1CP_212_UseWithItemNcCauldron1();              // #212
         G1CP_213_UseWithItemNcCauldron2();              // #213
+        G1CP_226_PotionStonehengeChest();               // #226
     };
 };
 
@@ -66,5 +67,6 @@ func void G1CP_GamesaveFixes_Revert() {
         G1CP_205_LogEntryWolfMerchantRevert();          // #205
         G1CP_212_UseWithItemNcCauldron1Revert();        // #212
         G1CP_213_UseWithItemNcCauldron2Revert();        // #213
+        G1CP_226_PotionStonehengeChestRevert();         // #226
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test226.d
+++ b/src/Ninja/G1CP/Content/Tests/test226.d
@@ -1,0 +1,26 @@
+/*
+ * #226 Missing mana potion in stonehenge crypt chest
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ * Caution: This test will break the game. Save the game beforehand.
+ *
+ * Expected behavior: The potion is now in the chest.
+ */
+func void G1CP_Test_226() {
+    G1CP_Testsuite_CheckManual();
+    var int itemId; itemId = G1CP_Testsuite_CheckItem("ItKe_Focus5");
+    var zCWaypoint wp; wp = G1CP_Testsuite_FindWaypoint("LOCATION_05_02_STONEHENGE4");
+    G1CP_Testsuite_CheckPassed();
+
+    // Define possibly missing symbols locally
+    const int NPC_FLAG_IMMORTAL = 1 << 1;
+
+    // Set PC to invincible to not be killed
+    hero.flags = hero.flags | NPC_FLAG_IMMORTAL;
+
+    // Offer the key
+    CreateInvItem(hero, itemId);
+
+    // Teleport to the nearest waypoint
+    AI_Teleport(hero, wp.name);
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -145,6 +145,7 @@ Content\Fixes\Gamesave\fix203_LogEntryGrahamMerchant.d
 Content\Fixes\Gamesave\fix205_LogEntryWolfMerchant.d
 Content\Fixes\Gamesave\fix212_UseWithItemNcCauldron1.d
 Content\Fixes\Gamesave\fix213_UseWithItemNcCauldron2.d
+Content\Fixes\Gamesave\fix226_PotionStonehengeChest.d
 
 // Initialization
 Content\initPre.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -110,3 +110,4 @@ Content\Tests\test215.d
 Content\Tests\test216.d
 Content\Tests\test217.d
 Content\Tests\test223.d
+Content\Tests\test226.d


### PR DESCRIPTION
**Describe the bug**
Due to a typo, there's a mana potion missing in one of the chests in the crypt under the stonehenge.

**Expected behavior**
A mana potion is now correctly inserted in one of the chests in the crypt under the stonehenge.

**Additional context**
Bug and fix provided by [N1kX94](https://github.com/AmProsius/gothic-1-community-patch/issues/211#issuecomment-808912236).

```
[% oCMobContainer:oCMobInter:oCMOB:zCVob 64513 16024]
pack=int:0
presetName=string:
bbox3DWS=rawFloat:-35454.0898 2280.677 -15369.6855 -35365.7734 2357.57202 -15269.3906
trafoOSToWSRot=raw:ceb5a63e00000000a40c723f000000000000803f00000000a40c72bf00000000ceb5a63e
trafoOSToWSPos=vec3:-35412.4219 2280.677 -15320.7129
vobName=string:CHEST
visual=string:CHESTBIG_OCCHESTMEDIUMLOCKED.MDS
showVisual=bool:1
visualCamAlign=enum:0
cdStatic=bool:0
cdDyn=bool:1
staticVob=bool:1
dynShadow=enum:0
[visual zCModel 0 16025]
[]
[ai % 0 0]
[]
focusName=string:CHEST
hitpoints=int:10
damage=int:0
moveable=bool:0
takeable=bool:0
focusOverride=bool:0
soundMaterial=enum:0
visualDestroyed=string:
owner=string:
ownerGuild=string:
isDestroyed=bool:0
stateNum=int:1
triggerTarget=string:
useWithItem=string:
conditionFunc=string:
onStateFunc=string:
rewind=bool:0
locked=bool:-1
keyInstance=string:ItKe_Focus5
pickLockStr=string:
contains=string:FOCUS_5,ITKELOCKPICK:2,ITFOBEER:2,ITAMARROW:45,ITMINUGGET:521,,ITFO_POTION_MANA_03
[]
```