### PR TITLE
Mordrag can be told to "get out" in New Camp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix [#129](https://g1cp.org/issues/129): Drake's body skin color now matches his head.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
 * Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (the last undead orc priest) can no longer be killed by fall damage.
+* Fix [#225](https://g1cp.org/issues/225): Mordrag can no longer be told to "get out of here" if he guided the player to the New Camp.
 * Fix [#226](https://g1cp.org/issues/226): A misplaced mana potion is now correctly inserted in one of the chests in the crypt under the stonehenge.
 * Fix [#228](https://g1cp.org/issues/228): Gorn can now correctly be asked about in ambient dialogs after the player talked to Lares.
 

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -15,6 +15,7 @@
 * Fix [#129](https://g1cp.org/issues/129): Drakes Hautfarbe des Körpers entspricht jetzt der seines Kopfes.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
 * Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (der letzte untote Ork-Priester) kann nicht mehr durch Fallschaden getötet werden.
+* Fix [#225](https://g1cp.org/issues/225): Mordrag kann nicht mehr gesagt werden "Mach, dass du wegkommst", wenn er den Spieler-Charakter bereits ins Neue Lager geführt hat.
 * Fix [#226](https://g1cp.org/issues/226): Ein falsch platzierter Manatrank ist nun korrekt in einer der Truhen in der Gruft unter dem Stonehenge aufzufinden.
 * Fix [#228](https://g1cp.org/issues/228): Nach Gorn kann nun korrekt in Ambient-Dialogen gefragt werden, nachdem der Spieler mit Lares gesprochen hat.
 * Fix [#234](https://g1cp.org/issues/234): Im Tagebucheintrag für Drax als Lehrer "Wissen über Zähne entfernen - Wolf, Orchund, Snapper, Beisser, Bluthund, Schattenläufer." korrigiert zu "Wissen über Zähne entfernen - Wolf, Orkhund, Snapper, Beißer, Bluthund, Schattenläufer.".

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix225_MordragNcGetOut.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix225_MordragNcGetOut.d
@@ -1,0 +1,48 @@
+/*
+ * #225 Mordrag can be told to "get out" in New Camp
+ */
+func int G1CP_225_MordragNcGetOut() {
+    const string CONDITION = ""; CONDITION = "Org_826_Mordrag_HauAb_Condition";
+
+    if (!G1CP_IsFunc(CONDITION, "int|none"))
+    || (!G1CP_IsInfoInst("Org_826_Mordrag_GotoNewcamp"))
+    || (!G1CP_IsIntVar("Thorus_MordragKo", 0)) {
+        return FALSE;
+    };
+
+    HookDaedalusFuncS(CONDITION, "G1CP_225_MordragNcGetOut_Hook");
+    return TRUE;
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int G1CP_225_MordragNcGetOut_Hook() {
+    G1CP_ReportFuncToSpy();
+
+    // Define possibly missing symbols locally
+    const int LOG_RUNNING = 1;
+
+    // Add the new conditions (other conditions remain untouched)
+    var int cond1;
+    var int cond2;
+
+    // Check if dialog was told (check if symbol exists first!)
+    var int symbId; symbId = MEM_GetSymbolIndex("Org_826_Mordrag_GotoNewcamp");
+    if (symbId != -1) {
+        cond1 = !Npc_KnowsInfo(hero, symbId);
+    } else {
+        cond1 = TRUE; // If the dialog does not even exist take no chances
+    };
+
+    // Check if quest is running (If that variable does not even exist take no chances)
+    cond2 = (G1CP_GetIntVar("Thorus_MordragKo", 0, LOG_RUNNING) == LOG_RUNNING);
+
+    // Return false if either of the conditions is false
+    if ((!cond1) || (!cond2)) {
+        return FALSE;
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/Tests/test225.d
+++ b/src/Ninja/G1CP/Content/Tests/test225.d
@@ -1,16 +1,16 @@
 /*
- * #33 Shrike's Hut quest
+ * #225 Mordrag can be told to "get out" in New Camp
  *
  * A variable and dialog are temporarily set and the condition function of the dialog is called.
  *
  * Expected behavior: The condition function will return FALSE.
  */
-func int G1CP_Test_033() {
-    var int funcId; funcId = G1CP_Testsuite_CheckDialogConditionFunc("DIA_Shrike_GetLost_Condition");
-    var int infoId; infoId = G1CP_Testsuite_CheckInfo("DIA_Gorn_Hut");
-    var C_Npc npc; npc = G1CP_Testsuite_FindNpc("ORG_842_Shrike");
+func int G1CP_Test_225() {
+    var int funcId; funcId = G1CP_Testsuite_CheckDialogConditionFunc("Org_826_Mordrag_HauAb_Condition");
+    var int infoId; infoId = G1CP_Testsuite_CheckInfo("Org_826_Mordrag_GotoNewcamp");
+    var C_Npc npc; npc = G1CP_Testsuite_FindNpc("Org_826_Mordrag");
     var int aiVarId; aiVarId = G1CP_Testsuite_CheckIntConst("AIV_WASDEFEATEDBYSC", 0);
-    var int varId; varId = G1CP_Testsuite_CheckIntVar("Gorn_ShrikesHut", 0);
+    var int varId; varId = G1CP_Testsuite_CheckIntVar("Thorus_MordragKo", 0);
     G1CP_Testsuite_CheckPassed();
 
     // Backup values
@@ -19,7 +19,7 @@ func int G1CP_Test_033() {
     var int varBak; varBak = G1CP_GetIntVarI(varId, 0, 0);
 
     // Set new values
-    G1CP_SetInfoToldI(infoId, FALSE);
+    G1CP_SetInfoToldI(infoId, TRUE);
     G1CP_NpcSetAiVarI(npc, aiVarId, TRUE);
     G1CP_SetIntVarI(varId, 0, 0);
 

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -101,6 +101,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_217_MercenaryDailyRoutine();               // #217
         G1CP_220_GorNaRanDialogMad();                   // #220
         G1CP_223_CarKalomSpyQuest();                    // #223
+        G1CP_225_MordragNcGetOut();                     // #225
         G1CP_228_LaresDialogFindGorn();                 // #228
         G1CP_231_DE_TransformOrcDogDescription();       // #231
         G1CP_232_DE_TransformBloodflyDescription();     // #232

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -131,6 +131,7 @@ Content\Fixes\Session\fix216_DiggerDailyRoutine.d
 Content\Fixes\Session\fix217_MercenaryDailyRoutine.d
 Content\Fixes\Session\fix220_GorNaRanDialogMad.d
 Content\Fixes\Session\fix223_CorKalomSpyQuest.d
+Content\Fixes\Session\fix225_MordragNcGetOut.d
 Content\Fixes\Session\fix228_LaresDialogFindGorn.d
 Content\Fixes\Session\fix231_DE_TransformOrcDogDescription.d
 Content\Fixes\Session\fix232_DE_TransformBloodflyDescription.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -117,6 +117,7 @@ Content\Tests\test217.d
 Content\Tests\test220.d
 Content\Tests\test223.d
 Content\Tests\test224.d
+Content\Tests\test225.d
 Content\Tests\test226.d
 Content\Tests\test228.d
 Content\Tests\test231.d


### PR DESCRIPTION
**Describe the bug**
Mordrag can be told to "get out of here" even if he guided the player to the New Camp.

**Expected behavior**
Mordrag can no longer be told to "get out of here" if he guided the player to the New Camp.

**Additional context**
Bug provided by [Blubbler](https://forum.worldofplayers.de/forum/threads/1574630-Release-Gothic-1-Community-Patch/page2?p=26716794&viewfull=1#post26716794).

Reference for the proposed fix:

https://github.com/AmProsius/gothic-1-community-patch/blob/e66b303623c042ec5cfc387a1b0d4bd352605f12/scriptbase/_work/Data/Scripts/Content/Story/Missions/DIA_ORG_826_Mordrag.d#L328-L334