### PR TITLE
Gor Na Ran attacks the player character in chapter 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix [#226](https://g1cp.org/issues/226): A misplaced mana potion is now correctly inserted in one of the chests in the crypt under the stonehenge.
 ### Story
 * Fix [#55](https://g1cp.org/issues/55) (updated): Grim now correctly mentions In Extremo in the second chapter even if the concert has not yet started playing. For details on the fix, see v1.1.0.
+* Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
 
 ## [v1.1.0](https://g1cp.org/releases/tag/v1.1.0) (2021-05-01)
 ### General

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -10,6 +10,7 @@
 * Fix [#236](https://g1cp.org/issues/226): Der Name in der Gildenzuordnung des Monsters "Ork-Hund" heißt nun korrekt "Orkhund".
 ### Story
 * Fix [#55](https://g1cp.org/issues/55) (aktualisiert): Grim erwähnt In Extremo im zweiten Kapitel nun auch wenn das Konzert noch nicht begonnen hat. Für weitere Informationen zum Fix, siehe v1.1.0.
+* Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
 
 ## [v1.1.0](https://g1cp.org/releases/tag/v1.1.0) (01.05.2021)
 ### General

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix220_GorNaRanDialogMad.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix220_GorNaRanDialogMad.d
@@ -1,0 +1,21 @@
+/*
+ * #220 Gor Na Ran attacks the player character in chapter 6
+ */
+func int G1CP_220_GorNaRanDialogMad() {
+    if (G1CP_IsFunc("Info_TPL_1405_GorNaRan_Condition", "int|none")) {
+        HookDaedalusFuncS("Info_TPL_1405_GorNaRan_Condition", "G1CP_220_GorNaRanDialogMad_Hook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * Hook the dialog condition function to disable it
+ */
+func int G1CP_220_GorNaRanDialogMad_Hook() {
+    G1CP_ReportFuncToSpy();
+
+    // Always return false: The dialog is inaccessible
+    return FALSE;
+};

--- a/src/Ninja/G1CP/Content/Tests/test220.d
+++ b/src/Ninja/G1CP/Content/Tests/test220.d
@@ -1,0 +1,33 @@
+/*
+ * #220 Gor Na Ran attacks the player character in chapter 6
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: Gor Na Ran no longer talks to and attacks the player.
+ */
+func int G1CP_Test_220() {
+    var int chptId; chptId = G1CP_Testsuite_CheckIntVar("Kapitel", 0);
+    var int funcId; funcId = G1CP_Testsuite_CheckDialogConditionFunc("Info_TPL_1405_GorNaRan_Condition");
+    G1CP_Testsuite_CheckPassed();
+
+    // Backup values
+    var int chapterBak; chapterBak = G1CP_GetIntVarI(chptId, 0, 0);
+
+    // Set new values
+    G1CP_SetIntVarI(chptId, 0, 6);
+
+    // Call dialog condition function
+    G1CP_Testsuite_Call(funcId, 0, 0, FALSE);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore values
+    G1CP_SetIntVarI(chptId, 0, chapterBak);
+
+    // Check return value
+    if (ret) {
+        G1CP_TestsuiteErrorDetail("Dialog condition failed");
+        return FALSE;
+    };
+
+    return TRUE;
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -99,6 +99,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_215_GuyDailyRoutine();                     // #215
         G1CP_216_DiggerDailyRoutine();                  // #216
         G1CP_217_MercenaryDailyRoutine();               // #217
+        G1CP_220_GorNaRanDialogMad();                   // #220
         G1CP_223_CarKalomSpyQuest();                    // #223
         G1CP_235_DE_OrcDogMagBook();                    // #235
         G1CP_236_DE_OrcDogGuild();                      // #236

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -128,6 +128,7 @@ Content\Fixes\Session\fix214_GrahamDailyRoutine.d
 Content\Fixes\Session\fix215_GuyDailyRoutine.d
 Content\Fixes\Session\fix216_DiggerDailyRoutine.d
 Content\Fixes\Session\fix217_MercenaryDailyRoutine.d
+Content\Fixes\Session\fix220_GorNaRanDialogMad.d
 Content\Fixes\Session\fix223_CorKalomSpyQuest.d
 Content\Fixes\Session\fix235_DE_OrcDogMagBook.d
 Content\Fixes\Session\fix236_DE_OrcDogGuild.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -112,6 +112,7 @@ Content\Tests\test214.d
 Content\Tests\test215.d
 Content\Tests\test216.d
 Content\Tests\test217.d
+Content\Tests\test220.d
 Content\Tests\test223.d
 Content\Tests\test226.d
 Content\Tests\test235.d


### PR DESCRIPTION
**Describe the bug**
Gor Na Ran attacks the player character in chapter 6. Considering the corresponding dialog, it seems that he is supposed to be in the Sleeper's temple.

**Expected behavior**
Gor Na Ran no longer attacks the player character in chapter 6.

**Additional context**
Bug provided by [Blubbler](https://forum.worldofplayers.de/forum/threads/1574630-Release-Gothic-1-Community-Patch/page2?p=26716794&viewfull=1#post26716794).

https://github.com/AmProsius/gothic-1-community-patch/blob/7406330aae51b13622443869aea1c7140d5dc99d/scriptbase/_work/Data/Scripts/Content/Story/Missions/DIA_TPL_1405_GorNaRan.d#L61-L168
