### PR TITLE
Spelling - Transform Bloodfly (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -4,6 +4,7 @@
 ### General
 * Fix [#58](https://g1cp.org/issues/58): Fallen kann nicht mehr durch Kampfaktionen in der Luft unterbrochen werden.
 * Fix [#194](https://g1cp.org/issues/194): NSCs sammeln nun korrekt die Waffe ihres besiegten Gegners auf.
+* Fix [#232](https://g1cp.org/issues/232): Die Spruchrolle "Verwandlung Bloodfly" heißt nun korrekt "Verwandlung Blutfliege".
 * Fix [#235](https://g1cp.org/issues/235): Der Name im Magiebuch des Zaubers "Verwandlung Orc-Hund" heißt nun korrekt "Verwandlung Orkhund".
 * Fix [#236](https://g1cp.org/issues/226): Der Name in der Gildenzuordnung des Monsters "Ork-Hund" heißt nun korrekt "Orkhund".
 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix232_DE_TransformBloodflyDescription.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix232_DE_TransformBloodflyDescription.d
@@ -1,0 +1,9 @@
+/*
+ * #232 Spelling - Transform Bloodfly (DE)
+ */
+func int G1CP_232_DE_TransformBloodflyDescription() {
+    var int itemId; itemId = G1CP_GetItemInstId("ItArScrollTrfBloodfly");
+    const string needle = "Verwandlung Bloodfly";
+    const string replace = "Verwandlung Blutfliege";
+    return (G1CP_ReplaceAssignStr(itemId, 0, "C_ITEM.DESCRIPTION", 0, needle, replace) > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test043.d
+++ b/src/Ninja/G1CP/Content/Tests/test043.d
@@ -18,10 +18,10 @@ func int G1CP_Test_043() {
     var string output; output = MEM_PopStringResult();
 
     // Test the output
-    if (Hlp_StrCmp(output, "Test 43 (10 ore, 20 skill points)")) {
-        return TRUE;
-    } else {
+    if (!Hlp_StrCmp(output, "Test 43 (10 ore, 20 skill points)")) {
         G1CP_TestsuiteErrorDetail(ConcatStrings("Output incorrect: ", output));
         return FALSE;
     };
+
+    return TRUE;
 };

--- a/src/Ninja/G1CP/Content/Tests/test125.d
+++ b/src/Ninja/G1CP/Content/Tests/test125.d
@@ -11,13 +11,13 @@ func int G1CP_Test_125() {
     G1CP_Testsuite_CheckPassed();
 
     // Static string arrays cannot be read directly
-    var string itm_text_4; itm_text_4 = MEM_ReadStatStringArr(itm.text, 4);
+    var string itmText; itmText = MEM_ReadStatStringArr(itm.text, 4);
 
-    if (Hlp_StrCmp(itm_text_4, "One-handed Weapon")) // EN
-    || (Hlp_StrCmp(itm_text_4, "Einhandwaffe")) {    // DE
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Text incorrect: text[4] = '", itm_text_4, "'");
+    if (!Hlp_StrCmp(itmText, "One-handed Weapon")) // EN
+    && (!Hlp_StrCmp(itmText, "Einhandwaffe")) {    // DE
+        G1CP_TestsuiteErrorDetailSSS("Text incorrect: text[4] = '", itmText, "'");
         return FALSE;
     };
+
+    return TRUE;
 };

--- a/src/Ninja/G1CP/Content/Tests/test144.d
+++ b/src/Ninja/G1CP/Content/Tests/test144.d
@@ -1,19 +1,10 @@
 /*
  * #144 Spelling - Gomez' Armor (DE)
- *
- * The name of the item "EBR_ARMOR_H" is inspected programmatically.
- *
- * Expected behavior: The armor will have the correct name (checked for German localization only).
  */
 func int G1CP_Test_144() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("EBR_ARMOR_H");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.name, "Gomez' Rüstung")) {
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Name incorrect: name = '", itm.name, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "name", "Gomez' Rüstung");
 };

--- a/src/Ninja/G1CP/Content/Tests/test145.d
+++ b/src/Ninja/G1CP/Content/Tests/test145.d
@@ -1,18 +1,10 @@
 /*
  * #145 Spelling - Light Mercenary's Armor (DE)
- *
- * The name of the item "SLD_ARMOR_L" is inspected programmatically.
- *
- * Expected behavior: The armor will have the correct name (checked for German localization only).
  */
 func int G1CP_Test_145() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("SLD_ARMOR_L");
     G1CP_Testsuite_CheckPassed();
 
-    if (STR_Compare(itm.name, "Leichte Söldnerrüstung") == STR_EQUAL) { // Case-sensitive
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Name incorrect: name = '", itm.name, "'");
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "name", "Leichte Söldnerrüstung");
 };

--- a/src/Ninja/G1CP/Content/Tests/test146.d
+++ b/src/Ninja/G1CP/Content/Tests/test146.d
@@ -1,19 +1,10 @@
 /*
  * #146 Spelling - Novice's Loincloth (DE)
- *
- * The name of the item "NOV_ARMOR_L" is inspected programmatically.
- *
- * Expected behavior: The armor will have the correct name (checked for German localization only).
  */
 func int G1CP_Test_146() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("NOV_ARMOR_L");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.name, "Novizenrock")) {
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Name incorrect: name = '", itm.name, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "name", "Novizenrock");
 };

--- a/src/Ninja/G1CP/Content/Tests/test147.d
+++ b/src/Ninja/G1CP/Content/Tests/test147.d
@@ -1,19 +1,10 @@
 /*
  * #147 Spelling - Crawler Plate Armor (DE)
- *
- * The name of the item "CRW_ARMOR_H" is inspected programmatically.
- *
- * Expected behavior: The armor will have the correct name (checked for German localization only).
  */
 func int G1CP_Test_147() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("CRW_ARMOR_H");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.name, "Crawlerplatten-Rüstung")) {
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Name incorrect: name = '", itm.name, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "name", "Crawlerplatten-Rüstung");
 };

--- a/src/Ninja/G1CP/Content/Tests/test148.d
+++ b/src/Ninja/G1CP/Content/Tests/test148.d
@@ -1,18 +1,10 @@
 /*
  * #148 Spelling - Ancient Ore Armor (DE)
- *
- * The name of the item "ORE_ARMOR_M" is inspected programmatically.
- *
- * Expected behavior: The armor will have the correct name (checked for German localization only).
  */
 func int G1CP_Test_148() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("ORE_ARMOR_M");
     G1CP_Testsuite_CheckPassed();
 
-    if (STR_Compare(itm.name, "Antike Erzrüstung") == STR_EQUAL) { // Case-sensitive
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Name incorrect: name = '", itm.name, "'");
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "name", "Antike Erzrüstung");
 };

--- a/src/Ninja/G1CP/Content/Tests/test149.d
+++ b/src/Ninja/G1CP/Content/Tests/test149.d
@@ -11,11 +11,11 @@ func int G1CP_Test_149() {
     G1CP_Testsuite_CheckPassed();
 
     // Case-sensitive comparison!
-    if (STR_Compare(itm.name, "Improved Ore Armor") == STR_EQUAL) // EN
-    || (STR_Compare(itm.name, "Verbesserte Erzrüstung") == STR_EQUAL) { // DE
-        return TRUE;
-    } else {
+    if (STR_Compare(itm.name, "Improved Ore Armor") != STR_EQUAL)       // EN
+    && (STR_Compare(itm.name, "Verbesserte Erzrüstung") != STR_EQUAL) { // DE
         G1CP_TestsuiteErrorDetailSSS("Name incorrect: name = '", itm.name, "'");
         return FALSE;
     };
+
+    return TRUE;
 };

--- a/src/Ninja/G1CP/Content/Tests/test152.d
+++ b/src/Ninja/G1CP/Content/Tests/test152.d
@@ -1,19 +1,10 @@
 /*
  * #152 Spelling - Ring of Fire Protection (EN)
- *
- * The description of the item "Schutzring_Feuer2" is inspected programmatically.
- *
- * Expected behavior: The ring will have the correct description (checked for English localization only).
  */
 func int G1CP_Test_152() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_EN);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("Schutzring_Feuer2");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.description, "Ring of Fire Protection")) {
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Description incorrect: description = '", itm.description, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "description", "Ring of Fire Protection");
 };

--- a/src/Ninja/G1CP/Content/Tests/test172.d
+++ b/src/Ninja/G1CP/Content/Tests/test172.d
@@ -1,19 +1,10 @@
 /*
  * #172 Spelling - Kalom's Recipe (DE)
- *
- * The name of the item "KalomsRecipe" is inspected programmatically.
- *
- * Expected behavior: The scroll will have the correct name (checked for German localization only).
  */
 func int G1CP_Test_172() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("KalomsRecipe");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.name, "Kaloms Rezept")) {
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Name incorrect: name = '", itm.name, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "name", "Kaloms Rezept");
 };

--- a/src/Ninja/G1CP/Content/Tests/test173.d
+++ b/src/Ninja/G1CP/Content/Tests/test173.d
@@ -1,19 +1,10 @@
 /*
  * #173 Spelling - Gomez' Key: "Gomez' Truhen" (DE)
- *
- * The text of the item "ItKe_Gomez_01" is inspected programmatically.
- *
- * Expected behavior: The key will have the correct text (checked for German localization only).
  */
 func int G1CP_Test_173() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("ItKe_Gomez_01");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.text, "Öffnet Gomez' Truhen")) {
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Text incorrect: text[0] = '", itm.text, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "text[0]", "Öffnet Gomez' Truhen");
 };

--- a/src/Ninja/G1CP/Content/Tests/test174.d
+++ b/src/Ninja/G1CP/Content/Tests/test174.d
@@ -1,19 +1,10 @@
 /*
  * #174 Spelling - Gomez' Key (EN)
- *
- * The name of the item "ItKe_Gomez_01" is inspected programmatically.
- *
- * Expected behavior: The key will have the correct name (checked for English localization only).
  */
 func int G1CP_Test_174() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_EN);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("ItKe_Gomez_01");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.name, "Gomez' Key")) { // EN
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Name incorrect: name = '", itm.name, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "name", "Gomez' Key");
 };

--- a/src/Ninja/G1CP/Content/Tests/test175.d
+++ b/src/Ninja/G1CP/Content/Tests/test175.d
@@ -1,19 +1,10 @@
 /*
  * #175 Spelling - Rice Lord's Key (EN)
- *
- * The name of the item "ItKey_RB_01" is inspected programmatically.
- *
- * Expected behavior: The key will have the correct name (checked for English localization only).
  */
 func int G1CP_Test_175() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_EN);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("ItKey_RB_01");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.name, "Rice Lord's Key")) {
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Name incorrect: name = '", itm.name, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "name", "Rice Lord's Key");
 };

--- a/src/Ninja/G1CP/Content/Tests/test200.d
+++ b/src/Ninja/G1CP/Content/Tests/test200.d
@@ -1,19 +1,10 @@
 /*
  * #200 Text of Improved Ore Armor too long (DE)
- *
- * The text of the item "ORE_ARMOR_H" is inspected programmatically.
- *
- * Expected behavior: The armor will have the correct text (checked for German localization only).
  */
 func int G1CP_Test_200() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("ORE_ARMOR_H");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.text, "Stone der Schmied hat sie noch verbessern können!")) {
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Text incorrect: text[0] = '", itm.text, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "text[0]", "Stone der Schmied hat sie noch verbessern können!");
 };

--- a/src/Ninja/G1CP/Content/Tests/test201.d
+++ b/src/Ninja/G1CP/Content/Tests/test201.d
@@ -1,19 +1,10 @@
 /*
  * #201 Text of Ancient Ore Armor too long (DE)
- *
- * The text of the item "ORE_ARMOR_M" is inspected programmatically.
- *
- * Expected behavior: The armor will have the correct text (checked for German localization only).
  */
 func int G1CP_Test_201() {
     G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
     var C_Item itm; itm = G1CP_Testsuite_CreateItem("ORE_ARMOR_M");
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(itm.text, "Diese alte Rüstung wurde aus magischem Erz gefertigt.")) {
-        return TRUE;
-    } else {
-        G1CP_TestsuiteErrorDetailSSS("Text incorrect: text[0] = '", itm.text, "'");
-        return FALSE;
-    };
+    return G1CP_Testsuite_InspectItemVariable(itm, "text[0]", "Diese alte Rüstung wurde aus magischem Erz gefertigt.");
 };

--- a/src/Ninja/G1CP/Content/Tests/test232.d
+++ b/src/Ninja/G1CP/Content/Tests/test232.d
@@ -1,0 +1,10 @@
+/*
+ * #232 Spelling - Transform Bloodfly (DE)
+ */
+func int G1CP_Test_232() {
+    G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
+    var C_Item itm; itm = G1CP_Testsuite_CreateItem("ItArScrollTrfBloodfly");
+    G1CP_Testsuite_CheckPassed();
+
+    return G1CP_Testsuite_InspectItemVariable(itm, "description", "Verwandlung Blutfliege");
+};

--- a/src/Ninja/G1CP/Content/Tests/test235.d
+++ b/src/Ninja/G1CP/Content/Tests/test235.d
@@ -8,10 +8,10 @@ func int G1CP_Test_235() {
     var string name; name = G1CP_Testsuite_GetStringConst("TXT_SPELLS", SPL_TRF_ORCDOG);
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(name, "Verwandlung Orkhund")) {
-        return TRUE;
+    if (!Hlp_StrCmp(name, "Verwandlung Orkhund")) {
+        G1CP_TestsuiteErrorDetailSSSSS("String incorrect: TXT_SPELLS[", SPELL_NAME, "] = '", name, "'");
+        return FALSE;
     };
 
-    G1CP_TestsuiteErrorDetailSSSSS("String incorrect: TXT_SPELLS[", SPELL_NAME, "] = '", name, "'");
-    return FALSE;
+    return TRUE;
 };

--- a/src/Ninja/G1CP/Content/Tests/test236.d
+++ b/src/Ninja/G1CP/Content/Tests/test236.d
@@ -8,10 +8,10 @@ func int G1CP_Test_236() {
     var string name; name = G1CP_Testsuite_GetStringConst("TXT_GUILDS", GIL_ORCDOG);
     G1CP_Testsuite_CheckPassed();
 
-    if (Hlp_StrCmp(name, "Orkhund")) {
-        return TRUE;
+    if (!Hlp_StrCmp(name, "Orkhund")) {
+        G1CP_TestsuiteErrorDetailSSSSS("String incorrect: TXT_GUILDS[", GUILD_NAME, "] = '", name, "'");
+        return FALSE;
     };
 
-    G1CP_TestsuiteErrorDetailSSSSS("String incorrect: TXT_GUILDS[", GUILD_NAME, "] = '", name, "'");
-    return FALSE;
+    return TRUE;
 };

--- a/src/Ninja/G1CP/Content/Testsuite/inspect.d
+++ b/src/Ninja/G1CP/Content/Testsuite/inspect.d
@@ -1,0 +1,33 @@
+/*
+ * The variable of the item is inspected programmatically.
+ *
+ * Expected behavior: The item will have the correct variable.
+ */
+func int G1CP_Testsuite_InspectItemVariable(var C_Item itm, var string type, var string expectedVar) {
+    var string itmVar;
+
+    if (type == "name") {
+        itmVar = itm.name;
+    } else if (type == "description") {
+        itmVar = itm.description;
+    } else if (type == "text[0]") {
+        itmVar = itm.text;
+    } else if (type == "text[1]") {
+        itmVar = MEM_ReadStatStringArr(itm.text, 1);
+    } else if (type == "text[2]") {
+        itmVar = MEM_ReadStatStringArr(itm.text, 2);
+    } else if (type == "text[3]") {
+        itmVar = MEM_ReadStatStringArr(itm.text, 3);
+    } else if (type == "text[4]") {
+        itmVar = MEM_ReadStatStringArr(itm.text, 4);
+    } else {
+        return FALSE;
+    };
+
+    if (STR_Compare(itmVar, expectedVar) != STR_EQUAL) {
+        G1CP_TestsuiteErrorDetailSSSSS("Property incorrect: ", type, " = '", itmVar, "'");
+        return FALSE;
+    };
+    
+    return TRUE;
+};

--- a/src/Ninja/G1CP/Content/Testsuite/inspect.d
+++ b/src/Ninja/G1CP/Content/Testsuite/inspect.d
@@ -6,19 +6,19 @@
 func int G1CP_Testsuite_InspectItemVariable(var C_Item itm, var string type, var string expectedVar) {
     var string itmVar;
 
-    if (type == "name") {
+    if (Hlp_StrCmp(type, "name")) {
         itmVar = itm.name;
-    } else if (type == "description") {
+    } else if (Hlp_StrCmp(type, "description")) {
         itmVar = itm.description;
-    } else if (type == "text[0]") {
+    } else if (Hlp_StrCmp(type, "text[0]")) {
         itmVar = itm.text;
-    } else if (type == "text[1]") {
+    } else if (Hlp_StrCmp(type, "text[1]")) {
         itmVar = MEM_ReadStatStringArr(itm.text, 1);
-    } else if (type == "text[2]") {
+    } else if (Hlp_StrCmp(type, "text[2]")) {
         itmVar = MEM_ReadStatStringArr(itm.text, 2);
-    } else if (type == "text[3]") {
+    } else if (Hlp_StrCmp(type, "text[3]")) {
         itmVar = MEM_ReadStatStringArr(itm.text, 3);
-    } else if (type == "text[4]") {
+    } else if (Hlp_StrCmp(type, "text[4]")) {
         itmVar = MEM_ReadStatStringArr(itm.text, 4);
     } else {
         return FALSE;

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -102,6 +102,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_220_GorNaRanDialogMad();                   // #220
         G1CP_223_CarKalomSpyQuest();                    // #223
         G1CP_228_LaresDialogFindGorn();                 // #228
+        G1CP_232_DE_TransformBloodflyDescription();     // #232
         G1CP_235_DE_OrcDogMagBook();                    // #235
         G1CP_236_DE_OrcDogGuild();                      // #236
     };

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -131,6 +131,7 @@ Content\Fixes\Session\fix217_MercenaryDailyRoutine.d
 Content\Fixes\Session\fix220_GorNaRanDialogMad.d
 Content\Fixes\Session\fix223_CorKalomSpyQuest.d
 Content\Fixes\Session\fix228_LaresDialogFindGorn.d
+Content\Fixes\Session\fix232_DE_TransformBloodflyDescription.d
 Content\Fixes\Session\fix235_DE_OrcDogMagBook.d
 Content\Fixes\Session\fix236_DE_OrcDogGuild.d
 

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -6,6 +6,7 @@ Content\Testsuite\find.d
 Content\Testsuite\create.d
 Content\Testsuite\call.d
 Content\Testsuite\npc.d
+Content\Testsuite\inspect.d
 
 Content\Tests\test001.d
 Content\Tests\test002.d
@@ -118,5 +119,6 @@ Content\Tests\test223.d
 Content\Tests\test224.d
 Content\Tests\test226.d
 Content\Tests\test228.d
+Content\Tests\test232.d
 Content\Tests\test235.d
 Content\Tests\test236.d


### PR DESCRIPTION
**Describe the bug**
In the German localization of the game there' a typo in the description of the scroll "Transform into Bloodfly".

**Changelog**
Die Spruchrolle "Verwandlung Bloodfly" heißt nun korrekt "Verwandlung Blutfliege".

**Additional context**
Bug provided by [Blubbler](https://forum.worldofplayers.de/forum/threads/1574630-Release-Gothic-1-Community-Patch/page2?p=26716794&viewfull=1#post26716794).