### PR TITLE
Ambient dialogs of rogue not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix [#127](https://g1cp.org/issues/127): The locked chest near Buster's hut can now be picked.
 * Fix [#128](https://g1cp.org/issues/128): One of the guards who guard the diggers in the Old Mine no longer has two END dialog options.
 * Fix [#129](https://g1cp.org/issues/129): Drake's body skin color now matches his head.
+* Fix [#166](https://g1cp.org/issues/166): Ambient dialogs of a gate guard of the New Camp are now available after giving him a joint.
 * Fix [#168](https://g1cp.org/issues/168): Gor Na Bar now tells only novices to speak to Cor Angar about becoming a templar.
 * Fix [#191](https://g1cp.org/issues/191): Cord's dialog option to teach One-handed Sword Level 2 now appears only after the player learned Level 1.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran no longer attacks the player character in chapter 6.

--- a/docs/changelog_de.md
+++ b/docs/changelog_de.md
@@ -16,6 +16,7 @@
 * Fix [#127](https://g1cp.org/issues/127): Die verschlossene Truhe in der Nähe von Busters Hütte kann nun mit der richtigen Kombination geöffnet werden.
 * Fix [#128](https://g1cp.org/issues/128): Einer der Gardisten der Alten Mine hat nun nicht mehr zwei ENDE-Dialogoptionen.
 * Fix [#129](https://g1cp.org/issues/129): Drakes Hautfarbe des Körpers entspricht jetzt der seines Kopfes.
+* Fix [#166](https://g1cp.org/issues/166): Die Ambient-Dialoge einer Torwache des Neuen Lagers sind nun verfügbar, wenn man ihm Sumpfkraut gegeben hat.
 * Fix [#168](https://g1cp.org/issues/168): Gor Na Bar schickt nun nur noch Novizen zur Cor Angar, um Templer zu werden.
 * Fix [#191](https://g1cp.org/issues/191): Cords Dialogopion zum Erlenen von Einhänder Stufe 2 ist jetzt erst verfügbar, wenn der Spielercharakter vorher Stufe 1 gelernt hat.
 * Fix [#220](https://g1cp.org/issues/220): Gor Na Ran greift den Spielercharakter nicht länger im 6. Kapitel an.

--- a/src/Ninja/G1CP/Content/Fixes/Session/fix166_RogueWeedDialog.d
+++ b/src/Ninja/G1CP/Content/Fixes/Session/fix166_RogueWeedDialog.d
@@ -1,0 +1,94 @@
+/*
+ * #166 Ambient dialogs of rogue not available
+ */
+func int G1CP_166_RogueWeedDialog() {
+    if (!G1CP_IsFunc("Info_ORG_829_SpecialInfo_Condition", "int|none"))
+    || (!G1CP_IsIntVar("Org_829_GotJoint", 0))
+    || (!G1CP_IsInfoInst("Info_ORG_829_OfferJoint"))
+    || (!G1CP_IsItemInst("ItMiJoint_1"))
+    || (!G1CP_IsItemInst("ItMiJoint_2"))
+    || (!G1CP_IsItemInst("ItMiJoint_3")) {
+        return FALSE;
+    };
+
+    HookDaedalusFuncS("Info_ORG_829_SpecialInfo_Condition", "G1CP_166_RogueWeedDialog_Hook1");
+    HookDaedalusFuncS("Info_ORG_829_PERM_Condition", "G1CP_166_RogueWeedDialog_Hook2");
+    return TRUE;
+};
+
+/*
+ * This function intercepts the dialog condition to introduce more conditions
+ */
+func int G1CP_166_RogueWeedDialog_Hook1() {
+    G1CP_ReportFuncToSpy();
+
+    // Symbol indices (existence confirmed by function above)
+    var int joint1Id; joint1Id = MEM_GetSymbolIndex("ItMiJoint_1");
+    var int joint2Id; joint2Id = MEM_GetSymbolIndex("ItMiJoint_2");
+    var int joint3Id; joint3Id = MEM_GetSymbolIndex("ItMiJoint_3");
+    var int gotJointId; gotJointId = MEM_GetSymbolIndex("Org_829_GotJoint");
+
+    // Add the new conditions (other conditions remain untouched)
+    var int cond1;
+    var int cond2;
+    var int cond3;
+    var int cond4;
+
+    // Check if dialog was told (check if symbol exists first!)
+    cond1 = !Npc_KnowsInfo(hero, MEM_GetSymbolIndex("Info_ORG_829_OfferJoint"));
+
+    // Check if NPC has a joint
+    cond2 = !Npc_HasItems(self, joint1Id);
+    cond3 = !Npc_HasItems(self, joint2Id);
+    cond4 = !Npc_HasItems(self, joint3Id);
+
+    // Return false if either of the conditions is true
+    if (cond1) || (cond2 && cond3 && cond4) {
+        return FALSE;
+    };
+
+    // Set the variable
+    G1CP_SetIntVarI(gotJointId, 0, TRUE);
+
+    // Continue with the original function
+    ContinueCall();
+};
+
+/*
+ * Exact copy of the function above. Need unique functions for both because of the way Daedalus hooks work
+ */
+
+func int G1CP_166_RogueWeedDialog_Hook2() {
+    G1CP_ReportFuncToSpy();
+
+    // Symbol indices (existence confirmed by function above)
+    var int joint1Id; joint1Id = MEM_GetSymbolIndex("ItMiJoint_1");
+    var int joint2Id; joint2Id = MEM_GetSymbolIndex("ItMiJoint_2");
+    var int joint3Id; joint3Id = MEM_GetSymbolIndex("ItMiJoint_3");
+    var int gotJointId; gotJointId = MEM_GetSymbolIndex("Org_829_GotJoint");
+
+    // Add the new conditions (other conditions remain untouched)
+    var int cond1;
+    var int cond2;
+    var int cond3;
+    var int cond4;
+
+    // Check if dialog was told (check if symbol exists first!)
+    cond1 = !Npc_KnowsInfo(hero, MEM_GetSymbolIndex("Info_ORG_829_OfferJoint"));
+
+    // Check if NPC has a joint
+    cond2 = !Npc_HasItems(self, joint1Id);
+    cond3 = !Npc_HasItems(self, joint2Id);
+    cond4 = !Npc_HasItems(self, joint3Id);
+
+    // Return false if either of the conditions is true
+    if (cond1) || (cond2 && cond3 && cond4) {
+        return FALSE;
+    };
+
+    // Set the variable
+    G1CP_SetIntVarI(gotJointId, 0, TRUE);
+
+    // Continue with the original function
+    ContinueCall();
+};

--- a/src/Ninja/G1CP/Content/Tests/test166.d
+++ b/src/Ninja/G1CP/Content/Tests/test166.d
@@ -1,0 +1,29 @@
+/*
+ * #166 Ambient dialogs of rogue not available
+ *
+ * There does not seem an easy way to test this fix programmatically, so this test relies on manual confirmation.
+ *
+ * Expected behavior: The new ambient dialogs should be available after giving the organizator a joint.
+ */
+func void G1CP_Test_166() {
+    G1CP_Testsuite_CheckManual();
+    var zCWaypoint wp; wp = G1CP_Testsuite_FindWaypoint("OW_PATH_07_21_GUARD_RIGHT");
+    var int joint1Id; joint1Id = G1CP_Testsuite_CheckItem("ItMiJoint_1");
+    var int joint2Id; joint2Id = G1CP_Testsuite_CheckItem("ItMiJoint_2");
+    var int joint3Id; joint3Id = G1CP_Testsuite_CheckItem("ItMiJoint_3");
+    G1CP_Testsuite_CheckPassed();
+
+    // Give the player an item to check
+    if (!Npc_HasItems(hero, joint1Id)) {
+        CreateInvItem(hero, joint1Id);
+    };
+    if (!Npc_HasItems(hero, joint2Id)) {
+        CreateInvItem(hero, joint2Id);
+    };
+    if (!Npc_HasItems(hero, joint3Id)) {
+        CreateInvItem(hero, joint3Id);
+    };
+
+    // Teleport the player to the hut
+    AI_Teleport(hero, wp.name);
+};

--- a/src/Ninja/G1CP/Content/patchInit.d
+++ b/src/Ninja/G1CP/Content/patchInit.d
@@ -78,6 +78,7 @@ func void Ninja_G1CP_Menu(var int menuPtr) {
         G1CP_157_SpeedPotion2Value();                   // #157
         G1CP_158_SpeedPotion3Value();                   // #158
         G1CP_163_CastleGate();                          // #163
+        G1CP_166_RogueWeedDialog();                     // #166
         G1CP_168_GorNaBarBecomeTemplar();               // #168
         G1CP_172_DE_KalomsRecipeName();                 // #172
         G1CP_173_DE_GomezKeyText();                     // #173

--- a/src/Ninja/G1CP/Content_G1.src
+++ b/src/Ninja/G1CP/Content_G1.src
@@ -108,6 +108,7 @@ Content\Fixes\Session\fix152_EN_ProtectionOfFireDescription.d
 Content\Fixes\Session\fix157_SpeedPotion2Value.d
 Content\Fixes\Session\fix158_SpeedPotion3Value.d
 Content\Fixes\Session\fix163_CastleGate.d
+Content\Fixes\Session\fix166_RogueWeedDialog.d
 Content\Fixes\Session\fix168_GorNaBarBecomeTemplar.d
 Content\Fixes\Session\fix172_DE_KalomsRecipeName.d
 Content\Fixes\Session\fix173_DE_GomezKeyText.d

--- a/src/Ninja/G1CP/Testsuite.src
+++ b/src/Ninja/G1CP/Testsuite.src
@@ -89,6 +89,7 @@ Content\Tests\test152.d
 Content\Tests\test157.d
 Content\Tests\test158.d
 Content\Tests\test163.d
+Content\Tests\test166.d
 Content\Tests\test168.d
 Content\Tests\test172.d
 Content\Tests\test173.d


### PR DESCRIPTION
**Describe the bug**
Two ambient dialogs of a rogue in the New Camp are not available due to a missing variable set.

**Expected behavior**
Ambient dialogs of a rogue in the New Camp are now available.

**Additional context**
https://github.com/AmProsius/gothic-1-community-patch/blob/0623f55a4ba7811367e2bc52a879724c4616717e/scriptbase/_work/Data/Scripts/Content/Story/Missions/DIA_ORG_829_Organisator.d#L111-L117

https://github.com/AmProsius/gothic-1-community-patch/blob/0623f55a4ba7811367e2bc52a879724c4616717e/scriptbase/_work/Data/Scripts/Content/Story/Missions/DIA_ORG_829_Organisator.d#L141-L147
