### PR TITLE
Cord teaches One-handed Sword Level 2 too soon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Story
 * Fix [#55](https://g1cp.org/issues/55) (updated): Grim now correctly mentions In Extremo in the second chapter even if the concert has not yet started playing. For details on the fix, see [v1.1.0](https://g1cp.org/blob/master/CHANGELOG.md#v110-2021-05-01).
 * Fix [#129](https://g1cp.org/issues/129): Drake's body skin color now matches his head.
+* Fix [#191](https://g1cp.org/issues/191): Cord's dialog option to teach One-handed Sword Level 2 now appears only after the player learned Level 1.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.
 * Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (the last undead orc priest) can no longer be killed by fall damage.
 * Fix [#225](https://g1cp.org/issues/225): Mordrag can no longer be told to "get out of here" if he guided the player to the New Camp.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -13,7 +13,7 @@
 ### Story
 * Fix [#55](https://g1cp.org/issues/55) (aktualisiert): Grim erwähnt In Extremo im zweiten Kapitel nun auch wenn das Konzert noch nicht begonnen hat. Für weitere Informationen zum Fix, siehe [v1.1.0](https://g1cp.org/blob/master/docs/changelog_de.md#v110-01052021).
 * Fix [#129](https://g1cp.org/issues/129): Drakes Hautfarbe des Körpers entspricht jetzt der seines Kopfes.
-* Fix [#191](https://g1cp.org/issues/191): Cords Dialogopion zum Erlenen von Einhänder Stufe 2 ist jetzt erst verfügbar, wenn der Spieler vorher Stufe 1 gelernt hat.
+* Fix [#191](https://g1cp.org/issues/191): Cords Dialogopion zum Erlenen von Einhänder Stufe 2 ist jetzt erst verfügbar, wenn der Spielercharakter vorher Stufe 1 gelernt hat.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran greift den Spielercharakter nicht länger im 6. Kapitel an.
 * Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (der letzte untote Ork-Priester) kann nicht mehr durch Fallschaden getötet werden.
 * Fix [#225](https://g1cp.org/issues/225): Mordrag kann nicht mehr gesagt werden "Mach, dass du wegkommst", wenn er den Spieler bereits ins Neue Lager geführt hat.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -13,6 +13,7 @@
 ### Story
 * Fix [#55](https://g1cp.org/issues/55) (aktualisiert): Grim erwähnt In Extremo im zweiten Kapitel nun auch wenn das Konzert noch nicht begonnen hat. Für weitere Informationen zum Fix, siehe [v1.1.0](https://g1cp.org/blob/master/docs/changelog_de.md#v110-01052021).
 * Fix [#129](https://g1cp.org/issues/129): Drakes Hautfarbe des Körpers entspricht jetzt der seines Kopfes.
+* Fix [#191](https://g1cp.org/issues/191): Cords Dialogopion zum Erlenen von Einhänder Stufe 2 ist jetzt erst verfügbar, wenn der Spieler vorher Stufe 1 gelernt hat.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran greift den Spielercharakter nicht länger im 6. Kapitel an.
 * Fix [#224](https://g1cp.org/issues/224): Grash-Varrag-Arushat (der letzte untote Ork-Priester) kann nicht mehr durch Fallschaden getötet werden.
 * Fix [#225](https://g1cp.org/issues/225): Mordrag kann nicht mehr gesagt werden "Mach, dass du wegkommst", wenn er den Spieler bereits ins Neue Lager geführt hat.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix191_CordOneHanded.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix191_CordOneHanded.d
@@ -19,7 +19,7 @@ func int G1CP_191_CordOneHanded_Hook() {
 
     // Add the new condition (other conditions remain untouched)
     const int NPC_TALENT_1H = 0; NPC_TALENT_1H = G1CP_GetIntConst("NPC_TALENT_1H", 0, 0);
-    if (Npc_GetTalentSkill(hero, NPC_TALENT_1H) == 0) {
+    if (Npc_GetTalentSkill(hero, NPC_TALENT_1H) != 1) {
         return FALSE;
     };
 

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix191_CordOneHanded.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix191_CordOneHanded.d
@@ -1,0 +1,28 @@
+/*
+ * #191 Cord teaches One-handed Sword Level 2 too soon
+ */
+func int G1CP_191_CordOneHanded() {
+    if (G1CP_IsFunc("SLD_709_Cord_TRAINAGAIN_Condition", "int|none"))
+    && (G1CP_IsIntConst("NPC_TALENT_1H", 0)) {
+        HookDaedalusFuncS("SLD_709_Cord_TRAINAGAIN_Condition", "G1CP_191_CordOneHanded_Hook");
+        return TRUE;
+    } else {
+        return FALSE;
+    };
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int G1CP_191_CordOneHanded_Hook() {
+    G1CP_ReportFuncToSpy();
+
+    // Add the new condition (other conditions remain untouched)
+    const int NPC_TALENT_1H = 0; NPC_TALENT_1H = G1CP_GetIntConst("NPC_TALENT_1H", 0, 0);
+    if (Npc_GetTalentSkill(hero, NPC_TALENT_1H) == 0) {
+        return FALSE;
+    };
+
+    // Continue with the original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/Tests/test191.d
+++ b/src/Ninja/G1CP/Content/Tests/test191.d
@@ -1,0 +1,37 @@
+/*
+ * #191 Cord teaches One-handed Sword Level 2 too soon
+ *
+ * The one-handed sword level is removed from the hero and the condition function of the dialog is called.
+ *
+ * Expected behavior: The condition function will return FALSE.
+ */
+func int G1CP_Test_191() {
+    var int funcId; funcId = G1CP_Testsuite_CheckDialogConditionFunc("SLD_709_Cord_TRAINAGAIN_Condition");
+    var int infoId; infoId = G1CP_Testsuite_CheckInfo("SLD_709_Cord_TRAINAGAIN");
+    const int NPC_TALENT_1H = 0; NPC_TALENT_1H = G1CP_Testsuite_GetIntConst("NPC_TALENT_1H", 0);
+    G1CP_Testsuite_CheckPassed();
+
+    // Backup values
+    var int toldBak; toldBak = Npc_KnowsInfo(hero, infoId);
+    var int talentBak; talentBak = Npc_GetTalentSkill(hero, NPC_TALENT_1H);
+
+    // Set new values
+    G1CP_SetInfoToldI(infoId, TRUE);
+    Npc_SetTalentSkill(hero, NPC_TALENT_1H, 0);
+
+    // Call dialog condition function
+    G1CP_Testsuite_Call(funcId, 0, 0, FALSE);
+    var int ret; ret = MEM_PopIntResult();
+
+    // Restore values
+    G1CP_SetInfoToldI(infoId, toldBak);
+    Npc_SetTalentSkill(hero, NPC_TALENT_1H, talentBak);
+
+    // Check return value
+    if (ret) {
+        G1CP_TestsuiteErrorDetail("Dialog condition failed");
+        return FALSE;
+    } else {
+        return TRUE;
+    };
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -89,6 +89,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_185_ScorpioCrossbow();                     // #185
         G1CP_186_CorristoJoinMages();                   // #186
         G1CP_188_CorKalomWeedExploit();                 // #188
+        G1CP_191_CordOneHanded();                       // #191
         G1CP_192_MagicUserAutoEquip();                  // #192
         G1CP_194_TakeOpponentWeapon();                  // #194
         G1CP_197_TemplarCampDialog();                   // #197

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -119,6 +119,7 @@ Content\Fixes\Session\fix184_BartholoWeedExploit.d
 Content\Fixes\Session\fix185_ScorpioCrossbow.d
 Content\Fixes\Session\fix186_CorristoJoinMages.d
 Content\Fixes\Session\fix188_CorKalomWeedExploit.d
+Content\Fixes\Session\fix191_CordOneHanded.d
 Content\Fixes\Session\fix192_MagicUserAutoEquip.d
 Content\Fixes\Session\fix194_TakeOpponentWeapon.d
 Content\Fixes\Session\fix197_TemplarCampDialog.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -99,6 +99,7 @@ Content\Tests\test184.d
 Content\Tests\test185.d
 Content\Tests\test186.d
 Content\Tests\test188.d
+Content\Tests\test191.d
 Content\Tests\test192.d
 Content\Tests\test193.d
 Content\Tests\test194.d


### PR DESCRIPTION
**Describe the bug**
Cord's dialog option to teach One-handed Sword Level 2 appears before the player learned Level 1.

**Expected behavior**
Cord's dialog option to teach One-handed Sword Level 2 now appears only after the player learned Level 1.

**Additional context**
* The German translation for *One-handed Sword Level 2* is *Einhänder Stufe 2*.
* The player can't actually learn Level 2 before Level 1, but for consistency reasons I suggest to hide the dialog option (see #39). Therefore the issue is marked as `opinionated`.

https://github.com/AmProsius/gothic-1-community-patch/blob/746a440f78e80e8a1e3195de6768b0427687ef77/scriptbase/_work/Data/Scripts/Content/Story/Missions/DIA_TPL_1402_GorNaToth.d#L441-L449

https://github.com/AmProsius/gothic-1-community-patch/blob/746a440f78e80e8a1e3195de6768b0427687ef77/scriptbase/_work/Data/Scripts/Content/Story/Missions/DIA_GRD_210_Scatty.d#L318-L321