### PR TITLE
Spelling - Transform Orc Dog (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -4,9 +4,10 @@
 ### General
 * Fix [#58](https://g1cp.org/issues/58): Fallen kann nicht mehr durch Kampfaktionen in der Luft unterbrochen werden.
 * Fix [#194](https://g1cp.org/issues/194): NSCs sammeln nun korrekt die Waffe ihres besiegten Gegners auf.
-* Fix [#232](https://g1cp.org/issues/232): Die Spruchrolle "Verwandlung Bloodfly" heißt nun korrekt "Verwandlung Blutfliege".
-* Fix [#235](https://g1cp.org/issues/235): Der Name im Magiebuch des Zaubers "Verwandlung Orc-Hund" heißt nun korrekt "Verwandlung Orkhund".
-* Fix [#236](https://g1cp.org/issues/226): Der Name in der Gildenzuordnung des Monsters "Ork-Hund" heißt nun korrekt "Orkhund".
+* Fix [#231](https://g1cp.org/issues/231): Die Beschreibung der Spruchrolle "Verwandlung Orcdog" lautet nun korrekt "Verwandlung Orkhund".
+* Fix [#232](https://g1cp.org/issues/232): Die Beschreibung der Spruchrolle "Verwandlung Bloodfly" lautet nun korrekt "Verwandlung Blutfliege".
+* Fix [#235](https://g1cp.org/issues/235): Der Name im Magiebuch des Zaubers "Verwandlung Orc-Hund" lautet nun korrekt "Verwandlung Orkhund".
+* Fix [#236](https://g1cp.org/issues/226): Der Name in der Gildenzuordnung des Monsters "Ork-Hund" lautet nun korrekt "Orkhund".
 
 ### Story
 * Fix [#55](https://g1cp.org/issues/55) (aktualisiert): Grim erwähnt In Extremo im zweiten Kapitel nun auch wenn das Konzert noch nicht begonnen hat. Für weitere Informationen zum Fix, siehe [v1.1.0](https://g1cp.org/blob/master/docs/changelog_de.md#v110-01052021).

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix231_DE_TransformOrcDogDescription.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix231_DE_TransformOrcDogDescription.d
@@ -1,0 +1,9 @@
+/*
+ * #231 Spelling - Transform Orc Dog (DE)
+ */
+func int G1CP_231_DE_TransformOrcDogDescription() {
+    var int itemId; itemId = G1CP_GetItemInstId("ItArScrollTrfOrcdog");
+    const string needle = "Verwandlung Orcdog";
+    const string replace = "Verwandlung Orkhund";
+    return (G1CP_ReplaceAssignStr(itemId, 0, "C_ITEM.DESCRIPTION", 0, needle, replace) > 0);
+};

--- a/src/Ninja/G1CP/Content/Tests/test231.d
+++ b/src/Ninja/G1CP/Content/Tests/test231.d
@@ -1,0 +1,10 @@
+/*
+ * #231 Spelling - Transform Orc Dog (DE)
+ */
+func int G1CP_Test_231() {
+    G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
+    var C_Item itm; itm = G1CP_Testsuite_CreateItem("ItArScrollTrfOrcdog");
+    G1CP_Testsuite_CheckPassed();
+
+    return G1CP_Testsuite_InspectItemVariable(itm, "description", "Verwandlung Orkhund");
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -102,6 +102,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_220_GorNaRanDialogMad();                   // #220
         G1CP_223_CarKalomSpyQuest();                    // #223
         G1CP_228_LaresDialogFindGorn();                 // #228
+        G1CP_231_DE_TransformOrcDogDescription();       // #231
         G1CP_232_DE_TransformBloodflyDescription();     // #232
         G1CP_235_DE_OrcDogMagBook();                    // #235
         G1CP_236_DE_OrcDogGuild();                      // #236

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -131,6 +131,7 @@ Content\Fixes\Session\fix217_MercenaryDailyRoutine.d
 Content\Fixes\Session\fix220_GorNaRanDialogMad.d
 Content\Fixes\Session\fix223_CorKalomSpyQuest.d
 Content\Fixes\Session\fix228_LaresDialogFindGorn.d
+Content\Fixes\Session\fix231_DE_TransformOrcDogDescription.d
 Content\Fixes\Session\fix232_DE_TransformBloodflyDescription.d
 Content\Fixes\Session\fix235_DE_OrcDogMagBook.d
 Content\Fixes\Session\fix236_DE_OrcDogGuild.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -119,6 +119,7 @@ Content\Tests\test223.d
 Content\Tests\test224.d
 Content\Tests\test226.d
 Content\Tests\test228.d
+Content\Tests\test231.d
 Content\Tests\test232.d
 Content\Tests\test235.d
 Content\Tests\test236.d


### PR DESCRIPTION
**Describe the bug**
In the German localization of the game there' a typo in the description of the scroll "Transform into Orc Dog".

**Changelog**
Die Spruchrolle "Verwandlung Orcdog" heißt nun korrekt "Verwandlung Orkhund".

**Additional context**
Bug provided by [Blubbler](https://forum.worldofplayers.de/forum/threads/1574630-Release-Gothic-1-Community-Patch/page2?p=26716794&viewfull=1#post26716794).