### PR TITLE
Spelling - Drax: "Orkhund" (DE)

### DIFF
--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -16,6 +16,7 @@
 * Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (der letzte untote Ork-Priester) kann nicht mehr durch Fallschaden getötet werden.
 * Fix [#226](https://g1cp.org/issues/226): Ein falsch platzierter Manatrank ist nun korrekt in einer der Truhen in der Gruft unter dem Stonehenge aufzufinden.
 * Fix [#228](https://g1cp.org/issues/228): Nach Gorn kann nun korrekt in Ambient-Dialogen gefragt werden, nachdem der Spieler mit Lares gesprochen hat.
+* Fix [#234](https://g1cp.org/issues/234): Im Tagebucheintrag für Drax als Lehrer "Wissen über Zähne entfernen - Wolf, Orchund, Snapper, Beisser, Bluthund, Schattenläufer." korrigiert zu "Wissen über Zähne entfernen - Wolf, Orkhund, Snapper, Beißer, Bluthund, Schattenläufer.".
 
 ## [v1.1.0](https://g1cp.org/releases/tag/v1.1.0) (01.05.2021)
 ### General

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix234_DE_LogEntryDrax.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix234_DE_LogEntryDrax.d
@@ -1,0 +1,60 @@
+/*
+ * #234 Spelling - Drax: "Orkhund" (DE)
+ */
+func int G1CP_234_DE_LogEntryDrax() {
+    const string curString = "Wissen über Zähne entfernen - Wolf, Orchund, Snapper, Beisser, Bluthund, Schattenläufer.";
+    const string newString = "Wissen über Zähne entfernen - Wolf, Orkhund, Snapper, Beißer, Bluthund, Schattenläufer.";
+    const string topicName = "";
+
+    // Do only once per session for performance on consecutive calls
+    const int topicId = -2; // -1 is reserved for invalid symbols
+    const int count   = -1;
+    if (topicId == -2) {
+        // Find and retrieve the topic
+        topicId = G1CP_GetStringConstId("GE_AnimalTrophies", 0);
+        topicName = G1CP_GetStringConstI(topicId, 0, "");
+
+        // Replace the push of the old string with the new string (this is never reverted, i.e. session fix)
+        count = G1CP_ReplacePushStr(
+            G1CP_GetFuncId("Org_819_Drax_Creatures_Zahn", "void|none"), 0, curString, newString
+        );
+    };
+
+    // Check if the log topic constant exists and if the adding of the log entry was successfully replaced
+    if (topicId == -1) || (count < 1) {
+        return FALSE;
+    };
+
+    // Replace the log entry
+    G1CP_LogReplaceEntry(topicName, curString, newString);
+
+    // Return success
+    return TRUE;
+};
+
+/*
+ * This function reverts the changes of #234
+ */
+func int G1CP_234_DE_LogEntryDraxRevert() {
+    // Only revert if it was applied by the G1CP
+    if (!G1CP_IsFixApplied(234)) {
+        return FALSE;
+    };
+
+    const string oldString = "Wissen über Zähne entfernen - Wolf, Orchund, Snapper, Beisser, Bluthund, Schattenläufer.";
+    const string curString = "Wissen über Zähne entfernen - Wolf, Orkhund, Snapper, Beißer, Bluthund, Schattenläufer.";
+    const string topicName = "";
+
+    // Retrieve the topic name only once per session for performance on consecutive calls
+    const int once = 0;
+    if (!once) {
+        topicName = G1CP_GetStringConst("GE_AnimalTrophies", 0, "");
+        once = 1;
+    };
+
+    // Revert the log entry
+    G1CP_LogReplaceEntry(topicName, curString, oldString);
+
+    // Return success
+    return TRUE;
+};

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -43,6 +43,7 @@ func void G1CP_GamesaveFixes_Apply() {
         G1CP_213_UseWithItemNcCauldron2();              // #213
         G1CP_224_OrcPriestFallDamage();                 // #224
         G1CP_226_PotionStonehengeChest();               // #226
+        G1CP_234_DE_LogEntryDrax();                     // #234
     };
 };
 
@@ -70,5 +71,6 @@ func void G1CP_GamesaveFixes_Revert() {
         G1CP_213_UseWithItemNcCauldron2Revert();        // #213
         G1CP_224_OrcPriestFallDamageRevert();           // #224
         G1CP_226_PotionStonehengeChestRevert();         // #226
+        G1CP_234_DE_LogEntryDraxRevert();               // #234
     };
 };

--- a/src/Ninja/G1CP/Content/Tests/test234.d
+++ b/src/Ninja/G1CP/Content/Tests/test234.d
@@ -1,0 +1,95 @@
+/*
+ * #234 Spelling - Drax: "Orkhund" (DE)
+ *
+ * The faulty log topic entry will be temporarily created and the fix is called, then the dialog function will be
+ * called to check if the entry was correctly created there, too.
+ *
+ * Expected behavior: The wording of the log topic entry will be correct in both cases.
+ */
+func int G1CP_Test_234() {
+    G1CP_Testsuite_CheckLang(G1CP_Lang_DE);
+    const string TEMP_TOPIC_NAME = "G1CP Test 234"; // Has to be a unique name with absolute certainty
+    const string GE_AnimalTrophies = ""; GE_AnimalTrophies = G1CP_Testsuite_GetStringConst("GE_AnimalTrophies", 0);
+    var int funcId; funcId = G1CP_Testsuite_CheckDialogFunc("Org_819_Drax_Creatures_Zahn");
+    var int skillId; skillId = G1CP_Testsuite_CheckIntVar("Knows_GetTeeth", 0);
+    var int oreId; oreId = G1CP_Testsuite_CheckItem("ItMinugget");
+    G1CP_Testsuite_CheckPassed();
+
+    // Define variables for specific test
+    // I'm sorry for not breaking the line at 120 characters
+    const string logEntryWrong = "Wissen über Zähne entfernen - Wolf, Orchund, Snapper, Beisser, Bluthund, Schattenläufer.";
+    const string logEntryRight = "Wissen über Zähne entfernen - Wolf, Orkhund, Snapper, Beißer, Bluthund, Schattenläufer.";
+
+    // Define possibly missing symbols locally
+    const int LOG_MISSION = 0;
+    const int LOG_RUNNING = 1;
+
+    // Rename the log topic if it already exists
+    G1CP_LogRenameTopic(GE_AnimalTrophies, TEMP_TOPIC_NAME);
+
+    // Check status of the test
+    var int passed; passed = TRUE;
+
+    // First pass: Create the log topic with the faulty entry and see if the fix will update it
+
+    // Create the topic
+    Log_CreateTopic(GE_AnimalTrophies, LOG_MISSION);
+    Log_SetTopicStatus(GE_AnimalTrophies, LOG_RUNNING);
+    Log_AddEntry(GE_AnimalTrophies, logEntryWrong);
+
+    // Trigger the fix (careful now, don't overwrite the fix status!)
+    var int r; r = G1CP_234_DE_LogEntryDrax();
+
+    // Check if it was updated
+    if (G1CP_LogHasEntry(GE_AnimalTrophies, logEntryWrong)) {
+        G1CP_TestsuiteErrorDetail("Log topic entry (incorrect) remained unchanged");
+        passed = FALSE;
+    };
+    if (!G1CP_LogHasEntry(GE_AnimalTrophies, logEntryRight)) {
+        G1CP_TestsuiteErrorDetail("Log topic entry (correct) does not exist");
+        passed = FALSE;
+    };
+    G1CP_LogRemoveTopic(GE_AnimalTrophies);
+
+    // Second pass: Call the dialog function and observe if it creates the corrected entry
+
+    // Backup values
+    var int skillBak; skillBak = G1CP_GetIntVarI(skillId, 0, 0);
+    var int oreBefore; oreBefore = Npc_HasItems(hero, oreId);
+    var int lpBak; lpBak = hero.lp;
+
+    // Set new values
+    CreateInvItems(hero, oreId, 50); // Add 50 ore for the condition within the dialog
+    hero.lp = hero.lp + 1;
+
+    // Call dialog condition function
+    G1CP_Testsuite_Call(funcId, 0, 0, TRUE);
+
+    // Check if log was updated
+    if (G1CP_LogHasEntry(GE_AnimalTrophies, logEntryWrong)) {
+        G1CP_TestsuiteErrorDetail("Log topic entry was created with incorrect wording");
+        passed = FALSE;
+    };
+    if (!G1CP_LogHasEntry(GE_AnimalTrophies, logEntryRight)) {
+        G1CP_TestsuiteErrorDetail("Log topic entry was not added by the dialog function");
+        passed = FALSE;
+    };
+
+    // Restore values
+    G1CP_LogRemoveTopic(GE_AnimalTrophies);
+    G1CP_LogRenameTopic(TEMP_TOPIC_NAME, GE_AnimalTrophies);
+    G1CP_SetIntVarI(skillId, 0, skillBak);
+    hero.lp = lpBak;
+
+    // Restore the amount of ore
+    var int oreAfter; oreAfter = Npc_HasItems(hero, oreId);
+    if (oreAfter > 0) {
+        Npc_RemoveInvItems(hero, oreId, oreAfter);
+    };
+    if (oreBefore > 0) {
+        CreateInvItems(hero, oreId, oreBefore);
+    };
+
+    // Return success
+    return passed;
+};

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -156,6 +156,7 @@ Content\Fixes\Gamesave\fix212_UseWithItemNcCauldron1.d
 Content\Fixes\Gamesave\fix213_UseWithItemNcCauldron2.d
 Content\Fixes\Gamesave\fix224_OrcPriestFallDamage.d
 Content\Fixes\Gamesave\fix226_PotionStonehengeChest.d
+Content\Fixes\Gamesave\fix234_DE_LogEntryDrax.d
 
 // Initialization
 Content\initPre.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -121,5 +121,6 @@ Content\Tests\test226.d
 Content\Tests\test228.d
 Content\Tests\test231.d
 Content\Tests\test232.d
+Content\Tests\test234.d
 Content\Tests\test235.d
 Content\Tests\test236.d


### PR DESCRIPTION
**Describe the bug**
In the German localization of the game there' a typo in the log entry concerning Drax as teacher for animal trophies.

**Changelog**
Im Tagebucheintrag für Drax als Lehrer "Wissen über Zähne entfernen - Wolf, Orchund, Snapper, Beisser, Bluthund, Schattenläufer." korrigiert zu "Wissen über Zähne entfernen - Wolf, Orkhund, Snapper, Beißer, Bluthund, Schattenläufer.".

**Additional context**
Similar to #143.