### PR TITLE
Spelling - Guild: "Orkhund" (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -5,6 +5,7 @@
 * Fix [#58](https://g1cp.org/issues/58): Fallen kann nicht mehr durch Kampfaktionen in der Luft unterbrochen werden.
 * Fix [#194](https://g1cp.org/issues/194): NSCs sammeln nun korrekt die Waffe ihres besiegten Gegners auf.
 * Fix [#226](https://g1cp.org/issues/226): Ein falsch platzierter Manatrank ist nun korrekt in einer der Truhen in der Gruft unter dem Stonehenge aufzufinden.
+* Fix [#236](https://g1cp.org/issues/226): Der Name in der Gildenzuordnung des Monsters "Ork-Hund" heißt nun korrekt "Orkhund".
 ### Story
 * Fix [#55](https://g1cp.org/issues/55) (aktualisiert): Grim erwähnt In Extremo im zweiten Kapitel nun auch wenn das Konzert noch nicht begonnen hat. Für weitere Informationen zum Fix, siehe v1.1.0.
 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix236_DE_OrcDogGuild.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix236_DE_OrcDogGuild.d
@@ -1,0 +1,12 @@
+/*
+ * #236 Spelling - Guild: "Orkhund" (DE)
+ */
+func int G1CP_236_DE_OrcDogGuild() {
+    var int idx; idx = G1CP_FindStringConstArrIdx("TXT_GUILDS", "Ork-Hund");
+    if (idx != -1) {
+        G1CP_SetStringConst("TXT_GUILDS", idx, "Orkhund");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};

--- a/src/Ninja/G1CP/Content/Tests/test236.d
+++ b/src/Ninja/G1CP/Content/Tests/test236.d
@@ -1,0 +1,11 @@
+/*
+ * #236 Spelling - Guild: "Orkhund" (DE)
+ */
+func int G1CP_Test_236() {
+    G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
+    const int GIL_ORCDOG = 0; GIL_ORCDOG = G1CP_Testsuite_GetIntConst("GIL_ORCDOG", 0);
+    var string name; name = G1CP_Testsuite_GetStringConst("TXT_GUILDS", GIL_ORCDOG);
+    G1CP_Testsuite_CheckPassed();
+
+    return Hlp_StrCmp(name, "Orkhund");
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -99,6 +99,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_216_DiggerDailyRoutine();                  // #216
         G1CP_217_MercenaryDailyRoutine();               // #217
         G1CP_223_CarKalomSpyQuest();                    // #223
+        G1CP_236_DE_OrcDogGuild();                      // #236
     };
 };
 

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -128,6 +128,7 @@ Content\Fixes\Session\fix215_GuyDailyRoutine.d
 Content\Fixes\Session\fix216_DiggerDailyRoutine.d
 Content\Fixes\Session\fix217_MercenaryDailyRoutine.d
 Content\Fixes\Session\fix223_CorKalomSpyQuest.d
+Content\Fixes\Session\fix236_DE_OrcDogGuild.d
 
 // Game save fixes
 Content\Fixes\Gamesave\fix037_LogEntryGravoMerchant.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -113,3 +113,4 @@ Content\Tests\test216.d
 Content\Tests\test217.d
 Content\Tests\test223.d
 Content\Tests\test226.d
+Content\Tests\test236.d


### PR DESCRIPTION
**Describe the bug**
In the German localization of the game there' a typo in the guild name of the monster "Orc Dog".

**Changelog**
Der Name in der Gildenzuordnung des Monsters "Ork-Hund" heißt nun korrekt "Orkhund".
