### PR TITLE
Gorn can't be asked about after talking to Lares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix [#129](https://g1cp.org/issues/129): Drake's body skin color now matches his head.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
 * Fix [#226](https://g1cp.org/issues/226): A misplaced mana potion is now correctly inserted in one of the chests in the crypt under the stonehenge.
+* Fix [#228](https://g1cp.org/issues/228): Gorn can now correctly be asked about in ambient dialogs after the player talked to Lares.
 
 ## [v1.1.0](https://g1cp.org/releases/tag/v1.1.0) (2021-05-01)
 ### General

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -12,6 +12,7 @@
 * Fix [#129](https://g1cp.org/issues/129): Drakes Hautfarbe des Körpers entspricht jetzt der seines Kopfes.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
 * Fix [#226](https://g1cp.org/issues/226): Ein falsch platzierter Manatrank ist nun korrekt in einer der Truhen in der Gruft unter dem Stonehenge aufzufinden.
+* Fix [#228](https://g1cp.org/issues/228): Nach Gorn kann nun korrekt in Ambient-Dialogen gefragt werden, nachdem der Spieler mit Lares gesprochen hat.
 
 ## [v1.1.0](https://g1cp.org/releases/tag/v1.1.0) (01.05.2021)
 ### General

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix228_LaresDialogFindGorn.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix228_LaresDialogFindGorn.d
@@ -1,0 +1,26 @@
+/*
+ * #228 Gorn can't be asked about after talking to Lares
+ */
+func int G1CP_228_LaresDialogFindGorn() {
+    if (G1CP_IsFunc("ORG_801_Lares_BringListAnteil_Info", "void|none"))
+    && (G1CP_IsIntConst("AIV_FINDABLE", 0))
+    && (G1CP_IsNpcInst("PC_Fighter")) {
+        HookDaedalusFuncS("ORG_801_Lares_BringListAnteil_Info", "G1CP_228_LaresDialogFindGorn_Hook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts the dialog to add actions afterwards
+ */
+func void G1CP_228_LaresDialogFindGorn_Hook() {
+    G1CP_ReportFuncToSpy();
+
+    // Call the original function first
+    ContinueCall();
+
+    // Set Gorn to be "findable"
+    G1CP_NpcIDSetAIVar(MEM_GetSymbolIndex("PC_Fighter"), "AIV_FINDABLE", TRUE);
+};

--- a/src/Ninja/G1CP/Content/Tests/test228.d
+++ b/src/Ninja/G1CP/Content/Tests/test228.d
@@ -1,0 +1,43 @@
+/*
+ * #228 Gorn can't be asked about after talking to Lares
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: Gorn is findable after talking to Lares.
+ */
+func int G1CP_Test_228() {
+    const string TEMP_TOPIC_NAME = "G1CP Test 228"; // Has to be a unique name with absolute certainty
+    const string CH1_JoinNC = ""; CH1_JoinNC = G1CP_Testsuite_GetStringConst("CH1_JoinNC", 0);
+    var C_Npc npc; npc = G1CP_Testsuite_FindNpc("PC_Fighter");
+    var int funcId; funcId = G1CP_Testsuite_CheckDialogFunc("ORG_801_Lares_BringListAnteil_Info");
+    var int infoId; infoId = G1CP_Testsuite_CheckInfo("ORG_801_Lares_BringListBack");
+    var int aiVarId; aiVarId = G1CP_Testsuite_CheckIntConst("AIV_FINDABLE", 0);
+    G1CP_Testsuite_CheckPassed();
+
+    // Backup values
+    G1CP_LogRenameTopic(CH1_JoinNC, TEMP_TOPIC_NAME);
+    var int aiVarBak; aiVarBak = G1CP_NpcGetAiVarI(npc, aiVarId, 0);
+    var int toldBak; toldBak = Npc_KnowsInfo(hero, infoId);
+
+    // Set new values
+    G1CP_SetInfoToldI(infoId, TRUE);
+
+    // Call dialog condition function
+    G1CP_Testsuite_Call(funcId, npc, hero, TRUE);
+
+    // Retrieve the AI variable's value
+    var int passed; passed = G1CP_NpcGetAiVarI(npc, aiVarId, 0);
+
+    // Restore values
+    G1CP_LogRenameTopic(CH1_JoinNC, TEMP_TOPIC_NAME);
+    G1CP_NpcSetAiVarI(npc, aiVarId, aiVarBak);
+    G1CP_SetInfoToldI(infoId, toldBak);
+
+    // Check return value
+    if (passed) {
+        return TRUE;
+    };
+
+    G1CP_TestsuiteErrorDetail("The dialog function did not set the AI variable");
+    return FALSE;
+};

--- a/src/Ninja/G1CP/Content/Tests/test228.d
+++ b/src/Ninja/G1CP/Content/Tests/test228.d
@@ -29,7 +29,8 @@ func int G1CP_Test_228() {
     var int passed; passed = G1CP_NpcGetAiVarI(npc, aiVarId, 0);
 
     // Restore values
-    G1CP_LogRenameTopic(CH1_JoinNC, TEMP_TOPIC_NAME);
+    G1CP_LogRemoveTopic(CH1_JoinNC);
+    G1CP_LogRenameTopic(TEMP_TOPIC_NAME, CH1_JoinNC);
     G1CP_NpcSetAiVarI(npc, aiVarId, aiVarBak);
     G1CP_SetInfoToldI(infoId, toldBak);
 

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -101,6 +101,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_217_MercenaryDailyRoutine();               // #217
         G1CP_220_GorNaRanDialogMad();                   // #220
         G1CP_223_CarKalomSpyQuest();                    // #223
+        G1CP_228_LaresDialogFindGorn();                 // #228
         G1CP_235_DE_OrcDogMagBook();                    // #235
         G1CP_236_DE_OrcDogGuild();                      // #236
     };

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -130,6 +130,7 @@ Content\Fixes\Session\fix216_DiggerDailyRoutine.d
 Content\Fixes\Session\fix217_MercenaryDailyRoutine.d
 Content\Fixes\Session\fix220_GorNaRanDialogMad.d
 Content\Fixes\Session\fix223_CorKalomSpyQuest.d
+Content\Fixes\Session\fix228_LaresDialogFindGorn.d
 Content\Fixes\Session\fix235_DE_OrcDogMagBook.d
 Content\Fixes\Session\fix236_DE_OrcDogGuild.d
 

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -115,5 +115,6 @@ Content\Tests\test217.d
 Content\Tests\test220.d
 Content\Tests\test223.d
 Content\Tests\test226.d
+Content\Tests\test228.d
 Content\Tests\test235.d
 Content\Tests\test236.d


### PR DESCRIPTION
**Describe the bug**
Because of an incorrect assignment, Gorn can't be asked about in ambient dialogs after Lares talks of his existence.

**Expected behavior**
Gorn can now correctly be asked about in ambient dialogs after the player talked to Lares.

**Additional context**
Bug and fix provided by [N1kX94](https://github.com/AmProsius/gothic-1-community-patch/issues/211#issuecomment-809048931).