### PR TITLE
Exploit: Undead orc priest can die from fall damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix [#55](https://g1cp.org/issues/55) (updated): Grim now correctly mentions In Extremo in the second chapter even if the concert has not yet started playing. For details on the fix, see v1.1.0.
 * Fix [#129](https://g1cp.org/issues/129): Drake's body skin color now matches his head.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
+* Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (the last undead orc priest) can now only be killed with Uriziel.
 * Fix [#226](https://g1cp.org/issues/226): A misplaced mana potion is now correctly inserted in one of the chests in the crypt under the stonehenge.
 
 ## [v1.1.0](https://g1cp.org/releases/tag/v1.1.0) (2021-05-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fix [#55](https://g1cp.org/issues/55) (updated): Grim now correctly mentions In Extremo in the second chapter even if the concert has not yet started playing. For details on the fix, see v1.1.0.
 * Fix [#129](https://g1cp.org/issues/129): Drake's body skin color now matches his head.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
-* Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (the last undead orc priest) can now only be killed with Uriziel.
+* Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (the last undead orc priest) can no longer be killed by fall damage.
 * Fix [#226](https://g1cp.org/issues/226): A misplaced mana potion is now correctly inserted in one of the chests in the crypt under the stonehenge.
 
 ## [v1.1.0](https://g1cp.org/releases/tag/v1.1.0) (2021-05-01)

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -11,6 +11,7 @@
 * Fix [#55](https://g1cp.org/issues/55) (aktualisiert): Grim erwähnt In Extremo im zweiten Kapitel nun auch wenn das Konzert noch nicht begonnen hat. Für weitere Informationen zum Fix, siehe v1.1.0.
 * Fix [#129](https://g1cp.org/issues/129): Drakes Hautfarbe des Körpers entspricht jetzt der seines Kopfes.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
+* Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (der letzte untote Ork-Priester) kann nun nur noch mit Uriziel getötet werden.
 * Fix [#226](https://g1cp.org/issues/226): Ein falsch platzierter Manatrank ist nun korrekt in einer der Truhen in der Gruft unter dem Stonehenge aufzufinden.
 
 ## [v1.1.0](https://g1cp.org/releases/tag/v1.1.0) (01.05.2021)

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -11,7 +11,7 @@
 * Fix [#55](https://g1cp.org/issues/55) (aktualisiert): Grim erwähnt In Extremo im zweiten Kapitel nun auch wenn das Konzert noch nicht begonnen hat. Für weitere Informationen zum Fix, siehe v1.1.0.
 * Fix [#129](https://g1cp.org/issues/129): Drakes Hautfarbe des Körpers entspricht jetzt der seines Kopfes.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
-* Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (der letzte untote Ork-Priester) kann nun nur noch mit Uriziel getötet werden.
+* Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (der letzte untote Ork-Priester) kann nicht mehr durch Fallschaden getötet werden.
 * Fix [#226](https://g1cp.org/issues/226): Ein falsch platzierter Manatrank ist nun korrekt in einer der Truhen in der Gruft unter dem Stonehenge aufzufinden.
 
 ## [v1.1.0](https://g1cp.org/releases/tag/v1.1.0) (01.05.2021)

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix224_OrcPriestFallDamage.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix224_OrcPriestFallDamage.d
@@ -1,0 +1,55 @@
+/*
+ * #224 Undead orc priest can die from fall damage
+ *
+ * Retrieve the symbol index of the NPC
+ */
+func int G1CP_224_OrcPriestFallDamage_GetInst() {
+    const int npcId = -2; // -1 is reserved for invalid symbols
+
+    if (npcId == -2) {
+        npcId = G1CP_GetNpcInstId("ORC_Priest_5");
+    };
+
+    return npcId;
+};
+
+/*
+ * This function applies the changes
+ */
+func int G1CP_224_OrcPriestFallDamage() {
+    var oCNpc npc; npc = Hlp_GetNpc(G1CP_224_OrcPriestFallDamage_GetInst());
+
+    if (!Hlp_IsValidNpc(npc)) {
+        return FALSE;
+    };
+    
+    if (npc.fallDownDamage != 10) {
+        return FALSE;
+    };    
+
+    npc.fallDownDamage = 0;
+    return TRUE;
+};
+
+/*
+ * This function reverts the changes. Not necessary here, but for completeness and proper applied-status.
+ */
+func int G1CP_224_OrcPriestFallDamageRevert() {
+    // Only revert if it was applied by the G1CP
+    if (!G1CP_IsFixApplied(224)) {
+        return FALSE;
+    };
+
+    var oCNpc npc; npc = Hlp_GetNpc(G1CP_224_OrcPriestFallDamage_GetInst());
+
+    if (!Hlp_IsValidNpc(npc)) {
+        return FALSE;
+    };
+    
+    if (npc.fallDownDamage != 0) {
+        return FALSE;
+    };    
+
+    npc.fallDownDamage = 10;
+    return TRUE;
+};

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -41,6 +41,7 @@ func void G1CP_GamesaveFixes_Apply() {
         G1CP_205_LogEntryWolfMerchant();                // #205
         G1CP_212_UseWithItemNcCauldron1();              // #212
         G1CP_213_UseWithItemNcCauldron2();              // #213
+        G1CP_224_OrcPriestFallDamage();                 // #224
         G1CP_226_PotionStonehengeChest();               // #226
     };
 };
@@ -67,6 +68,7 @@ func void G1CP_GamesaveFixes_Revert() {
         G1CP_205_LogEntryWolfMerchantRevert();          // #205
         G1CP_212_UseWithItemNcCauldron1Revert();        // #212
         G1CP_213_UseWithItemNcCauldron2Revert();        // #213
+        G1CP_224_OrcPriestFallDamageRevert();           // #224
         G1CP_226_PotionStonehengeChestRevert();         // #226
     };
 };

--- a/src/Ninja/G1CP/Content/Misc/npc.d
+++ b/src/Ninja/G1CP/Content/Misc/npc.d
@@ -116,48 +116,6 @@ func int G1CP_NpcIsInSpawnMan(var C_Npc slf) {
 
 
 /*
- * Instant teleport (for the testsuite functions)
- * Advantages:
- * - Destination may be anything from a waypoint to a VOB name/NPC instance name
- * - The teleport is instant
- */
-func void G1CP_NpcBeamTo(var C_Npc slf, var string destination) {
-    var int slfPtr; slfPtr = _@(slf);
-    const int oCNpc__BeamTo = 6896400; //0x693B10
-    const int strPtr = 0;
-    const int call = 0;
-    if (CALL_Begin(call)) {
-        strPtr = _@s(destination);
-        CALL_PtrParam(_@(strPtr));
-        CALL__thiscall(_@(slfPtr), oCNpc__BeamTo);
-        call = CALL_End();
-    };
-};
-
-
-/*
- * Instant teleport (for the testsuite functions) to an exact position (rotation not considered)
- */
-func void G1CP_NpcBeamToPosF(var C_Npc slf, var float x, var float y, var float z) {
-    // Abuse a random waypoint
-    var zCWaypoint wp; wp = _^(MEM_GetAnyWPPtr());
-    var int posBak[3];
-    posBak[0] = wp.pos[0];
-    posBak[1] = wp.pos[1];
-    posBak[2] = wp.pos[2];
-
-    wp.pos[0] = castToIntf(x);
-    wp.pos[1] = castToIntf(y);
-    wp.pos[2] = castToIntf(z);
-    G1CP_NpcBeamTo(slf, wp.name);
-
-    wp.pos[0] = posBak[0];
-    wp.pos[1] = posBak[1];
-    wp.pos[2] = posBak[2];
-};
-
-
-/*
  * Safe way to obtain the content of an AI-variable
  */
 func int G1CP_NpcGetAiVarI(var C_Npc slf, var int aiVarId, var int dflt) {

--- a/src/Ninja/G1CP/Content/Tests/test009.d
+++ b/src/Ninja/G1CP/Content/Tests/test009.d
@@ -11,7 +11,7 @@ func void G1CP_Test_009() {
     var zCWaypoint wp; wp = G1CP_Testsuite_FindWaypoint("PSI_TEMPLE_COURT_2");
     G1CP_Testsuite_CheckPassed();
 
-    G1CP_NpcBeamTo(hero, wp.name);
+    G1CP_Testsuite_NpcBeamTo(hero, wp.name);
     AI_SetNpcsToState(hero, ZS_G1CP_Test_009_State, 4500);
 };
 

--- a/src/Ninja/G1CP/Content/Tests/test032.d
+++ b/src/Ninja/G1CP/Content/Tests/test032.d
@@ -28,5 +28,5 @@ func void G1CP_Test_032() {
     EquipWeapon(hero, weapId);
 
     // Teleport the player to the entrance of the Free Mine
-    G1CP_TeleportToWorld("FREEMINE.ZEN", "FM_02");
+    G1CP_Testsuite_NpcTeleportToWorld(hero, "FREEMINE.ZEN", "FM_02");
 };

--- a/src/Ninja/G1CP/Content/Tests/test032.d
+++ b/src/Ninja/G1CP/Content/Tests/test032.d
@@ -6,8 +6,6 @@
   * Expected behavior: Gorn no longer attacks the player or comments on a death during the raid of the Free Mine.
   */
 func void G1CP_Test_032() {
-    const string WORLD = "FREEMINE.ZEN";
-    const string WP = "FM_02";
     G1CP_Testsuite_CheckManual();
     var int chptrId; chptrId = G1CP_Testsuite_CheckIntVar("Kapitel", 0);
     var int weapId; weapId = G1CP_Testsuite_CheckItem("ItMw_1H_Sword_Old_01");
@@ -30,12 +28,5 @@ func void G1CP_Test_032() {
     EquipWeapon(hero, weapId);
 
     // Teleport the player to the entrance of the Free Mine
-    if (!Hlp_StrCmp(MEM_World.worldFilename, WORLD)) {
-        const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
-        CALL_zStringPtrParam(WP);
-        CALL_zStringPtrParam(WORLD);
-        CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
-    } else {
-        AI_Teleport(hero, WP);
-    };
+    G1CP_TeleportToWorld("FREEMINE.ZEN", "FM_02");
 };

--- a/src/Ninja/G1CP/Content/Tests/test050.d
+++ b/src/Ninja/G1CP/Content/Tests/test050.d
@@ -18,5 +18,5 @@ func void G1CP_Test_050() {
     pillar.bitfield[0] = pillar.bitfield[0] | zCVob_bitfield0_drawBBox3D;
 
     // Teleport PC to the pillar (AI_Teleport not applicable because there is no waypoint nearby)
-    G1CP_NpcBeamTo(hero, pillar._zCObject_objectname);
+    G1CP_Testsuite_NpcBeamTo(hero, pillar._zCObject_objectname);
 };

--- a/src/Ninja/G1CP/Content/Tests/test058.d
+++ b/src/Ninja/G1CP/Content/Tests/test058.d
@@ -9,5 +9,5 @@ func void G1CP_Test_058() {
     G1CP_Testsuite_CheckManual();
 
     Npc_SetToFistMode(hero);
-    G1CP_NpcBeamToPosF(hero, -5055.20459, 3906.66333, -3661.51001);
+    G1CP_Testsuite_NpcBeamToPosF(hero, -5055.20459, 3906.66333, -3661.51001);
 };

--- a/src/Ninja/G1CP/Content/Tests/test115.d
+++ b/src/Ninja/G1CP/Content/Tests/test115.d
@@ -15,5 +15,5 @@ func void G1CP_Test_115() {
     hero.flags = hero.flags | NPC_FLAG_IMMORTAL;
 
     // Teleport the player to the entrance of the orc graveyard
-    G1CP_TeleportToWorld("ORCGRAVEYARD.ZEN", "GRYD_001");
+    G1CP_Testsuite_NpcTeleportToWorld(hero, "ORCGRAVEYARD.ZEN", "GRYD_001");
 };

--- a/src/Ninja/G1CP/Content/Tests/test115.d
+++ b/src/Ninja/G1CP/Content/Tests/test115.d
@@ -7,8 +7,6 @@
  */
 func void G1CP_Test_115() {
     G1CP_Testsuite_CheckManual();
-    const string WORLD = "ORCGRAVEYARD.ZEN";
-    const string WP = "GRYD_001";
 
     // Define possibly missing symbols locally
     const int NPC_FLAG_IMMORTAL = 1 << 1;
@@ -17,12 +15,5 @@ func void G1CP_Test_115() {
     hero.flags = hero.flags | NPC_FLAG_IMMORTAL;
 
     // Teleport the player to the entrance of the orc graveyard
-    if (!Hlp_StrCmp(MEM_World.worldFilename, WORLD)) {
-        const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
-        CALL_zStringPtrParam(WP);
-        CALL_zStringPtrParam(WORLD);
-        CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
-    } else {
-        AI_Teleport(hero, WP);
-    };
+    G1CP_TeleportToWorld("ORCGRAVEYARD.ZEN", "GRYD_001");
 };

--- a/src/Ninja/G1CP/Content/Tests/test129.d
+++ b/src/Ninja/G1CP/Content/Tests/test129.d
@@ -7,5 +7,5 @@
  */
 func void G1CP_Test_129() {
     G1CP_Testsuite_CheckManual();
-    G1CP_TeleportToWorld("OLDMINE.ZEN", "OM_CAVE1_13A");
+    G1CP_Testsuite_NpcTeleportToWorld(hero, "OLDMINE.ZEN", "OM_CAVE1_13A");
 };

--- a/src/Ninja/G1CP/Content/Tests/test129.d
+++ b/src/Ninja/G1CP/Content/Tests/test129.d
@@ -7,16 +7,5 @@
  */
 func void G1CP_Test_129() {
     G1CP_Testsuite_CheckManual();
-    const string WORLD = "OLDMINE.ZEN";
-    const string WP = "OM_CAVE1_13A";
-
-    // Teleport the player to the entrance of the Free Mine
-    if (!Hlp_StrCmp(MEM_World.worldFilename, WORLD)) {
-        const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
-        CALL_zStringPtrParam(WP);
-        CALL_zStringPtrParam(WORLD);
-        CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
-    } else {
-        AI_Teleport(hero, WP);
-    };
+    G1CP_TeleportToWorld("OLDMINE.ZEN", "OM_CAVE1_13A");
 };

--- a/src/Ninja/G1CP/Content/Tests/test136.d
+++ b/src/Ninja/G1CP/Content/Tests/test136.d
@@ -6,17 +6,6 @@
  * Expected behavior: Gorn should be able to climb up the ladder to reach the PC without interruptions.
  */
 func void G1CP_Test_136() {
-    const string WORLD = "FREEMINE.ZEN";
-    const string WP = "FM_20";
     G1CP_Testsuite_CheckManual();
-
-    // Teleport the player to the entrance of the Free Mine
-    if (!Hlp_StrCmp(MEM_World.worldFilename, WORLD)) {
-        const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
-        CALL_zStringPtrParam(WP);
-        CALL_zStringPtrParam(WORLD);
-        CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
-    } else {
-        AI_Teleport(hero, WP);
-    };
+    G1CP_TeleportToWorld("FREEMINE.ZEN", "FM_20");
 };

--- a/src/Ninja/G1CP/Content/Tests/test136.d
+++ b/src/Ninja/G1CP/Content/Tests/test136.d
@@ -7,5 +7,5 @@
  */
 func void G1CP_Test_136() {
     G1CP_Testsuite_CheckManual();
-    G1CP_TeleportToWorld("FREEMINE.ZEN", "FM_20");
+    G1CP_Testsuite_NpcTeleportToWorld(hero, "FREEMINE.ZEN", "FM_20");
 };

--- a/src/Ninja/G1CP/Content/Tests/test182.d
+++ b/src/Ninja/G1CP/Content/Tests/test182.d
@@ -42,7 +42,7 @@ func int G1CP_Test_182() {
 
     // Satisfy dialog conditions
     G1CP_NpcSetAiVarI(npc, aiVarId, TRUE);
-    G1CP_NpcBeamTo(npc, Npc_GetNearestWp(hero));
+    G1CP_Testsuite_NpcBeamTo(npc, Npc_GetNearestWp(hero));
 
     // Call the condition function
     G1CP_Testsuite_Call(condId, 0, 0, TRUE);
@@ -61,7 +61,7 @@ func int G1CP_Test_182() {
         CreateInvItems(hero, oreId, amountBefore);
     };
     G1CP_NpcSetAiVarI(npc, aiVarId, aivBak);
-    G1CP_NpcBeamTo(npc, npcWp);
+    G1CP_Testsuite_NpcBeamTo(npc, npcWp);
     G1CP_LogRemoveTopic(CH1_RecruitDusty);
     G1CP_LogRenameTopic(TEMP_TOPIC_NAME, CH1_RecruitDusty);
 

--- a/src/Ninja/G1CP/Content/Tests/test224.d
+++ b/src/Ninja/G1CP/Content/Tests/test224.d
@@ -7,5 +7,5 @@
  */
 func void G1CP_Test_224() {
     G1CP_Testsuite_CheckManual();
-    G1CP_TeleportToWorld("ORCTEMPEL.ZEN", "TPL_289");
+    G1CP_Testsuite_NpcTeleportToWorld(hero, "ORCTEMPEL.ZEN", "TPL_289");
 };

--- a/src/Ninja/G1CP/Content/Tests/test224.d
+++ b/src/Ninja/G1CP/Content/Tests/test224.d
@@ -1,0 +1,11 @@
+/*
+ * #224 Exploit: Undead orc priest can die from fall damage
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: Grash-Varrag-Arushat doesn't die from fall damage.
+ */
+func void G1CP_Test_224() {
+    G1CP_Testsuite_CheckManual();
+    G1CP_TeleportToWorld("ORCTEMPEL.ZEN", "TPL_289");
+};

--- a/src/Ninja/G1CP/Content/Testsuite/npc.d
+++ b/src/Ninja/G1CP/Content/Testsuite/npc.d
@@ -4,7 +4,7 @@
  * - Destination may be anything from a waypoint to a VOB name/NPC instance name
  * - The teleport is instant
  */
-func void G1CP_NpcBeamTo(var C_Npc slf, var string destination) {
+func void G1CP_Testsuite_NpcBeamTo(var C_Npc slf, var string destination) {
     var int slfPtr; slfPtr = _@(slf);
     const int oCNpc__BeamTo = 6896400; //0x693B10
     const int strPtr = 0;
@@ -21,7 +21,7 @@ func void G1CP_NpcBeamTo(var C_Npc slf, var string destination) {
 /*
  * Instant teleport (for the testsuite functions) to an exact position (rotation not considered)
  */
-func void G1CP_NpcBeamToPosF(var C_Npc slf, var float x, var float y, var float z) {
+func void G1CP_Testsuite_NpcBeamToPosF(var C_Npc slf, var float x, var float y, var float z) {
     // Abuse a random waypoint
     var zCWaypoint wp; wp = _^(MEM_GetAnyWPPtr());
     var int posBak[3];
@@ -32,7 +32,7 @@ func void G1CP_NpcBeamToPosF(var C_Npc slf, var float x, var float y, var float 
     wp.pos[0] = castToIntf(x);
     wp.pos[1] = castToIntf(y);
     wp.pos[2] = castToIntf(z);
-    G1CP_NpcBeamTo(slf, wp.name);
+    G1CP_Testsuite_NpcBeamTo(slf, wp.name);
 
     wp.pos[0] = posBak[0];
     wp.pos[1] = posBak[1];
@@ -40,15 +40,15 @@ func void G1CP_NpcBeamToPosF(var C_Npc slf, var float x, var float y, var float 
 };
 
 /*
- * Teleport the player to a waypoint that may be in another level
+ * Teleport the player to a waypoint that is presumably in another level
  */
-func void G1CP_TeleportToWorld(var string world, var string waypoint) {
+func void G1CP_Testsuite_NpcTeleportToWorld(var C_Npc slf, var string world, var string waypoint) {
     if (!Hlp_StrCmp(MEM_World.worldFilename, world)) {
         const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
         CALL_zStringPtrParam(waypoint);
         CALL_zStringPtrParam(world);
         CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
     } else {
-        AI_Teleport(hero, waypoint);
+        AI_Teleport(slf, waypoint);
     };
 };

--- a/src/Ninja/G1CP/Content/Testsuite/teleport.d
+++ b/src/Ninja/G1CP/Content/Testsuite/teleport.d
@@ -1,0 +1,54 @@
+/*
+ * Instant teleport (for the testsuite functions)
+ * Advantages:
+ * - Destination may be anything from a waypoint to a VOB name/NPC instance name
+ * - The teleport is instant
+ */
+func void G1CP_NpcBeamTo(var C_Npc slf, var string destination) {
+    var int slfPtr; slfPtr = _@(slf);
+    const int oCNpc__BeamTo = 6896400; //0x693B10
+    const int strPtr = 0;
+    const int call = 0;
+    if (CALL_Begin(call)) {
+        strPtr = _@s(destination);
+        CALL_PtrParam(_@(strPtr));
+        CALL__thiscall(_@(slfPtr), oCNpc__BeamTo);
+        call = CALL_End();
+    };
+};
+
+
+/*
+ * Instant teleport (for the testsuite functions) to an exact position (rotation not considered)
+ */
+func void G1CP_NpcBeamToPosF(var C_Npc slf, var float x, var float y, var float z) {
+    // Abuse a random waypoint
+    var zCWaypoint wp; wp = _^(MEM_GetAnyWPPtr());
+    var int posBak[3];
+    posBak[0] = wp.pos[0];
+    posBak[1] = wp.pos[1];
+    posBak[2] = wp.pos[2];
+
+    wp.pos[0] = castToIntf(x);
+    wp.pos[1] = castToIntf(y);
+    wp.pos[2] = castToIntf(z);
+    G1CP_NpcBeamTo(slf, wp.name);
+
+    wp.pos[0] = posBak[0];
+    wp.pos[1] = posBak[1];
+    wp.pos[2] = posBak[2];
+};
+
+/*
+ * Teleport the player to a waypoint that may be in another level
+ */
+func void G1CP_TeleportToWorld(var string world, var string waypoint) {
+    if (!Hlp_StrCmp(MEM_World.worldFilename, world)) {
+        const int oCGame__TriggerChangeLevel = 6542464; //0x63D480
+        CALL_zStringPtrParam(waypoint);
+        CALL_zStringPtrParam(world);
+        CALL__thiscall(_@(MEM_Game), oCGame__TriggerChangeLevel);
+    } else {
+        AI_Teleport(hero, waypoint);
+    };
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -151,6 +151,7 @@ Content\Fixes\Gamesave\fix203_LogEntryGrahamMerchant.d
 Content\Fixes\Gamesave\fix205_LogEntryWolfMerchant.d
 Content\Fixes\Gamesave\fix212_UseWithItemNcCauldron1.d
 Content\Fixes\Gamesave\fix213_UseWithItemNcCauldron2.d
+Content\Fixes\Gamesave\fix224_OrcPriestFallDamage.d
 Content\Fixes\Gamesave\fix226_PotionStonehengeChest.d
 
 // Initialization

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -5,7 +5,7 @@ Content\Testsuite\get.d
 Content\Testsuite\find.d
 Content\Testsuite\create.d
 Content\Testsuite\call.d
-Content\Testsuite\teleport.d
+Content\Testsuite\npc.d
 
 Content\Tests\test001.d
 Content\Tests\test002.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -5,6 +5,7 @@ Content\Testsuite\get.d
 Content\Testsuite\find.d
 Content\Testsuite\create.d
 Content\Testsuite\call.d
+Content\Testsuite\teleport.d
 
 Content\Tests\test001.d
 Content\Tests\test002.d
@@ -114,6 +115,7 @@ Content\Tests\test216.d
 Content\Tests\test217.d
 Content\Tests\test220.d
 Content\Tests\test223.d
+Content\Tests\test224.d
 Content\Tests\test226.d
 Content\Tests\test235.d
 Content\Tests\test236.d


### PR DESCRIPTION
**Describe the bug**
Grash-Varrag-Arushat (the last undead orc priest) can die by fall damage rather than by Uriziel damage only.

**Expected behavior**
Grash-Varrag-Arushat (the last undead orc priest) can now only be killed with Uriziel.

**Additional context**
Bug provided by [Blubbler](https://forum.worldofplayers.de/forum/threads/1574630-Release-Gothic-1-Community-Patch/page2?p=26716794&viewfull=1#post26716794).