### PR TITLE
One chest in NC cannot be opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Story
 * Fix [#42](https://g1cp.org/issues/42) (updated): One of the guards guarding the ore barons' house in the Old Camp no longer has two END dialog options.
 * Fix [#55](https://g1cp.org/issues/55) (updated): Grim now correctly mentions In Extremo in the second chapter even if the concert has not yet started playing. For details on the fix, see [v1.1.0](https://g1cp.org/blob/master/CHANGELOG.md#v110-2021-05-01).
+* Fix [#127](https://g1cp.org/issues/127): The locked chest near Buster's hut can now be picked.
 * Fix [#128](https://g1cp.org/issues/128): One of the guards who guard the diggers in the Old Mine no longer has two END dialog options.
 * Fix [#129](https://g1cp.org/issues/129): Drake's body skin color now matches his head.
 * Fix [#191](https://g1cp.org/issues/191): Cord's dialog option to teach One-handed Sword Level 2 now appears only after the player learned Level 1.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -13,6 +13,7 @@
 ### Story
 * Fix [#42](https://g1cp.org/issues/42) (aktualisiert): Eine der Torwachen vor dem Haus der Erzbarone im Alten Lager hat nun nicht mehr zwei ENDE-Dialogoptionen.
 * Fix [#55](https://g1cp.org/issues/55) (aktualisiert): Grim erwähnt In Extremo im zweiten Kapitel nun auch wenn das Konzert noch nicht begonnen hat. Für weitere Informationen zum Fix, siehe [v1.1.0](https://g1cp.org/blob/master/docs/changelog_de.md#v110-01052021).
+* Fix [#127](https://g1cp.org/issues/127): Die verschlossene Truhe in der Nähe von Busters Hütte kann nun mit der richtigen Kombination geöffnet werden.
 * Fix [#128](https://g1cp.org/issues/128): Einer der Gardisten der Alten Mine hat nun nicht mehr zwei ENDE-Dialogoptionen.
 * Fix [#129](https://g1cp.org/issues/129): Drakes Hautfarbe des Körpers entspricht jetzt der seines Kopfes.
 * Fix [#191](https://g1cp.org/issues/191): Cords Dialogopion zum Erlenen von Einhänder Stufe 2 ist jetzt erst verfügbar, wenn der Spielercharakter vorher Stufe 1 gelernt hat.

--- a/src/Ninja/G1CP/Content/Fixes/Gamesave/fix127_LockedChestNc.d
+++ b/src/Ninja/G1CP/Content/Fixes/Gamesave/fix127_LockedChestNc.d
@@ -1,0 +1,41 @@
+/*
+ * #127 One chest in NC cannot be opened
+ */
+func int G1CP_127_LockedChestNc() {
+    var int vobPtr; vobPtr = G1CP_FindVobByPosF(-55158.1367, 2919.41309, 1144.36926);
+    if (Hlp_Is_oCMobContainer(vobPtr)) { // Make sure we found a (the) chest
+        var oCMobContainer mob; mob  = _^(vobPtr);
+        if (Hlp_StrCmp(mob._oCMobLockable_keyInstance, "LRL"))
+        && (Hlp_StrCmp(mob._oCMobLockable_pickLockStr, "")) {
+            mob._oCMobLockable_keyInstance = "";
+            mob._oCMobLockable_pickLockStr = "LRL";
+            return TRUE;
+        };
+        return FALSE;
+    };
+    return FALSE;
+};
+
+/*
+ * This function reverts the changes
+ */
+func int G1CP_127_LockedChestNcRevert() {
+    // Only revert if it was applied by the G1CP
+    if (!G1CP_IsFixApplied(127)) {
+        return FALSE;
+    };
+
+    // Find the VOB again
+    var int vobPtr; vobPtr = G1CP_FindVobByPosF(-55158.1367, 2919.41309, 1144.36926);
+    if (Hlp_Is_oCMobContainer(vobPtr)) {
+        var oCMobContainer mob; mob  = _^(vobPtr);
+        if (Hlp_StrCmp(mob._oCMobLockable_keyInstance, ""))
+        && (Hlp_StrCmp(mob._oCMobLockable_pickLockStr, "LRL")) {
+            mob._oCMobLockable_keyInstance = "LRL";
+            mob._oCMobLockable_pickLockStr = "";
+            return TRUE;
+        };
+        return FALSE;
+    };
+    return FALSE;
+};

--- a/src/Ninja/G1CP/Content/Fixes/gamesave.d
+++ b/src/Ninja/G1CP/Content/Fixes/gamesave.d
@@ -33,6 +33,7 @@ func void G1CP_GamesaveFixes_Apply() {
         G1CP_055_ReactivateInExtremo();                 // #55
         G1CP_093_DE_LogEntryHoratio();                  // #93
         G1CP_121_DE_LogTopicShrikeHut();                // #121
+        G1CP_127_LockedChestNc();                       // #127
         G1CP_124_GateGuardId();                         // #124
         G1CP_133_DE_LogEntryScatty();                   // #133
         G1CP_143_DE_LogEntryBuster();                   // #143
@@ -62,6 +63,7 @@ func void G1CP_GamesaveFixes_Revert() {
         G1CP_093_DE_LogEntryHoratioRevert();            // #93
         G1CP_121_DE_LogTopicShrikeHutRevert();          // #121
         G1CP_124_GateGuardIdRevert();                   // #124
+        G1CP_127_LockedChestNcRevert();                 // #127
         G1CP_133_DE_LogEntryScattyRevert();             // #133
         G1CP_143_DE_LogEntryBusterRevert();             // #143
         G1CP_193_GateSwitchesStuckRevert();             // #193

--- a/src/Ninja/G1CP/Content/Tests/test127.d
+++ b/src/Ninja/G1CP/Content/Tests/test127.d
@@ -1,0 +1,21 @@
+/*
+ * #127 One chest in NC cannot be opened
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: The cauldron is not usable anymore (without a spoon).
+ */
+func void G1CP_Test_127() {
+    G1CP_Testsuite_CheckManual();
+    var zCWaypoint wp; wp = G1CP_Testsuite_FindWaypoint("NC_HUT28_OUT");
+    var int itemId; itemId = G1CP_Testsuite_CheckItem("itkelockpick");
+    G1CP_Testsuite_CheckPassed();
+
+    // Give the player item to check
+    if (!Npc_HasItems(hero, itemId)) {
+        CreateInvItem(hero, itemId);
+    };
+
+    // Teleport the player to the MOB
+    AI_Teleport(hero, wp.name);
+};

--- a/src/Ninja/G1CP/Content/Tests/test127.d
+++ b/src/Ninja/G1CP/Content/Tests/test127.d
@@ -15,6 +15,7 @@ func void G1CP_Test_127() {
     if (!Npc_HasItems(hero, itemId)) {
         CreateInvItem(hero, itemId);
     };
+    Print("The lockpicking combination is LRL");
 
     // Teleport the player to the hut
     AI_Teleport(hero, wp.name);

--- a/src/Ninja/G1CP/Content/Tests/test127.d
+++ b/src/Ninja/G1CP/Content/Tests/test127.d
@@ -3,19 +3,19 @@
  *
  * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
  *
- * Expected behavior: The cauldron is not usable anymore (without a spoon).
+ * Expected behavior: The chest can be picked with the combination "LRL".
  */
 func void G1CP_Test_127() {
     G1CP_Testsuite_CheckManual();
     var zCWaypoint wp; wp = G1CP_Testsuite_FindWaypoint("NC_HUT28_OUT");
-    var int itemId; itemId = G1CP_Testsuite_CheckItem("itkelockpick");
+    var int itemId; itemId = G1CP_Testsuite_CheckItem("ITKELOCKPICK");
     G1CP_Testsuite_CheckPassed();
 
-    // Give the player item to check
+    // Give the player an item to check
     if (!Npc_HasItems(hero, itemId)) {
         CreateInvItem(hero, itemId);
     };
 
-    // Teleport the player to the MOB
+    // Teleport the player to the hut
     AI_Teleport(hero, wp.name);
 };

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -153,6 +153,7 @@ Content\Fixes\Gamesave\fix055_ReactivateInExtremo.d
 Content\Fixes\Gamesave\fix093_DE_LogEntryHoratio.d
 Content\Fixes\Gamesave\fix121_DE_LogTopicShrikeHut.d
 Content\Fixes\Gamesave\fix124_GateGuardId.d
+Content\Fixes\Gamesave\fix127_LockedChestNc.d
 Content\Fixes\Gamesave\fix133_DE_LogEntryScatty.d
 Content\Fixes\Gamesave\fix143_DE_LogEntryBuster.d
 Content\Fixes\Gamesave\fix193_GateSwitchesStuck.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -72,6 +72,7 @@ Content\Tests\test122.d
 Content\Tests\test124.d
 Content\Tests\test125.d
 Content\Tests\test126.d
+Content\Tests\test127.d
 Content\Tests\test128.d
 Content\Tests\test129.d
 Content\Tests\test133.d


### PR DESCRIPTION
**Describe the bug**
Right next to the house of Buster there is a chest that cannot be opened/picked.

**Expected behavior**
The closed chest next to Buster's house can now be picked.

**Additional context**
```
[% oCMobContainer:oCMobInter:oCMOB:zCVob 64513 6384]
pack=int:0
presetName=string:OC_CHEST_MEDIUM_NC
bbox3DWS=rawFloat:-55190.5391 2919.41309 1100.78479 -55120.3203 2996.30811 1188.93396
trafoOSToWSRot=raw:2bd58e3d0000000068607f3f000000000000803f0000000068607fbf000000002bd58e3d
trafoOSToWSPos=vec3:-55158.1367 2919.41309 1144.36926
vobName=string:OC_CHEST_MEDIUM
visual=string:CHESTBIG_OCCHESTMEDIUMLOCKED.MDS
showVisual=bool:1
visualCamAlign=enum:0
cdStatic=bool:0
cdDyn=bool:1
staticVob=bool:1
dynShadow=enum:0
[visual zCModel 0 6385]
[]
[ai % 0 0]
[]
focusName=string:Chest
hitpoints=int:10
damage=int:0
moveable=bool:0
takeable=bool:0
focusOverride=bool:0
soundMaterial=enum:0
visualDestroyed=string:
owner=string:
ownerGuild=string:
isDestroyed=bool:0
stateNum=int:1
triggerTarget=string:
useWithItem=string:
conditionFunc=string:
onStateFunc=string:
rewind=bool:0
locked=bool:-1
keyInstance=string:LRL
pickLockStr=string:
contains=string:ItMiNugget:15,ItMi_Stuff_Plate_01,ItMi_Stuff_Cup_01,ItFoRice:3,ItFo_Potion_Water_01:2
[]
```