### PR TITLE
Spelling - Magic book: "Verwandlung Orkhund" (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -5,6 +5,7 @@
 * Fix [#58](https://g1cp.org/issues/58): Fallen kann nicht mehr durch Kampfaktionen in der Luft unterbrochen werden.
 * Fix [#194](https://g1cp.org/issues/194): NSCs sammeln nun korrekt die Waffe ihres besiegten Gegners auf.
 * Fix [#226](https://g1cp.org/issues/226): Ein falsch platzierter Manatrank ist nun korrekt in einer der Truhen in der Gruft unter dem Stonehenge aufzufinden.
+* Fix [#235](https://g1cp.org/issues/235): Der Name im Magiebuch des Zaubers "Verwandlung Orc-Hund" heißt nun korrekt "Verwandlung Orkhund".
 ### Story
 * Fix [#55](https://g1cp.org/issues/55) (aktualisiert): Grim erwähnt In Extremo im zweiten Kapitel nun auch wenn das Konzert noch nicht begonnen hat. Für weitere Informationen zum Fix, siehe v1.1.0.
 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix235_DE_OrcDogMagBook.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix235_DE_OrcDogMagBook.d
@@ -1,0 +1,12 @@
+/*
+ * #235 Spelling - Magic book: "Verwandlung Orkhund" (DE)
+ */
+func int G1CP_235_DE_OrcDogMagBook() {
+    var int idx; idx = G1CP_FindStringConstArrIdx("TXT_SPELLS", "Verwandlung Orc-Hund");
+    if (idx != -1) {
+        G1CP_SetStringConst("TXT_SPELLS", idx, "Verwandlung Orkhund");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/Tests/test235.d
+++ b/src/Ninja/G1CP/Content/Tests/test235.d
@@ -1,0 +1,11 @@
+/*
+ * #235 Spelling - Magic book: "Verwandlung Orkhund" (DE)
+ */
+func int G1CP_Test_235() {
+    G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
+    const int SPL_TRF_ORCDOG = 0; SPL_TRF_ORCDOG = G1CP_Testsuite_GetIntConst("SPL_TRF_ORCDOG", 0);
+    var string name; name = G1CP_Testsuite_GetStringConst("TXT_SPELLS", SPL_TRF_ORCDOG);
+    G1CP_Testsuite_CheckPassed();
+
+    return Hlp_StrCmp(name, "Verwandlung Orkhund");
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -99,6 +99,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_216_DiggerDailyRoutine();                  // #216
         G1CP_217_MercenaryDailyRoutine();               // #217
         G1CP_223_CarKalomSpyQuest();                    // #223
+        G1CP_235_DE_OrcDogMagBook();                    // #235
     };
 };
 

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -128,6 +128,7 @@ Content\Fixes\Session\fix215_GuyDailyRoutine.d
 Content\Fixes\Session\fix216_DiggerDailyRoutine.d
 Content\Fixes\Session\fix217_MercenaryDailyRoutine.d
 Content\Fixes\Session\fix223_CorKalomSpyQuest.d
+Content\Fixes\Session\fix235_DE_OrcDogMagBook.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix037_LogEntryGravoMerchant.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -113,3 +113,4 @@ Content\Tests\test216.d
 Content\Tests\test217.d
 Content\Tests\test223.d
 Content\Tests\test226.d
+Content\Tests\test235.d


### PR DESCRIPTION
**Describe the bug**
In the German localization of the game there' a typo in the spell book name of the spell "Transform into Orc Dog".

**Changelog**
Der Name im Magiebuch des Zaubers "Verwandlung Orc-Hund" heißt nun korrekt "Verwandlung Orkhund".
